### PR TITLE
Separate browser and server TypeScript configs for SSR build

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -49,6 +49,25 @@
           },
           "defaultConfiguration": "production"
         },
+        "server": {
+          "builder": "@angular-devkit/build-angular:server",
+          "options": {
+            "outputPath": "dist/bot-list/server",
+            "main": "server.ts",
+            "tsConfig": "tsconfig.server.json"
+          },
+          "configurations": {
+            "production": {
+              "bundleDependencies": "all",
+              "sourceMap": false
+            },
+            "development": {
+              "bundleDependencies": "all",
+              "sourceMap": true
+            }
+          },
+          "defaultConfiguration": "production"
+        },
         "serve": {
           "options": {
             "proxyConfig": "proxy.conf.json"

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,17 +1,16 @@
 /* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
-/* To learn more about Angular compiler options: https://angular.dev/reference/configs/angular-compiler-options. */
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "./out-tsc/app",
+    "outDir": "./out-tsc/server",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "types": [
       "node"
     ]
   },
   "files": [
-    "src/main.ts"
-  ],
-  "include": [
-    "src/**/*.d.ts"
+    "src/main.server.ts",
+    "server.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- limit the browser tsconfig to the client entry point to avoid server-only files during browser builds
- add a dedicated tsconfig.server.json with Node-oriented compiler options for the SSR bundle
- update the Angular server target to consume the new server tsconfig while keeping existing build outputs

## Testing
- npm run build *(fails: ng not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2a949ed00832ba4bd090e14ec5aad