### PR TITLE
feat: restyle bot catalog to match portfolio aesthetic

### DIFF
--- a/src/app/components/bot-card/bot-card.component.html
+++ b/src/app/components/bot-card/bot-card.component.html
@@ -1,18 +1,19 @@
-<div class="bot">
-    <h3>{{ bot.botName }}</h3>
-    <p>Description: {{ bot.description || 'No description available' }}</p>
-    <p>Start Command <br>{{ bot.startCommand || 'No start commands provided' }}</p>
+<article class="bot-card">
+  <header class="bot-card__header">
+    <div class="bot-card__icon" aria-hidden="true">🤖</div>
+    <div>
+      <h3 class="bot-card__title">{{ bot.botName }}</h3>
+      <p class="bot-card__meta">Start command · {{ bot.startCommand || 'Non fornito' }}</p>
+    </div>
+  </header>
 
-    <!-- Bottone "Vai al PDF to Txt" solo se il nome del bot è pdfToTxt -->
-    <button *ngIf="bot.botName === 'pdf-to-txt'" class="nav-link-button" (click)="navigateToPdfToTxt()">
-        Vai al Converter PDF to Txt
+  <p class="bot-card__description">{{ bot.description || 'Descrizione non disponibile.' }}</p>
+
+  <div class="bot-card__actions">
+    <button *ngIf="bot.botName === 'pdf-to-txt'" class="ghost-button" (click)="navigateToPdfToTxt()">
+      Apri converter PDF to Txt
     </button>
-
-
-
-    <!-- Altri pulsanti dinamici esistenti -->
-    <button (click)="openBot()">View Source</button>
-    <button (click)="downloadBot()">Download</button>
-</div>
-
-<!-- pdfToTxt -->
+    <button class="ghost-button" (click)="openBot()">Apri sorgente</button>
+    <button (click)="downloadBot()">Scarica</button>
+  </div>
+</article>

