### PR TITLE
Fix preview deploy structure for PR previews

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -18,6 +18,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.preview-vars.outputs.pr_number }}
+      preview_path: ${{ steps.preview-vars.outputs.preview_path }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -31,8 +34,53 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Capture preview metadata
+        id: preview-vars
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "preview_path=previews/pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            echo "preview_path=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build project
-        run: npm run build
+        run: |
+          rm -rf dist
+          if [ -n "${{ steps.preview-vars.outputs.pr_number }}" ]; then
+            PR_NUMBER="${{ steps.preview-vars.outputs.pr_number }}"
+            PREVIEW_PATH="${{ steps.preview-vars.outputs.preview_path }}"
+            npm run build -- --base-href "/scriptagher/${PREVIEW_PATH}/" --output-path "dist/${PREVIEW_PATH}"
+            cat <<EOF > dist/index.html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting…</title>
+    <meta http-equiv="refresh" content="0; url=./${PREVIEW_PATH}/" />
+  </head>
+  <body>
+    <p>Preview for PR #${PR_NUMBER} is available at <a href="./${PREVIEW_PATH}/">./${PREVIEW_PATH}/</a>.</p>
+  </body>
+</html>
+EOF
+            cat <<EOF > dist/404.html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting…</title>
+    <meta http-equiv="refresh" content="0; url=./${PREVIEW_PATH}/" />
+  </head>
+  <body>
+    <p>Preview for PR #${PR_NUMBER} is available at <a href="./${PREVIEW_PATH}/">./${PREVIEW_PATH}/</a>.</p>
+  </body>
+</html>
+EOF
+          else
+            npm run build
+          fi
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
@@ -54,3 +102,19 @@ jobs:
         uses: actions/deploy-pages@v4
         with:
           preview: true
+
+      - name: Publish preview link
+        if: ${{ needs.build.outputs.pr_number != '' }}
+        env:
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+          PREVIEW_PATH: ${{ needs.build.outputs.preview_path }}
+          PR_NUMBER: ${{ needs.build.outputs.pr_number }}
+        run: |
+          BASE_URL="${PAGE_URL%/}"
+          PREVIEW_URL="${BASE_URL}/${PREVIEW_PATH}/"
+          {
+            echo "### Preview ready"
+            echo
+            echo "* **PR**: #${PR_NUMBER}"
+            echo "* **URL**: ${PREVIEW_URL}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -7,9 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: preview-${{ github.ref }}
@@ -52,65 +50,65 @@ jobs:
             PR_NUMBER="${{ steps.preview-vars.outputs.pr_number }}"
             PREVIEW_PATH="${{ steps.preview-vars.outputs.preview_path }}"
             npm run build -- --base-href "/scriptagher/${PREVIEW_PATH}/" --output-path "dist/${PREVIEW_PATH}"
-            cat <<EOF > dist/index.html
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title>Redirecting…</title>
-    <meta http-equiv="refresh" content="0; url=./${PREVIEW_PATH}/" />
-  </head>
-  <body>
-    <p>Preview for PR #${PR_NUMBER} is available at <a href="./${PREVIEW_PATH}/">./${PREVIEW_PATH}/</a>.</p>
-  </body>
-</html>
-EOF
-            cat <<EOF > dist/404.html
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title>Redirecting…</title>
-    <meta http-equiv="refresh" content="0; url=./${PREVIEW_PATH}/" />
-  </head>
-  <body>
-    <p>Preview for PR #${PR_NUMBER} is available at <a href="./${PREVIEW_PATH}/">./${PREVIEW_PATH}/</a>.</p>
-  </body>
-</html>
-EOF
           else
             npm run build
           fi
 
-      - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Upload preview artifact
+        if: ${{ steps.preview-vars.outputs.pr_number != '' }}
+        uses: actions/upload-artifact@v4
         with:
-          path: dist
+          name: preview-dist
+          path: dist/${{ steps.preview-vars.outputs.preview_path }}
+          if-no-files-found: error
 
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  deploy-preview:
+    if: ${{ needs.build.outputs.pr_number != '' }}
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
-          preview: true
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Download preview artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: preview-dist
+          path: preview-artifact
+
+      - name: Prepare preview content
+        env:
+          PREVIEW_PATH: ${{ needs.build.outputs.preview_path }}
+        run: |
+          mkdir -p "$(dirname "${PREVIEW_PATH}")"
+          rm -rf "${PREVIEW_PATH}"
+          rsync -a --delete "preview-artifact/dist/${PREVIEW_PATH}/" "${PREVIEW_PATH}/"
+
+      - name: Commit preview update
+        env:
+          PR_NUMBER: ${{ needs.build.outputs.pr_number }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git status --short "${{ needs.build.outputs.preview_path }}" | grep .; then
+            git add "${{ needs.build.outputs.preview_path }}"
+            git commit -m "chore: update preview for PR #${PR_NUMBER}"
+          else
+            echo "No changes to commit"
+          fi
+
+      - name: Push preview changes
+        run: git push origin gh-pages
 
       - name: Publish preview link
-        if: ${{ needs.build.outputs.pr_number != '' }}
         env:
-          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
           PREVIEW_PATH: ${{ needs.build.outputs.preview_path }}
           PR_NUMBER: ${{ needs.build.outputs.pr_number }}
         run: |
-          BASE_URL="${PAGE_URL%/}"
+          BASE_URL="https://$GITHUB_REPOSITORY_OWNER.github.io/${GITHUB_REPOSITORY##*/}"
           PREVIEW_URL="${BASE_URL}/${PREVIEW_PATH}/"
           {
             echo "### Preview ready"

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,118 +1,107 @@
-name: Preview Deploy
+name: Deploy Preview to GitHub Pages
 
 on:
-  pull_request:
-    branches:
-      - main
-  workflow_dispatch:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
 
 permissions:
   contents: write
+  pull-requests: read
 
 concurrency:
-  group: preview-${{ github.ref }}
+  group: deploy-preview-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-and-deploy:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
-    outputs:
-      pr_number: ${{ steps.preview-vars.outputs.pr_number }}
-      preview_path: ${{ steps.preview-vars.outputs.preview_path }}
+    environment:
+      name: preview/pr-${{ github.event.number }}
+      url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.number }}/
+
+    env:
+      PREVIEW_FOLDER: previews/pr-${{ github.event.number }}
+      PREVIEW_BASE_HREF: /${{ github.event.repository.name }}/previews/pr-${{ github.event.number }}/
+      PREVIEW_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.number }}/
+      CI: true
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: npm
+          node-version: '20'
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Capture preview metadata
-        id: preview-vars
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-            echo "preview_path=previews/pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "pr_number=" >> "$GITHUB_OUTPUT"
-            echo "preview_path=" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Run unit tests
+        run: npm test -- --watch=false --browsers=ChromeHeadless
 
