### PR TITLE
Add production GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,36 @@
+name: Deploy Production to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build production bundle
+        run: npm run build -- --configuration production
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: dist
+          clean: true
+          clean-exclude: previews


### PR DESCRIPTION
## Summary
- add a production deployment workflow that runs on main pushes or manual dispatch
- build the Angular app with npm ci and a production configuration before publishing
- publish the dist output to gh-pages while preserving the previews directory created by the preview workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f123a2c534832bb9a0ddd444df72bc