### PR TITLE
Modernize bot catalog UI with portfolio-inspired styling

### DIFF
--- a/src/app/components/bot-card/bot-card.component.html
+++ b/src/app/components/bot-card/bot-card.component.html
@@ -1,18 +1,19 @@
 <div class="bot">
-    <h3>{{ bot.botName }}</h3>
-    <p>Description: {{ bot.description || 'No description available' }}</p>
-    <p>Start Command <br>{{ bot.startCommand || 'No start commands provided' }}</p>
+    <div class="bot-header">
+        <h3>{{ bot.botName }}</h3>
+        <span class="bot-language">{{ language | uppercase }}</span>
+    </div>
+    <p class="bot-description">{{ bot.description || 'No description available' }}</p>
+    <div class="bot-command">
+        <span>Start command</span>
+        <code>{{ bot.startCommand || 'No start commands provided' }}</code>
+    </div>
 
-    <!-- Bottone "Vai al PDF to Txt" solo se il nome del bot è pdfToTxt -->
-    <button *ngIf="bot.botName === 'pdf-to-txt'" class="nav-link-button" (click)="navigateToPdfToTxt()">
-        Vai al Converter PDF to Txt
-    </button>
-
-
-
-    <!-- Altri pulsanti dinamici esistenti -->
-    <button (click)="openBot()">View Source</button>
-    <button (click)="downloadBot()">Download</button>
+    <div class="bot-actions">
+        <button *ngIf="bot.botName === 'pdf-to-txt'" class="ghost-button" (click)="navigateToPdfToTxt()">
+            Vai al converter PDF to Txt
+        </button>
+        <button class="ghost-button" (click)="openBot()">View source</button>
+        <button (click)="downloadBot()">Download</button>
+    </div>
 </div>
-
-<!-- pdfToTxt -->

