### PR TITLE
feat: restyle bot library to match portfolio aesthetic

### DIFF
--- a/src/app/components/bot-card/bot-card.component.html
+++ b/src/app/components/bot-card/bot-card.component.html
@@ -1,19 +1,21 @@
 <div class="bot">
-    <div class="bot-header">
-        <h3>{{ bot.botName }}</h3>
-        <span class="bot-language">{{ language | uppercase }}</span>
-    </div>
-    <p class="bot-description">{{ bot.description || 'No description available' }}</p>
-    <div class="bot-command">
-        <span>Start command</span>
-        <code>{{ bot.startCommand || 'No start commands provided' }}</code>
-    </div>
+    <div class="bot-surface">
+        <div class="bot-header">
+            <h3>{{ bot.botName }}</h3>
+            <span class="bot-language">{{ language | uppercase }}</span>
+        </div>
+        <p class="bot-description">{{ bot.description || 'No description available' }}</p>
+        <div class="bot-command">
+            <span>Start command</span>
+            <code>{{ bot.startCommand || 'No start commands provided' }}</code>
+        </div>
 
-    <div class="bot-actions">
-        <button *ngIf="bot.botName === 'pdf-to-txt'" class="ghost-button" (click)="navigateToPdfToTxt()">
-            Vai al converter PDF to Txt
-        </button>
-        <button class="ghost-button" (click)="openBot()">View source</button>
-        <button (click)="downloadBot()">Download</button>
+        <div class="bot-actions">
+            <button *ngIf="bot.botName === 'pdf-to-txt'" class="btn btn-secondary" (click)="navigateToPdfToTxt()">
+                Vai al converter PDF to Txt
+            </button>
+            <button class="btn btn-secondary" (click)="openBot()">View source</button>
+            <button class="btn btn-primary" (click)="downloadBot()">Download</button>
+        </div>
     </div>
 </div>

--- a/src/app/components/bot-card/bot-card.component.scss
+++ b/src/app/components/bot-card/bot-card.component.scss
@@ -1,76 +1,104 @@
 .bot {
   position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-  padding: 1.8rem;
-  border-radius: 24px;
-  background: rgba(8, 15, 31, 0.92);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.45);
-  transition: transform 0.25s ease, box-shadow 0.25s ease;
-  backdrop-filter: blur(18px);
+  padding: 1px;
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.4), rgba(129, 140, 248, 0.28));
+  transition: transform 0.3s ease, filter 0.3s ease;
+  isolation: isolate;
 
-  &::after {
+  &::before {
     content: '';
     position: absolute;
     inset: 0;
     border-radius: inherit;
-    background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(124, 58, 237, 0.12));
+    background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.35), transparent 60%);
     opacity: 0;
-    transition: opacity 0.25s ease;
+    transition: opacity 0.3s ease;
     pointer-events: none;
   }
 
   &:hover {
-    transform: translateY(-6px);
-    box-shadow: 0 28px 55px rgba(15, 23, 42, 0.5);
+    transform: translateY(-8px);
+    filter: drop-shadow(0 32px 55px rgba(8, 47, 73, 0.35));
 
-    &::after {
+    &::before {
       opacity: 1;
     }
   }
 
+  .bot-surface {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    padding: clamp(1.8rem, 4vw, 2.2rem);
+    border-radius: 27px;
+    background: linear-gradient(165deg, rgba(8, 15, 31, 0.95), rgba(15, 23, 42, 0.75));
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    backdrop-filter: blur(18px);
+  }
+
   .bot-header {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     justify-content: space-between;
     gap: 1rem;
 
     h3 {
       margin: 0;
-      font-size: 1.4rem;
+      font-size: 1.35rem;
       text-transform: capitalize;
+      letter-spacing: 0.04em;
     }
 
     .bot-language {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
       font-size: 0.75rem;
-      letter-spacing: 0.2em;
+      letter-spacing: 0.22em;
       text-transform: uppercase;
       color: var(--accent);
-      background: rgba(56, 189, 248, 0.1);
+      background: rgba(56, 189, 248, 0.12);
       border-radius: 999px;
-      padding: 0.35rem 0.8rem;
+      padding: 0.35rem 0.9rem;
       border: 1px solid rgba(56, 189, 248, 0.25);
+      box-shadow: inset 0 0 20px rgba(56, 189, 248, 0.12);
     }
   }
 
   .bot-description {
     margin: 0;
-    color: var(--text-muted);
-    line-height: 1.6;
+    color: rgba(226, 232, 240, 0.75);
+    line-height: 1.7;
   }
 
   .bot-command {
     display: flex;
     flex-direction: column;
-    gap: 0.55rem;
+    gap: 0.65rem;
+    padding: 1.15rem;
+    border-radius: 18px;
+    background: rgba(15, 23, 42, 0.75);
+    border: 1px solid rgba(56, 189, 248, 0.12);
+    box-shadow: inset 0 0 0 1px rgba(15, 118, 110, 0.12);
 
     span {
-      font-size: 0.85rem;
-      letter-spacing: 0.08em;
+      font-size: 0.8rem;
+      letter-spacing: 0.18em;
       text-transform: uppercase;
-      color: rgba(226, 232, 240, 0.65);
+      color: rgba(148, 163, 184, 0.85);
+    }
+
+    code {
+      display: block;
+      font-size: 0.95rem;
+      border-radius: 12px;
+      padding: 0.55rem 0.75rem;
+      background: rgba(8, 15, 31, 0.85);
+      border: 1px solid rgba(56, 189, 248, 0.2);
+      color: var(--accent);
     }
   }
 
@@ -78,5 +106,18 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0.75rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .bot {
+    .bot-actions {
+      flex-direction: column;
+
+      .btn {
+        width: 100%;
+        justify-content: center;
+      }
+    }
   }
 }