-      - name: Build project
-        run: |
-          rm -rf dist
-          if [ -n "${{ steps.preview-vars.outputs.pr_number }}" ]; then
-            PR_NUMBER="${{ steps.preview-vars.outputs.pr_number }}"
-            PREVIEW_PATH="${{ steps.preview-vars.outputs.preview_path }}"
-            npm run build -- --base-href "/scriptagher/${PREVIEW_PATH}/" --output-path "dist/${PREVIEW_PATH}"
-          else
-            npm run build
-          fi
+      - name: Build preview
+        run: npm run build -- --output-path=dist/${{ github.event.repository.name }} --base-href="$PREVIEW_BASE_HREF"
 
-      - name: Upload preview artifact
-        if: ${{ steps.preview-vars.outputs.pr_number != '' }}
-        uses: actions/upload-artifact@v4
+      - name: Verify preview output
+        run: ls dist/${{ github.event.repository.name }}
+
+      - name: Publish preview to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          name: preview-dist
-          path: dist/${{ steps.preview-vars.outputs.preview_path }}
-          if-no-files-found: error
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: dist/${{ github.event.repository.name }}
+          target-folder: ${{ env.PREVIEW_FOLDER }}
+          clean: false
 
-  deploy-preview:
-    if: ${{ needs.build.outputs.pr_number != '' }}
-    needs: build
+      - name: Post preview link to job summary
+        run: |
+          echo "### Preview ready" >> "$GITHUB_STEP_SUMMARY"
+          echo "$PREVIEW_URL" >> "$GITHUB_STEP_SUMMARY"
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout repository
+      - name: Checkout gh-pages branch
         uses: actions/checkout@v4
         with:
           ref: gh-pages
-          fetch-depth: 0
 
-      - name: Download preview artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: preview-dist
-          path: preview-artifact
-
-      - name: Prepare preview content
-        env:
-          PREVIEW_PATH: ${{ needs.build.outputs.preview_path }}
+      - name: Remove preview folder
+        id: cleanup
         run: |
-          mkdir -p "$(dirname "${PREVIEW_PATH}")"
-          rm -rf "${PREVIEW_PATH}"
-          rsync -a --delete "preview-artifact/dist/${PREVIEW_PATH}/" "${PREVIEW_PATH}/"
-
-      - name: Commit preview update
-        env:
-          PR_NUMBER: ${{ needs.build.outputs.pr_number }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git status --short "${{ needs.build.outputs.preview_path }}" | grep .; then
-            git add "${{ needs.build.outputs.preview_path }}"
-            git commit -m "chore: update preview for PR #${PR_NUMBER}"
+          set -euo pipefail
+          PREVIEW_FOLDER="previews/pr-${{ github.event.number }}"
+          if [ -d "$PREVIEW_FOLDER" ]; then
+            git rm -rf "$PREVIEW_FOLDER"
+            echo "removed=true" >> "$GITHUB_OUTPUT"
           else
-            echo "No changes to commit"
+            echo "removed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Push preview changes
-        run: git push origin gh-pages
-
-      - name: Publish preview link
-        env:
-          PREVIEW_PATH: ${{ needs.build.outputs.preview_path }}
-          PR_NUMBER: ${{ needs.build.outputs.pr_number }}
+      - name: Commit and push changes
+        if: steps.cleanup.outputs.removed == 'true'
         run: |
-          BASE_URL="https://$GITHUB_REPOSITORY_OWNER.github.io/${GITHUB_REPOSITORY##*/}"
-          PREVIEW_URL="${BASE_URL}/${PREVIEW_PATH}/"
-          {
-            echo "### Preview ready"
-            echo
-            echo "* **PR**: #${PR_NUMBER}"
-            echo "* **URL**: ${PREVIEW_URL}"
-          } >> "$GITHUB_STEP_SUMMARY"
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Remove preview for PR #${{ github.event.number }}"
+          git push origin HEAD:gh-pages
+
+      - name: Summarize cleanup result
+        run: |
+          if [ "${{ steps.cleanup.outputs.removed }}" = "true" ]; then
+            echo "Removed preview folder previews/pr-${{ github.event.number }}." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No preview folder to remove for PR #${{ github.event.number }}." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- detect pull request numbers during preview builds and derive the previews/pr-<nr> path
- build Angular assets into the matching folder and add redirecting index/404 pages for GitHub Pages
- publish a summary entry with the exact preview URL after deploying the artifact

## Testing
- Not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f10882e8e8832b9c142854532cd55e