### PR TITLE
Fix bot details request to use raw content endpoint

### DIFF
--- a/src/app/services/bot.service.ts
+++ b/src/app/services/bot.service.ts
@@ -26,7 +26,7 @@ export class BotService {
    * @param bot - The bot's name.
    */
   getBotDetails(bot: any): Observable<any> {
-    let botJsonPath = `${this.BASE_SOURCE}/${bot.language}/${bot.botName}/Bot.json`
+    const botJsonPath = `${this.BASE_PATH}/${bot.language}/${bot.botName}/Bot.json`;
     return this.http.get(botJsonPath);
   }
 


### PR DESCRIPTION
## Summary
- fetch bot detail JSON files from the raw GitHub content endpoint instead of the repository source view

## Testing
- not run (npm is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f1009cd568832b93bdaf656e29b2a7