### PR TITLE
Align app component spec with router outlet template

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -118,5 +118,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
@@ -20,10 +21,10 @@ describe('AppComponent', () => {
     expect(app.title).toEqual('bot-list');
   });
 
-  it('should render title', () => {
+  it('should render the router outlet', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, bot-list');
+    const routerOutlet = fixture.debugElement.query(By.css('router-outlet'));
+    expect(routerOutlet).not.toBeNull();
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,3 @@
-import { HttpClient } from '@angular/common/http';
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 


### PR DESCRIPTION
## Summary
- remove an unused HttpClient import from the root app component
- update the AppComponent unit test to assert the presence of the router outlet instead of a missing title element
- disable Angular CLI analytics to avoid interactive prompts during tests

## Testing
- `npm test -- --watch=false` *(fails: Chrome binary not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f1009a7134832bae5374e146c4fee4