--- a/src/app/components/bot-section/bot-section.component.html
+++ b/src/app/components/bot-section/bot-section.component.html
@@ -1,5 +1,8 @@
 <section class="bot-section">
-    <h2>{{ capitalize(language) }} Bots</h2>
+    <div class="section-header">
+        <span class="section-language">{{ language | uppercase }}</span>
+        <h2>{{ capitalize(language) }} Bots</h2>
+    </div>
     <div class="bot-container">
         <app-bot-card *ngFor="let bot of bots" [bot]="bot" [language]="language"
             (download)="downloadBot(bot)"></app-bot-card>

--- a/src/app/components/bot-section/bot-section.component.scss
+++ b/src/app/components/bot-section/bot-section.component.scss
@@ -2,34 +2,84 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
-  padding: clamp(2.5rem, 6vw, 3.5rem);
-  background: linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.55));
-  border-radius: 32px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  gap: clamp(2rem, 5vw, 2.8rem);
+  padding: clamp(2.8rem, 6vw, 3.8rem);
+  border-radius: 36px;
+  background: linear-gradient(160deg, rgba(10, 18, 36, 0.95), rgba(15, 23, 42, 0.65));
+  border: 1px solid rgba(148, 163, 184, 0.22);
   box-shadow: var(--shadow-strong);
   backdrop-filter: blur(22px);
   overflow: hidden;
 
