### PR TITLE
Align Angular build outputs for SSR deployment

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -17,7 +17,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "outputPath": "dist",
+            "outputPath": "dist/bot-list/browser",
             "main": "src/main.ts",
             "baseHref": "/scriptagher/",
             "index": "src/index.html",
@@ -91,30 +91,31 @@
         "deploy": {
           "builder": "angular-cli-ghpages:deploy",
           "options": {
-            "outputPath": "dist",
-            "baseHref": "/scriptagher/",
-            "index": "src/index.html",
-            "polyfills": [
-              "zone.js"
-            ],
+            "buildTarget": "bot-list:build:production",
+            "dir": "dist/bot-list/browser"
+          }
+        },
+        "server": {
+          "builder": "@angular-devkit/build-angular:server",
+          "options": {
+            "outputPath": "dist/bot-list/server",
+            "main": "server.ts",
+            "tsConfig": "tsconfig.server.json",
             "assets": [
               {
-                "glob": "**/*",
-                "input": "public"
+                "glob": "server.mjs",
+                "input": ".",
+                "output": "."
               }
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
-            "scripts": []
+            ]
           },
           "configurations": {
             "production": {
               "optimization": true,
-              "sourceMap": false,
-              "outputHashing": "all"
+              "sourceMap": false
             }
-          }
+          },
+          "defaultConfiguration": "production"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "bot-list",
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -8,7 +9,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "serve:ssr:bot-list": "node dist/bot-list/server/server.mjs",
-    "deploy": "npx angular-cli-ghpages --branch=gh-pages --message 'Deploy to GitHub Pages'"
+    "deploy": "npx angular-cli-ghpages --dir=dist/bot-list/browser --branch=gh-pages --message 'Deploy to GitHub Pages'"
   },
   "private": true,
   "dependencies": {

--- a/server.mjs
+++ b/server.mjs
@@ -1,0 +1,1 @@
+import './main.js';

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc/server",
+    "types": ["node"]
+  },
+  "files": [
+    "src/main.server.ts",
+    "server.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- update the browser build output and gh-pages deploy settings to publish `dist/bot-list/browser`
- add an SSR server target with its own TypeScript config and copy a wrapper entry so the bundled server runs from `server.mjs`
- mark the package as an ES module and point the npm deploy script at the new browser build directory

## Testing
- npx ng build --configuration production --progress=false
- npx ng run bot-list:server --progress=false
- npx ng deploy --no-build

------
https://chatgpt.com/codex/tasks/task_e_68f2a94850f4832b8e4232f458bf703b