### PR TITLE
Update hero messaging and CTA copy

### DIFF
--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -17,13 +17,13 @@
                 <span class="hero-eyebrow">Un arsenale di automazioni creative</span>
                 <h1 class="hero-title">Scriptagher Bot Library</h1>
                 <p class="hero-description">
-                    Esplora una raccolta curata di bot multi-lingua, con design e interazioni ispirate allo stile del
-                    portfolio personale.
+                    Esplora una raccolta curata di bot multi-lingua, con design e interazioni pensate per un'esperienza
+                    immersiva e coinvolgente.
                 </p>
                 <div class="hero-actions">
                     <a class="btn btn-primary" href="#bots">Esplora i bot</a>
                     <a class="btn btn-secondary" href="https://diegofcj.github.io/portfolio/" target="_blank" rel="noreferrer">
-                        Visita il portfolio
+                        Visita il sito
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- refresh the hero description to remove the portfolio reference and emphasize an immersive experience
- rename the hero secondary CTA button label to "Visita il sito"

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f2872e2b50832b881c7b7b03e9fdc2