--- a/src/app/components/bot-card/bot-card.component.scss
+++ b/src/app/components/bot-card/bot-card.component.scss
@@ -1,16 +1,82 @@
 .bot {
-    background-color: var(--bg-card, #333);
-    color: var(--text-card, #eee);
-    padding: 1rem;
-    border-radius: 8px;
-    margin: 1rem 0;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.8rem;
+  border-radius: 24px;
+  background: rgba(8, 15, 31, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  backdrop-filter: blur(18px);
 
-    .nav-link-button {
-        background-color: var(--button-bg, #5cb85c);
-        cursor: pointer;
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(124, 58, 237, 0.12));
+    opacity: 0;
+    transition: opacity 0.25s ease;
+    pointer-events: none;
+  }
 
-        &:hover {
-            background-color: var(--button-hover, #4cae4c);
-        }
+  &:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 28px 55px rgba(15, 23, 42, 0.5);
+
+    &::after {
+      opacity: 1;
     }
+  }
+
+  .bot-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+
+    h3 {
+      margin: 0;
+      font-size: 1.4rem;
+      text-transform: capitalize;
+    }
+
+    .bot-language {
+      font-size: 0.75rem;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: var(--accent);
+      background: rgba(56, 189, 248, 0.1);
+      border-radius: 999px;
+      padding: 0.35rem 0.8rem;
+      border: 1px solid rgba(56, 189, 248, 0.25);
+    }
+  }
+
+  .bot-description {
+    margin: 0;
+    color: var(--text-muted);
+    line-height: 1.6;
+  }
+
+  .bot-command {
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+
+    span {
+      font-size: 0.85rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: rgba(226, 232, 240, 0.65);
+    }
+  }
+
+  .bot-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
 }

--- a/src/app/components/bot-list/bot-list.component.html
+++ b/src/app/components/bot-list/bot-list.component.html
@@ -1,9 +1,12 @@
 <app-header></app-header>
-<main *ngIf="botSections.length; else errorTemplate">
+<main class="bot-list" id="bots" *ngIf="botSections.length; else errorTemplate">
   <app-bot-section *ngFor="let section of botSections" [language]="section.language"
     [bots]="section.botDetails"></app-bot-section>
 </main>
 <ng-template #errorTemplate>
-  <p>{{ errorMessage || 'No bots available.' }}</p>
+  <div class="error-state">
+    <h2>Ops, qualcosa è andato storto.</h2>
+    <p>{{ errorMessage || 'No bots available.' }}</p>
+  </div>
 </ng-template>
 <app-footer></app-footer>

--- a/src/app/components/bot-list/bot-list.component.scss
+++ b/src/app/components/bot-list/bot-list.component.scss
@@ -1,19 +1,33 @@
-:root {
-    --bg-header: #222;
-    --text-header: #fff;
-    --bg-footer: #111;
-    --text-footer: #ccc;
-    --bg-card: #333;
-    --text-card: #eee;
-    --button-bg: #007acc;
-    --button-text: #fff;
-    --button-hover: #005fa3;
+:host {
+  display: block;
 }
 
-body {
-    background-color: #121212;
-    color: #e0e0e0;
-    font-family: Arial, sans-serif;
+main.bot-list {
+  position: relative;
+  padding-bottom: clamp(3rem, 8vw, 5rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2.5rem, 6vw, 4rem);
+}
+
+.error-state {
+  width: min(600px, 100% - 3rem);
+  margin: 4rem auto;
+  padding: 2.5rem;
+  text-align: center;
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 24px;
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(16px);
+
+  h2 {
+    margin-bottom: 1rem;
+    font-size: clamp(1.4rem, 4vw, 1.8rem);
+  }
+
+  p {
     margin: 0;
-    padding: 0;
+    color: var(--text-muted);
+  }
 }

--- a/src/app/components/bot-section/bot-section.component.html
+++ b/src/app/components/bot-section/bot-section.component.html
@@ -1,4 +1,4 @@
-<section>
+<section class="bot-section">
     <h2>{{ capitalize(language) }} Bots</h2>
     <div class="bot-container">
         <app-bot-card *ngFor="let bot of bots" [bot]="bot" [language]="language"

--- a/src/app/components/bot-section/bot-section.component.scss
+++ b/src/app/components/bot-section/bot-section.component.scss
@@ -1,18 +1,35 @@
-section {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-}
+.bot-section {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding: clamp(2.5rem, 6vw, 3.5rem);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.55));
+  border-radius: 32px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: var(--shadow-strong);
+  backdrop-filter: blur(22px);
+  overflow: hidden;
 
-h2 {
-    color: #e0e0e0;
-}
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(59, 130, 246, 0.18), transparent 55%);
+    pointer-events: none;
+  }
 
-.bot-container {
-    display: flex;
-    flex-wrap: wrap;
-    flex-direction: row;
-    gap: 1rem;
-    justify-content: center;
+  h2 {
+    margin: 0;
+    font-size: clamp(1.6rem, 4vw, 2rem);
+    text-transform: capitalize;
+    letter-spacing: 0.04em;
+  }
+
+  .bot-container {
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+  }
 }

--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -1,3 +1,3 @@
 <footer>
-    <p>&copy; 2024 Scriptagher</p>
+    <p>&copy; 2024 Scriptagher · Crafted with passion for automation</p>
 </footer>

--- a/src/app/components/footer/footer.component.scss
+++ b/src/app/components/footer/footer.component.scss
@@ -1,6 +1,16 @@
 footer {
-    text-align: center;
-    padding: 1rem;
-    background-color: var(--bg-footer, #111);
-    color: var(--text-footer, #ccc);
+  margin-top: clamp(3rem, 8vw, 5rem);
+  padding: 2.5rem 1rem 2rem;
+  text-align: center;
+  color: var(--text-muted);
+  border-top: 1px solid rgba(148, 163, 184, 0.15);
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.08), transparent 65%);
+  backdrop-filter: blur(12px);
+
+  p {
+    margin: 0;
+    font-size: 0.95rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
 }

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -2,18 +2,30 @@
     <div class="header-content">
         <!-- Header PDF to Txt -->
         <div *ngIf="isPdfToTxtPage; else normalHeader" class="pdf-header">
-            <span class="app-name">Scriptagher</span>
-            <span class="current-page">PDF to Txt</span>
-            <div class="home-button" (click)="navigateHome()">
-                <img src="/icons/icons8-home-64.png"/>    
+            <div class="pdf-copy">
+                <span class="app-name">Scriptagher</span>
+                <span class="current-page">PDF to Txt</span>
             </div>
+            <button class="ghost-button" (click)="navigateHome()">
+                <span>Home</span>
+            </button>
         </div>
 
         <!-- Header normale -->
         <ng-template #normalHeader>
             <div class="normal-header">
-                <h1>Welcome to the Bot List</h1>
-                <p>Here is a list of available bots, organized by language.</p>
+                <p class="subtitle">Un arsenale di automazioni creative</p>
+                <h1 class="headline">Scriptagher Bot Library</h1>
+                <p class="description">
+                    Esplora una raccolta curata di bot multi-lingua, con design e interazioni ispirate allo stile del
+                    portfolio personale.
+                </p>
+                <div class="header-actions">
+                    <a class="ghost-button" href="#bots">Esplora i bot</a>
+                    <a class="ghost-button" href="https://diegofcj.github.io/portfolio/" target="_blank" rel="noreferrer">
+                        Visita il portfolio
+                    </a>
+                </div>
             </div>
         </ng-template>
     </div>

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -1,75 +1,121 @@
-/* Stile principale per l'header */
 header {
+  position: relative;
+  padding: clamp(3rem, 8vw, 5.5rem) 0 clamp(2rem, 6vw, 3.5rem);
+  color: var(--text-primary);
+  overflow: hidden;
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    width: 420px;
+    height: 420px;
+    border-radius: 50%;
+    filter: blur(120px);
+    opacity: 0.45;
+    pointer-events: none;
+  }
+
+  &::before {
+    background: rgba(56, 189, 248, 0.65);
+    top: -220px;
+    left: -180px;
+  }
+
+  &::after {
+    background: rgba(13, 148, 136, 0.55);
+    top: -150px;
+    right: -200px;
+  }
+
+  &.pdf-page {
+    padding: 1.5rem min(3rem, 6vw);
+    background: rgba(15, 23, 42, 0.75);
+    border-bottom: 1px solid var(--border-subtle);
+    box-shadow: var(--shadow-soft);
+
+    &::before,
+    &::after {
+      display: none;
+    }
+  }
+
+  .header-content {
+    position: relative;
+    z-index: 1;
+    width: min(1100px, 100% - 3rem);
+    margin: 0 auto;
+  }
+
+  .pdf-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+
+    .pdf-copy {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+
+      .app-name {
+        font-weight: 600;
+        font-size: 1.35rem;
+      }
+
+      .current-page {
+        font-size: 0.95rem;
+        color: var(--text-muted);
+      }
+    }
+  }
+
+  .normal-header {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    align-items: center;
     text-align: center;
-    padding: 1rem;
-    background: var(--header-bg, #222);
-    color: white;
-    transition: background-color 0.3s ease;
 
-    &.pdf-page {
-        height: 5cap;
-        background: var(--pdf-header-bg, #333);
-        position: relative;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 0 1rem;
+    .subtitle {
+      text-transform: uppercase;
+      font-size: 0.85rem;
+      letter-spacing: 0.35em;
+      color: var(--text-muted);
+      margin: 0;
     }
 
-    .header-content {
-        position: relative;
-        width: 100%;
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
-        gap: 0.5rem;
-
-        /* Header PDF to Txt dinamico */
-        .pdf-header {
-            position: absolute;
-            left: 0;
-            right: 0;
-            top: -20px;
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            gap: 1rem;
-
-            .app-name {
-                font-size: 2rem;
-                color: white;
-            }
-
-            .current-page {
-                color: #ddd;
-                font-size: 2rem;
-            }
-
-            .home-button {
-                img {
-                    cursor: pointer;
-                    width: 35px;
-                    height: 35px;
-                    transition: transform 0.2s ease;
-
-                    &:hover {
-                        transform: scale(1.1);
-                        filter: invert(60%);
-                    }
-                }
-            }
-        }
-
-        /* Header normale */
-        .normal-header {
-            h1 {
-                font-size: 2rem;
-            }
-
-            p {
-                font-size: 1rem;
-                opacity: 0.7;
-            }
-        }
+    .headline {
+      margin: 0;
+      font-size: clamp(2.4rem, 5vw, 3.6rem);
+      background: linear-gradient(120deg, #38bdf8 0%, #818cf8 50%, #c084fc 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
     }
+
+    .description {
+      margin: 0;
+      max-width: 640px;
+      color: var(--text-muted);
+      line-height: 1.7;
+    }
+
+    .header-actions {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 1rem;
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  header {
+    padding-top: 3.5rem;
+
+    .pdf-header {
+      align-items: flex-start;
+      flex-direction: column;
+    }
+  }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,11 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap"
+    rel="stylesheet">
 </head>
 
 <body>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,17 +1,105 @@
-body{
-    background-color: #181818;
+:root {
+  --bg-base: #030617;
+  --bg-elevated: rgba(15, 23, 42, 0.75);
+  --bg-panel: rgba(2, 8, 23, 0.6);
+  --accent: #38bdf8;
+  --accent-strong: #22d3ee;
+  --accent-muted: rgba(56, 189, 248, 0.2);
+  --text-primary: #e2e8f0;
+  --text-muted: #94a3b8;
+  --border-subtle: rgba(148, 163, 184, 0.25);
+  --shadow-strong: 0 30px 60px rgba(2, 8, 23, 0.45);
+  --shadow-soft: 0 18px 40px rgba(14, 23, 42, 0.35);
+  font-size: 16px;
 }
 
-button, .custom-button {
-    background-color: var(--button-bg, #007acc);
-    color: var(--button-text, #fff);
-    border: none;
-    padding: 0.5rem 1rem;
-    border-radius: 4px;
-    cursor: pointer;
-    margin: 3px;
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
 
-    &:hover {
-        background-color: var(--button-hover, #005fa3);
-    }
+body {
+  margin: 0;
+  font-family: 'Poppins', 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at 20% -10%, rgba(56, 189, 248, 0.25), transparent 55%),
+    radial-gradient(circle at 85% 10%, rgba(14, 165, 233, 0.18), transparent 60%),
+    linear-gradient(180deg, rgba(2, 6, 23, 0.85), rgba(2, 6, 23, 1));
+  color: var(--text-primary);
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+}
+
+main {
+  width: min(1100px, 100% - 3rem);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2.5rem, 4vw, 4rem);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+.custom-button,
+.ghost-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.7rem 1.6rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #04172b;
+  box-shadow: 0 14px 30px rgba(34, 211, 238, 0.18);
+}
+
+button:hover,
+.custom-button:hover,
+.ghost-button:hover {
+  transform: translateY(-1px) scale(1.01);
+  box-shadow: 0 20px 45px rgba(56, 189, 248, 0.25);
+  filter: brightness(1.05);
+}
+
+button:active,
+.custom-button:active,
+.ghost-button:active {
+  transform: translateY(0) scale(0.99);
+}
+
+.ghost-button {
+  background: rgba(15, 23, 42, 0.55);
+  color: var(--accent);
+  border: 1px solid var(--accent-muted);
+  box-shadow: none;
+  backdrop-filter: blur(12px);
+}
+
+.ghost-button:hover {
+  background: rgba(56, 189, 248, 0.08);
+  box-shadow: 0 15px 30px rgba(8, 145, 178, 0.2);
+}
+
+code {
+  font-family: 'Fira Code', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 0.5rem;
+  padding: 0.35rem 0.6rem;
+  color: var(--accent);
+  border: 1px solid rgba(14, 165, 233, 0.2);
+}
+
+::selection {
+  background: rgba(56, 189, 248, 0.35);
+  color: #0b152a;
 }


### PR DESCRIPTION
## Summary
- apply portfolio-inspired typography, gradients, and button styling globally
- refresh the hero header, bot sections, and cards with glassmorphism-inspired layouts and calls to action
- refine the empty/error state and footer copy to match the updated aesthetic

## Testing
- npm run build *(fails: ng not found in current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f10eeaa4ec832b8d3329df950c3362