-  &::before {
+  &::before,
+  &::after {
     content: '';
     position: absolute;
     inset: 0;
-    background: radial-gradient(circle at top right, rgba(59, 130, 246, 0.18), transparent 55%);
     pointer-events: none;
+  }
+
+  &::before {
+    background: radial-gradient(circle at top right, rgba(59, 130, 246, 0.22), transparent 55%);
+  }
+
+  &::after {
+    border-radius: inherit;
+    border: 1px solid rgba(56, 189, 248, 0.18);
+    opacity: 0.35;
+  }
+
+  .section-header {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .section-language {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.8rem;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: rgba(148, 163, 184, 0.85);
+    background: rgba(8, 47, 73, 0.6);
+    padding: 0.4rem 1rem;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    box-shadow: inset 0 0 20px rgba(56, 189, 248, 0.08);
   }
 
   h2 {
     margin: 0;
-    font-size: clamp(1.6rem, 4vw, 2rem);
+    font-size: clamp(1.8rem, 4vw, 2.2rem);
+    font-weight: 600;
+    letter-spacing: 0.05em;
     text-transform: capitalize;
-    letter-spacing: 0.04em;
+    background: linear-gradient(120deg, #38bdf8 0%, #818cf8 50%, #c084fc 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
   }
 
   .bot-container {
     position: relative;
+    z-index: 1;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: clamp(1.5rem, 4vw, 2rem);
+  }
+}
+
+@media (max-width: 640px) {
+  .bot-section {
+    .section-header {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.75rem;
+    }
   }
 }

--- a/src/app/components/footer/footer.component.scss
+++ b/src/app/components/footer/footer.component.scss
@@ -1,16 +1,30 @@
 footer {
-  margin-top: clamp(3rem, 8vw, 5rem);
-  padding: 2.5rem 1rem 2rem;
+  position: relative;
+  margin-top: clamp(3.5rem, 8vw, 5.5rem);
+  padding: 3rem 1rem 2.5rem;
   text-align: center;
-  color: var(--text-muted);
-  border-top: 1px solid rgba(148, 163, 184, 0.15);
-  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.08), transparent 65%);
-  backdrop-filter: blur(12px);
+  color: rgba(148, 163, 184, 0.85);
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+  background: linear-gradient(180deg, rgba(2, 8, 23, 0), rgba(2, 8, 23, 0.8));
+  backdrop-filter: blur(14px);
+  overflow: hidden;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top, rgba(56, 189, 248, 0.18), transparent 60%);
+    pointer-events: none;
+  }
 
   p {
+    position: relative;
     margin: 0;
     font-size: 0.95rem;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.18em;
     text-transform: uppercase;
+    background: linear-gradient(120deg, rgba(148, 163, 184, 0.85), rgba(56, 189, 248, 0.85));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
   }
 }

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -6,23 +6,23 @@
                 <span class="app-name">Scriptagher</span>
                 <span class="current-page">PDF to Txt</span>
             </div>
-            <button class="ghost-button" (click)="navigateHome()">
+            <button class="btn btn-secondary" (click)="navigateHome()">
                 <span>Home</span>
             </button>
         </div>
 
         <!-- Header normale -->
         <ng-template #normalHeader>
-            <div class="normal-header">
-                <p class="subtitle">Un arsenale di automazioni creative</p>
-                <h1 class="headline">Scriptagher Bot Library</h1>
-                <p class="description">
+            <div class="hero">
+                <span class="hero-eyebrow">Un arsenale di automazioni creative</span>
+                <h1 class="hero-title">Scriptagher Bot Library</h1>
+                <p class="hero-description">
                     Esplora una raccolta curata di bot multi-lingua, con design e interazioni ispirate allo stile del
                     portfolio personale.
                 </p>