--- a/src/app/components/bot-card/bot-card.component.scss
+++ b/src/app/components/bot-card/bot-card.component.scss
@@ -1,16 +1,67 @@
-.bot {
-    background-color: var(--bg-card, #333);
-    color: var(--text-card, #eee);
-    padding: 1rem;
-    border-radius: 8px;
-    margin: 1rem 0;
+.bot-card {
+  display: grid;
+  gap: 1.25rem;
+  padding: 1.8rem;
+  border-radius: 24px;
+  background: rgba(14, 14, 26, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 18px 40px -28px rgba(0, 0, 0, 0.95);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
 
-    .nav-link-button {
-        background-color: var(--button-bg, #5cb85c);
-        cursor: pointer;
+.bot-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(168, 130, 255, 0.25);
+  box-shadow: 0 30px 65px -40px rgba(108, 92, 231, 0.6);
+}
 
-        &:hover {
-            background-color: var(--button-hover, #4cae4c);
-        }
-    }
+.bot-card__header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.bot-card__icon {
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 18px;
+  display: grid;
+  place-items: center;
+  font-size: 1.6rem;
+  background: radial-gradient(circle at 30% 30%, rgba(168, 130, 255, 0.35), rgba(108, 92, 231, 0.15));
+  box-shadow: inset 0 0 0 1px rgba(168, 130, 255, 0.2);
+}
+
+.bot-card__title {
+  margin: 0;
+  font-size: 1.35rem;
+  letter-spacing: -0.01em;
+}
+
+.bot-card__meta {
+  margin: 0.2rem 0 0;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.bot-card__description {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+}
+
+.bot-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.bot-card__actions button {
+  flex: 1 1 auto;
+  min-width: 160px;
+}
+
+.bot-card__actions .ghost-button {
+  justify-content: center;
+  font-weight: 600;
 }

--- a/src/app/components/bot-list/bot-list.component.html
+++ b/src/app/components/bot-list/bot-list.component.html
@@ -1,9 +1,19 @@
-<app-header></app-header>
-<main *ngIf="botSections.length; else errorTemplate">
-  <app-bot-section *ngFor="let section of botSections" [language]="section.language"
-    [bots]="section.botDetails"></app-bot-section>
-</main>
-<ng-template #errorTemplate>
-  <p>{{ errorMessage || 'No bots available.' }}</p>
-</ng-template>
-<app-footer></app-footer>
+<div class="page-shell">
+  <app-header></app-header>
+
+  <main class="bot-list" *ngIf="botSections.length; else errorTemplate">
+    <section class="bot-list__grid" id="bot-collection">
+      <app-bot-section *ngFor="let section of botSections" [language]="section.language"
+        [bots]="section.botDetails"></app-bot-section>
+    </section>
+  </main>
+
+  <ng-template #errorTemplate>
+    <div class="empty-state">
+      <h2>Ops, nessun bot disponibile</h2>
+      <p>{{ errorMessage || 'Controlla più tardi per nuove integrazioni.' }}</p>
+    </div>
+  </ng-template>
+
+  <app-footer></app-footer>
+</div>

--- a/src/app/components/bot-list/bot-list.component.scss
+++ b/src/app/components/bot-list/bot-list.component.scss
@@ -1,19 +1,66 @@
-:root {
-    --bg-header: #222;
-    --text-header: #fff;
-    --bg-footer: #111;
-    --text-footer: #ccc;
-    --bg-card: #333;
-    --text-card: #eee;
-    --button-bg: #007acc;
-    --button-text: #fff;
-    --button-hover: #005fa3;
+.page-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
 }
 
-body {
-    background-color: #121212;
-    color: #e0e0e0;
-    font-family: Arial, sans-serif;
-    margin: 0;
-    padding: 0;
+.page-shell::before,
+.page-shell::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(120px);
+  opacity: 0.55;
+  z-index: 0;
+}
+
+.page-shell::before {
+  width: 420px;
+  height: 420px;
+  top: -180px;
+  right: -120px;
+  background: radial-gradient(circle, rgba(129, 89, 255, 0.65), transparent 70%);
+}
+
+.page-shell::after {
+  width: 340px;
+  height: 340px;
+  bottom: -140px;
+  left: -80px;
+  background: radial-gradient(circle, rgba(18, 194, 233, 0.55), transparent 70%);
+}
+
+.page-shell > * {
+  position: relative;
+  z-index: 1;
+}
+
+.bot-list {
+  flex: 1 0 auto;
+  display: flex;
+  justify-content: center;
+  padding: clamp(2.5rem, 5vw, 5rem) clamp(1.5rem, 5vw, 4rem);
+}
+
+.bot-list__grid {
+  width: min(1100px, 100%);
+  display: grid;
+  gap: clamp(2rem, 5vw, 3rem);
+}
+
+.empty-state {
+  flex: 1;
+  display: grid;
+  place-items: center;
+  padding: 6rem 1.5rem;
+  text-align: center;
+  color: var(--color-text-secondary);
+
+  h2 {
+    font-size: clamp(1.5rem, 3vw, 2rem);
+    margin-bottom: 0.75rem;
+    color: var(--color-text-primary);
+  }
 }

--- a/src/app/components/bot-section/bot-section.component.html
+++ b/src/app/components/bot-section/bot-section.component.html
@@ -1,7 +1,13 @@
-<section>
-    <h2>{{ capitalize(language) }} Bots</h2>
-    <div class="bot-container">
-        <app-bot-card *ngFor="let bot of bots" [bot]="bot" [language]="language"
-            (download)="downloadBot(bot)"></app-bot-card>
-    </div>
+<section class="bot-section">
+  <header class="bot-section__header">
+    <span class="bot-section__eyebrow">Linguaggio</span>
+    <h2 class="bot-section__title">{{ capitalize(language) }} Bots</h2>
+    <p class="bot-section__subtitle">
+      Automazioni affidabili e documentate per progetti {{ capitalize(language) }}.
+    </p>
+  </header>
+  <div class="bot-container">
+    <app-bot-card *ngFor="let bot of bots" [bot]="bot" [language]="language"
+      (download)="downloadBot(bot)"></app-bot-card>
+  </div>
 </section>

--- a/src/app/components/bot-section/bot-section.component.scss
+++ b/src/app/components/bot-section/bot-section.component.scss
@@ -1,18 +1,41 @@
-section {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
+.bot-section {
+  display: grid;
+  gap: 2rem;
+  padding: clamp(2rem, 3vw, 2.75rem);
+  border-radius: 28px;
+  background: linear-gradient(145deg, rgba(18, 18, 36, 0.8), rgba(8, 8, 18, 0.7));
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  box-shadow: 0 25px 55px -35px rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(18px);
 }
 
-h2 {
-    color: #e0e0e0;
+.bot-section__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.bot-section__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.bot-section__title {
+  margin: 0;
+  font-size: clamp(1.75rem, 3.5vw, 2.5rem);
+  color: var(--color-text-primary);
+}
+
+.bot-section__subtitle {
+  margin: 0;
+  color: var(--color-text-secondary);
+  max-width: 60ch;
 }
 
 .bot-container {
-    display: flex;
-    flex-wrap: wrap;
-    flex-direction: row;
-    gap: 1rem;
-    justify-content: center;
+  display: grid;
+  gap: clamp(1.25rem, 2vw, 2rem);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }

--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -1,3 +1,6 @@
-<footer>
-    <p>&copy; 2024 Scriptagher</p>
+<footer class="site-footer">
+  <div class="site-footer__content">
+    <p class="site-footer__title">Scriptagher Automation Hub</p>
+    <p class="site-footer__caption">Progettato con cura per accompagnare il portfolio professionale.</p>
+  </div>
 </footer>

--- a/src/app/components/footer/footer.component.scss
+++ b/src/app/components/footer/footer.component.scss
@@ -1,6 +1,28 @@
-footer {
-    text-align: center;
-    padding: 1rem;
-    background-color: var(--bg-footer, #111);
-    color: var(--text-footer, #ccc);
+.site-footer {
+  margin-top: auto;
+  padding: clamp(2rem, 4vw, 2.75rem) clamp(1.5rem, 5vw, 4rem) clamp(2.5rem, 6vw, 3.5rem);
+  background: transparent;
+  display: flex;
+  justify-content: center;
+}
+
+.site-footer__content {
+  width: min(1100px, 100%);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 1.5rem;
+  color: var(--color-text-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.site-footer__title {
+  margin: 0;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.site-footer__caption {
+  margin: 0;
+  font-size: 0.9rem;
 }

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -1,20 +1,33 @@
 <header [class.pdf-page]="isPdfToTxtPage">
-    <div class="header-content">
-        <!-- Header PDF to Txt -->
-        <div *ngIf="isPdfToTxtPage; else normalHeader" class="pdf-header">
-            <span class="app-name">Scriptagher</span>
-            <span class="current-page">PDF to Txt</span>
-            <div class="home-button" (click)="navigateHome()">
-                <img src="/icons/icons8-home-64.png"/>    
-            </div>
-        </div>
-
-        <!-- Header normale -->
-        <ng-template #normalHeader>
-            <div class="normal-header">
-                <h1>Welcome to the Bot List</h1>
-                <p>Here is a list of available bots, organized by language.</p>
-            </div>
-        </ng-template>
+  <div class="header-content" [class.header-content--pdf]="isPdfToTxtPage">
+    <div *ngIf="isPdfToTxtPage; else normalHeader" class="pdf-header">
+      <div class="pdf-header__brand">
+        <span class="app-name">Scriptagher</span>
+        <span class="current-page">PDF to Txt</span>
+      </div>
+      <button class="ghost-button" (click)="navigateHome()">
+        <span class="ghost-button__icon">⌂</span>
+        Torna alla raccolta
+      </button>
     </div>
+
+    <ng-template #normalHeader>
+      <div class="hero">
+        <div class="hero__meta">
+          <span class="hero__badge">Automations Portfolio</span>
+          <span class="hero__tagline">Workflow più smart, creati da Scriptagher</span>
+        </div>
+        <h1 class="hero__title">Esplora i bot che alimentano i miei progetti</h1>
+        <p class="hero__description">
+          Un catalogo curato di automazioni pronte all'uso, suddivise per linguaggio e
+          ottimizzate per integrarsi con il tuo stack. Ogni bot è parte del mio percorso
+          professionale e riflette l'attenzione ai dettagli del portfolio.
+        </p>
+        <div class="hero__actions">
+          <button class="ghost-button" (click)="navigateHome()">Scopri la selezione completa</button>
+          <a class="hero__cta" href="#bot-collection">Sfoglia le categorie</a>
+        </div>
+      </div>
+    </ng-template>
+  </div>
 </header>

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -1,75 +1,196 @@
-/* Stile principale per l'header */
 header {
-    text-align: center;
-    padding: 1rem;
-    background: var(--header-bg, #222);
-    color: white;
-    transition: background-color 0.3s ease;
+  position: relative;
+  padding: clamp(3rem, 6vw, 4.5rem) clamp(1.5rem, 5vw, 4rem) clamp(2rem, 5vw, 3rem);
+  color: var(--color-text-primary);
+  display: flex;
+  justify-content: center;
 
-    &.pdf-page {
-        height: 5cap;
-        background: var(--pdf-header-bg, #333);
-        position: relative;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 0 1rem;
-    }
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(140deg, rgba(108, 92, 231, 0.22), rgba(18, 194, 233, 0.05));
+    opacity: 0.9;
+    z-index: 0;
+  }
 
-    .header-content {
-        position: relative;
-        width: 100%;
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
-        gap: 0.5rem;
+  &.pdf-page {
+    padding: clamp(1.75rem, 4vw, 2.5rem) clamp(1.5rem, 5vw, 4rem);
+    background: rgba(5, 5, 9, 0.55);
+    backdrop-filter: blur(24px);
+    box-shadow: var(--shadow-soft);
+  }
+}
 
-        /* Header PDF to Txt dinamico */
-        .pdf-header {
-            position: absolute;
-            left: 0;
-            right: 0;
-            top: -20px;
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            gap: 1rem;
+.header-content {
+  position: relative;
+  z-index: 1;
+  width: min(1100px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  backdrop-filter: blur(8px);
+}
 
-            .app-name {
-                font-size: 2rem;
-                color: white;
-            }
+.header-content--pdf {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
 
-            .current-page {
-                color: #ddd;
-                font-size: 2rem;
-            }
+.pdf-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 1rem 1.5rem;
+  border-radius: 20px;
+  background: var(--color-surface-strong);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+}
 
-            .home-button {
-                img {
-                    cursor: pointer;
-                    width: 35px;
-                    height: 35px;
-                    transition: transform 0.2s ease;
+.pdf-header__brand {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
 
-                    &:hover {
-                        transform: scale(1.1);
-                        filter: invert(60%);
-                    }
-                }
-            }
-        }
+.app-name {
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 
-        /* Header normale */
-        .normal-header {
-            h1 {
-                font-size: 2rem;
-            }
+.current-page {
+  font-size: clamp(1.1rem, 2.5vw, 1.4rem);
+  color: var(--color-text-secondary);
+}
 
-            p {
-                font-size: 1rem;
-                opacity: 0.7;
-            }
-        }
-    }
+.ghost-button {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 999px;
+  padding: 0.55rem 1.25rem;
+  color: var(--color-text-primary);
+  font-weight: 500;
+  gap: 0.4rem;
+  transition: background-color 0.3s ease, transform 0.3s ease, border-color 0.3s ease;
+  box-shadow: none;
+}
+
+.ghost-button:hover,
+.ghost-button:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.ghost-button__icon {
+  font-size: 1.1rem;
+}
+
+.hero {
+  display: grid;
+  gap: 1.75rem;
+  padding: clamp(2rem, 4vw, 3rem);
+  background: var(--color-surface);
+  border-radius: 32px;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: -40% auto auto -20%;
+  width: 60%;
+  height: 150%;
+  background: radial-gradient(circle at center, rgba(108, 92, 231, 0.25), transparent 70%);
+  transform: rotate(15deg);
+  opacity: 0.8;
+}
+
+.hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.hero__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.hero__badge {
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(108, 92, 231, 0.15);
+  color: var(--color-accent-strong);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+.hero__tagline {
+  font-weight: 500;
+}
+
+.hero__title {
+  font-size: clamp(2rem, 6vw, 3.25rem);
+  margin: 0;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+
+.hero__description {
+  margin: 0;
+  color: var(--color-text-secondary);
+  max-width: 58ch;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.hero__cta {
+  font-weight: 600;
+  color: var(--color-accent-strong);
+  text-decoration: underline;
+  text-decoration-color: rgba(168, 130, 255, 0.4);
+  text-underline-offset: 0.35em;
+  transition: color 0.3s ease, text-decoration-color 0.3s ease;
+}
+
+.hero__cta:hover,
+.hero__cta:focus-visible {
+  color: #d1c4ff;
+  text-decoration-color: rgba(209, 196, 255, 0.8);
+}
+
+@media (max-width: 768px) {
+  .header-content--pdf {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .pdf-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .hero {
+    padding: clamp(1.75rem, 6vw, 2.25rem);
+  }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,17 +1,69 @@
-body{
-    background-color: #181818;
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap');
+
+:root {
+  --color-background: radial-gradient(circle at 20% 20%, #1f1f3a 0%, #101019 45%, #050509 100%);
+  --color-surface: rgba(20, 20, 36, 0.75);
+  --color-surface-strong: rgba(36, 36, 58, 0.85);
+  --color-border: rgba(255, 255, 255, 0.08);
+  --color-text-primary: #f4f6ff;
+  --color-text-secondary: #c0c5d6;
+  --color-accent: #6c5ce7;
+  --color-accent-strong: #a882ff;
+  --shadow-soft: 0 25px 60px -20px rgba(0, 0, 0, 0.6);
 }
 
-button, .custom-button {
-    background-color: var(--button-bg, #007acc);
-    color: var(--button-text, #fff);
-    border: none;
-    padding: 0.5rem 1rem;
-    border-radius: 4px;
-    cursor: pointer;
-    margin: 3px;
+* {
+  box-sizing: border-box;
+}
 
-    &:hover {
-        background-color: var(--button-hover, #005fa3);
-    }
+html,
+body {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--color-background);
+  color: var(--color-text-primary);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+.custom-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1.35rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-strong));
+  color: var(--color-text-primary);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
+  box-shadow: 0 18px 35px -15px rgba(108, 92, 231, 0.65);
+}
+
+button:hover,
+.custom-button:hover,
+button:focus-visible,
+.custom-button:focus-visible {
+  transform: translateY(-2px) scale(1.01);
+  filter: brightness(1.05);
+  box-shadow: 0 25px 40px -18px rgba(108, 92, 231, 0.75);
+}
+
+button:active,
+.custom-button:active {
+  transform: translateY(0);
+  filter: brightness(0.95);
 }


### PR DESCRIPTION
## Summary
- refresh the global theme with a portfolio-inspired gradient palette, typography, and button styling
- redesign the header, list layout, sections, cards, and footer to deliver a glassmorphism-inspired presentation for the bot catalog
- enhance each bot card with metadata, call-to-action buttons, and responsive grid placement

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f103f3a578832bb075ebcb199de640