-                <div class="header-actions">
-                    <a class="ghost-button" href="#bots">Esplora i bot</a>
-                    <a class="ghost-button" href="https://diegofcj.github.io/portfolio/" target="_blank" rel="noreferrer">
+                <div class="hero-actions">
+                    <a class="btn btn-primary" href="#bots">Esplora i bot</a>
+                    <a class="btn btn-secondary" href="https://diegofcj.github.io/portfolio/" target="_blank" rel="noreferrer">
                         Visita il portfolio
                     </a>
                 </div>

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -1,6 +1,6 @@
 header {
   position: relative;
-  padding: clamp(3rem, 8vw, 5.5rem) 0 clamp(2rem, 6vw, 3.5rem);
+  padding: clamp(3.5rem, 8vw, 6rem) 0 clamp(3rem, 6vw, 4.5rem);
   color: var(--text-primary);
   overflow: hidden;
 
@@ -8,29 +8,30 @@ header {
   &::after {
     content: '';
     position: absolute;
-    width: 420px;
-    height: 420px;
-    border-radius: 50%;
-    filter: blur(120px);
-    opacity: 0.45;
     pointer-events: none;
+    filter: blur(140px);
+    opacity: 0.7;
   }
 
   &::before {
-    background: rgba(56, 189, 248, 0.65);
-    top: -220px;
-    left: -180px;
+    width: 520px;
+    height: 520px;
+    top: -260px;
+    left: -200px;
+    background: radial-gradient(circle, rgba(56, 189, 248, 0.8), rgba(56, 189, 248, 0));
   }
 
   &::after {
-    background: rgba(13, 148, 136, 0.55);
-    top: -150px;
-    right: -200px;
+    width: 480px;
+    height: 480px;
+    bottom: -280px;
+    right: -160px;
+    background: radial-gradient(circle, rgba(129, 140, 248, 0.85), rgba(129, 140, 248, 0));
   }
 
   &.pdf-page {
     padding: 1.5rem min(3rem, 6vw);
-    background: rgba(15, 23, 42, 0.75);
+    background: rgba(15, 23, 42, 0.9);
     border-bottom: 1px solid var(--border-subtle);
     box-shadow: var(--shadow-soft);
 
@@ -70,42 +71,71 @@ header {
     }
   }
 
-  .normal-header {
+  .hero {
+    position: relative;
     display: flex;
     flex-direction: column;
-    gap: 1.5rem;
+    gap: 1.75rem;
     align-items: center;
     text-align: center;
+    padding: clamp(2.5rem, 6vw, 3.8rem) clamp(1.5rem, 4vw, 3rem);
+    border-radius: 42px;
+    background: linear-gradient(160deg, rgba(10, 18, 36, 0.9), rgba(15, 23, 42, 0.65));
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    box-shadow: 0 45px 120px rgba(8, 47, 73, 0.45);
+    overflow: hidden;
 
-    .subtitle {
-      text-transform: uppercase;
-      font-size: 0.85rem;
-      letter-spacing: 0.35em;
-      color: var(--text-muted);
-      margin: 0;
+    &::before,
+    &::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
     }
 
-    .headline {
-      margin: 0;
-      font-size: clamp(2.4rem, 5vw, 3.6rem);
-      background: linear-gradient(120deg, #38bdf8 0%, #818cf8 50%, #c084fc 100%);
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
+    &::before {
+      background: radial-gradient(circle at top, rgba(56, 189, 248, 0.25), transparent 65%);
     }
 
-    .description {
-      margin: 0;
-      max-width: 640px;
-      color: var(--text-muted);
-      line-height: 1.7;
+    &::after {
+      border-radius: inherit;
+      border: 1px solid rgba(56, 189, 248, 0.25);
+      opacity: 0.35;
     }
 
-    .header-actions {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      gap: 1rem;
+    > * {
+      position: relative;
+      z-index: 1;
     }
+  }
+
+  .hero-eyebrow {
+    font-size: 0.9rem;
+    letter-spacing: 0.4em;
+    text-transform: uppercase;
+    color: rgba(148, 163, 184, 0.85);
+  }
+
+  .hero-title {
+    margin: 0;
+    font-size: clamp(2.8rem, 6vw, 3.9rem);
+    background: linear-gradient(120deg, #38bdf8 0%, #818cf8 50%, #c084fc 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
+  .hero-description {
+    margin: 0;
+    max-width: 640px;
+    color: rgba(226, 232, 240, 0.78);
+    line-height: 1.8;
+  }
+
+  .hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1rem;
   }
 }
 
@@ -116,6 +146,10 @@ header {
     .pdf-header {
       align-items: flex-start;
       flex-direction: column;
+    }
+
+    .hero {
+      border-radius: 32px;
     }
   }
 }

--- a/src/app/components/not-found/not-found.component.html
+++ b/src/app/components/not-found/not-found.component.html
@@ -1,5 +1,5 @@
 <div style="text-align: center; margin-top: 50px;">
     <h1>404 - Page Not Found</h1>
     <p>The page you are looking for does not exist.</p>
-    <a routerLink="/" class="button" (click)="navigateHome()">Go Back to Home</a>
+    <a routerLink="/" class="btn btn-primary" (click)="navigateHome()">Go Back to Home</a>
 </div>

--- a/src/app/components/not-found/not-found.component.scss
+++ b/src/app/components/not-found/not-found.component.scss
@@ -1,14 +1,8 @@
-.button {
-    margin-top: 20px;
-    padding: 10px 15px;
-    background-color: #007BFF;
-    color: white;
-    text-decoration: none;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
+:host {
+  display: block;
 }
 
-.button:hover {
-    background-color: #0056b3;
+a {
+  margin-top: 2rem;
+  display: inline-flex;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,15 +1,16 @@
 :root {
   --bg-base: #030617;
-  --bg-elevated: rgba(15, 23, 42, 0.75);
-  --bg-panel: rgba(2, 8, 23, 0.6);
+  --bg-elevated: rgba(15, 23, 42, 0.78);
+  --bg-panel: rgba(2, 8, 23, 0.65);
   --accent: #38bdf8;
   --accent-strong: #22d3ee;
+  --accent-highlight: #818cf8;
   --accent-muted: rgba(56, 189, 248, 0.2);
   --text-primary: #e2e8f0;
   --text-muted: #94a3b8;
-  --border-subtle: rgba(148, 163, 184, 0.25);
-  --shadow-strong: 0 30px 60px rgba(2, 8, 23, 0.45);
-  --shadow-soft: 0 18px 40px rgba(14, 23, 42, 0.35);
+  --border-subtle: rgba(148, 163, 184, 0.22);
+  --shadow-strong: 0 40px 120px rgba(2, 8, 23, 0.55);
+  --shadow-soft: 0 18px 45px rgba(14, 23, 42, 0.35);
   font-size: 16px;
 }
 
@@ -22,9 +23,9 @@
 body {
   margin: 0;
   font-family: 'Poppins', 'Segoe UI', sans-serif;
-  background: radial-gradient(circle at 20% -10%, rgba(56, 189, 248, 0.25), transparent 55%),
-    radial-gradient(circle at 85% 10%, rgba(14, 165, 233, 0.18), transparent 60%),
-    linear-gradient(180deg, rgba(2, 6, 23, 0.85), rgba(2, 6, 23, 1));
+  background: radial-gradient(circle at 20% -5%, rgba(56, 189, 248, 0.4), transparent 60%),
+    radial-gradient(circle at 80% 0%, rgba(129, 140, 248, 0.35), transparent 58%),
+    linear-gradient(180deg, rgba(2, 6, 23, 0.95), rgba(2, 6, 23, 1));
   color: var(--text-primary);
   min-height: 100vh;
   -webkit-font-smoothing: antialiased;
@@ -43,51 +44,83 @@ a {
   text-decoration: none;
 }
 
-button,
-.custom-button,
-.ghost-button {
+button {
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+.btn {
   position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  padding: 0.7rem 1.6rem;
+  padding: 0.8rem 1.9rem;
   border-radius: 999px;
-  border: none;
+  border: 1px solid transparent;
   font-weight: 600;
+  font-size: 0.95rem;
   letter-spacing: 0.02em;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
-  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  color: #04172b;
-  box-shadow: 0 14px 30px rgba(34, 211, 238, 0.18);
+  text-decoration: none;
+  overflow: hidden;
+  isolation: isolate;
 }
 
-button:hover,
-.custom-button:hover,
-.ghost-button:hover {
-  transform: translateY(-1px) scale(1.01);
-  box-shadow: 0 20px 45px rgba(56, 189, 248, 0.25);
+.btn::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  z-index: -1;
+  transition: opacity 0.2s ease;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #04172b;
+  box-shadow: 0 20px 45px rgba(34, 211, 238, 0.2);
+}
+
+.btn-primary::after {
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.4), transparent 55%);
+  opacity: 0.5;
+}
+
+.btn-primary:hover {
+  transform: translateY(-2px) scale(1.01);
+  box-shadow: 0 28px 65px rgba(45, 212, 191, 0.28);
   filter: brightness(1.05);
 }
 
-button:active,
-.custom-button:active,
-.ghost-button:active {
+.btn-primary:active {
   transform: translateY(0) scale(0.99);
 }
 
-.ghost-button {
-  background: rgba(15, 23, 42, 0.55);
+.btn-secondary {
+  background: rgba(15, 23, 42, 0.65);
+  border-color: rgba(148, 163, 184, 0.25);
   color: var(--accent);
-  border: 1px solid var(--accent-muted);
   box-shadow: none;
-  backdrop-filter: blur(12px);
+  backdrop-filter: blur(16px);
 }
 
-.ghost-button:hover {
-  background: rgba(56, 189, 248, 0.08);
-  box-shadow: 0 15px 30px rgba(8, 145, 178, 0.2);
+.btn-secondary::after {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.15), rgba(129, 140, 248, 0.08));
+  opacity: 0.7;
+}
+
+.btn-secondary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 45px rgba(14, 165, 233, 0.15);
+}
+
+.btn-secondary:active {
+  transform: translateY(0);
 }
 
 code {


### PR DESCRIPTION
## Summary
- redesign the hero header with gradient framing and updated call-to-action buttons that mirror the portfolio styling
- restyle bot sections and cards with neon gradients, command blocks, and refreshed language pills
- introduce reusable button styles and apply them across footer and error views for a cohesive UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f2518d3f88832bac22987e0eb631df