### PR TITLE
Replace home carousel with bot category navigation

### DIFF
--- a/lib/backend/server/controllers/bot_controller.dart
+++ b/lib/backend/server/controllers/bot_controller.dart
@@ -71,7 +71,8 @@ class BotController {
   Future<Response> fetchLocalBots(Request request) async {
     try {
       logger.info(LOGS.BOT_SERVICE, 'Fetching list of local bots...');
-      final List<Bot> localBots = await botGetService.fetchLocalBotsFromDbAndFs();
+      final List<Bot> localBots =
+          await botGetService.fetchLocalBotsFromFilesystem();
 
       logger.info(LOGS.BOT_SERVICE, 'Fetched ${localBots.length} local bots.');
       return Response.ok(
@@ -83,6 +84,31 @@ class BotController {
       return Response.internalServerError(
         body: json.encode({
           'error': 'Error fetching local bots',
+          'message': e.toString(),
+        }),
+        headers: {'Content-Type': 'application/json'},
+      );
+    }
+  }
+
+  // Endpoint per ottenere la lista dei bot scaricati dal database
+  Future<Response> fetchDownloadedBots(Request request) async {
+    try {
+      logger.info(LOGS.BOT_SERVICE, 'Fetching downloaded bots from DB...');
+      final List<Bot> downloadedBots =
+          await botGetService.fetchDownloadedBotsFromDb();
+
+      logger.info(
+          LOGS.BOT_SERVICE, 'Fetched ${downloadedBots.length} downloaded bots.');
+      return Response.ok(
+        json.encode(downloadedBots.map((bot) => bot.toMap()).toList()),
+        headers: {'Content-Type': 'application/json'},
+      );
+    } catch (e) {
+      logger.error(LOGS.BOT_SERVICE, 'Error fetching downloaded bots: $e');
+      return Response.internalServerError(
+        body: json.encode({
+          'error': 'Error fetching downloaded bots',
           'message': e.toString(),
         }),
         headers: {'Content-Type': 'application/json'},

--- a/lib/backend/server/routes.dart
+++ b/lib/backend/server/routes.dart
@@ -20,6 +20,8 @@ class BotRoutes {
 
     router.get('/localbots', botController.fetchLocalBots);
 
+    router.get('/bots/downloaded', botController.fetchDownloadedBots);
+
     return router;
   }
 }

--- a/lib/frontend/models/bot_navigation.dart
+++ b/lib/frontend/models/bot_navigation.dart
@@ -1,0 +1,7 @@
+enum BotCategory { downloaded, online, local }
+
+class BotListArguments {
+  final BotCategory initialCategory;
+
+  const BotListArguments({required this.initialCategory});
+}

--- a/lib/frontend/services/bot_get_service.dart
+++ b/lib/frontend/services/bot_get_service.dart
@@ -7,9 +7,31 @@ class BotGetService {
 
   BotGetService({this.baseUrl = 'http://localhost:8080'});
 
-  Future<Map<String, List<Bot>>> fetchBots() async {
-    final url = Uri.parse('$baseUrl/bots');
+  Future<Map<String, List<Bot>>> fetchBots() => fetchOnlineBots();
 
+  Future<Map<String, List<Bot>>> fetchOnlineBots() async {
+    return _fetchGrouped(Uri.parse('$baseUrl/bots'));
+  }
+
+  Future<Map<String, List<Bot>>> fetchDownloadedBots() async {
+    return _fetchGrouped(Uri.parse('$baseUrl/bots/downloaded'));
+  }
+
+  Future<Map<String, List<Bot>>> fetchLocalBots() async {
+    return _fetchGrouped(Uri.parse('$baseUrl/localbots'));
+  }
+
+  Future<List<Bot>> fetchLocalBotsFlat() async {
+    final grouped = await fetchLocalBots();
+    return grouped.values.expand((bots) => bots).toList();
+  }
+
+  Future<List<Bot>> fetchDownloadedBotsFlat() async {
+    final grouped = await fetchDownloadedBots();
+    return grouped.values.expand((bots) => bots).toList();
+  }
+
+  Future<Map<String, List<Bot>>> _fetchGrouped(Uri url) async {
     try {
       final response = await http.get(url);
 
@@ -29,36 +51,6 @@ class BotGetService {
       }
     } catch (e) {
       throw Exception('Failed to fetch bots: $e');
-    }
-  }
-
-  Future<List<Bot>> fetchLocalBotsFlat() async {
-    final grouped = await fetchLocalBots();
-    return grouped.values.expand((bots) => bots).toList();
-  }
-
-  Future<Map<String, List<Bot>>> fetchLocalBots() async {
-    final url = Uri.parse('$baseUrl/localbots');
-
-    try {
-      final response = await http.get(url);
-
-      if (response.statusCode == 200) {
-        final List<dynamic> data = jsonDecode(response.body);
-        final Map<String, List<Bot>> groupedBots = {};
-
-        for (var botJson in data) {
-          final bot = Bot.fromJson(botJson);
-          groupedBots.putIfAbsent(bot.language, () => []).add(bot);
-        }
-
-        return groupedBots;
-      } else {
-        throw Exception(
-            'Failed to load local bots. Status Code: ${response.statusCode}');
-      }
-    } catch (e) {
-      throw Exception('Failed to fetch local bots: $e');
     }
   }
 }

--- a/lib/frontend/widgets/pages/bot_list_view.dart
+++ b/lib/frontend/widgets/pages/bot_list_view.dart
@@ -1,102 +1,159 @@
 import 'package:flutter/material.dart';
 import '../../models/bot.dart';
+import '../../models/bot_navigation.dart';
 import '../../services/bot_get_service.dart';
 import '../components/bot_card_component.dart';
 import 'bot_detail_view.dart';
 
 class BotList extends StatefulWidget {
+  const BotList({Key? key}) : super(key: key);
+
   @override
-  _BotListState createState() => _BotListState();
+  State<BotList> createState() => _BotListState();
 }
 
-class _BotListState extends State<BotList> {
-  late Future<Map<String, List<Bot>>> _remoteBots;
-  late Future<List<Bot>> _localBots;
-
+class _BotListState extends State<BotList>
+    with SingleTickerProviderStateMixin {
   final BotGetService _botGetService = BotGetService();
+
+  late final Map<BotCategory, Future<Map<String, List<Bot>>>> _categoryFutures;
+  late final TabController _tabController;
+
+  BotCategory _selectedCategory = BotCategory.online;
+  bool _argumentsHandled = false;
 
   @override
   void initState() {
     super.initState();
-    _remoteBots = _botGetService.fetchBots();
-    _localBots = _botGetService.fetchLocalBotsFlat();
+    _categoryFutures = {
+      BotCategory.downloaded: _botGetService.fetchDownloadedBots(),
+      BotCategory.online: _botGetService.fetchOnlineBots(),
+      BotCategory.local: _botGetService.fetchLocalBots(),
+    };
+    _tabController = TabController(
+      length: BotCategory.values.length,
+      vsync: this,
+      initialIndex: _selectedCategory.index,
+    );
+    _tabController.addListener(_handleTabChange);
+  }
+
+  @override
+  void dispose() {
+    _tabController.removeListener(_handleTabChange);
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  void _handleTabChange() {
+    if (!_tabController.indexIsChanging) {
+      setState(() {
+        _selectedCategory = BotCategory.values[_tabController.index];
+      });
+    }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_argumentsHandled) return;
+    final args = ModalRoute.of(context)?.settings.arguments;
+    if (args is BotListArguments) {
+      setState(() {
+        _selectedCategory = args.initialCategory;
+        _tabController.index = _selectedCategory.index;
+      });
+    }
+    _argumentsHandled = true;
+  }
+
+  String _labelForCategory(BotCategory category) {
+    switch (category) {
+      case BotCategory.downloaded:
+        return 'Scaricati';
+      case BotCategory.online:
+        return 'Online';
+      case BotCategory.local:
+        return 'Locali';
+    }
+  }
+
+  String _emptyMessageForCategory(BotCategory category) {
+    switch (category) {
+      case BotCategory.downloaded:
+        return 'Nessun bot scaricato trovato.';
+      case BotCategory.online:
+        return 'Nessun bot disponibile online al momento.';
+      case BotCategory.local:
+        return 'Nessun bot locale trovato.';
+    }
+  }
+
+  Widget _buildCategoryView(BotCategory category) {
+    return FutureBuilder<Map<String, List<Bot>>>(
+      future: _categoryFutures[category],
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        if (snapshot.hasError) {
+          return Center(
+            child: Text('Errore nel caricamento: ${snapshot.error}'),
+          );
+        }
+
+        final data = snapshot.data ?? {};
+        if (data.isEmpty) {
+          return Center(child: Text(_emptyMessageForCategory(category)));
+        }
+
+        return ListView(
+          padding: const EdgeInsets.all(16.0),
+          children: data.entries.map((entry) {
+            final language = entry.key;
+            final bots = entry.value;
+
+            return ExpansionTile(
+              title: Text(language),
+              children: bots
+                  .map(
+                    (bot) => BotCard(
+                      bot: bot,
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => BotDetailView(bot: bot),
+                          ),
+                        );
+                      },
+                    ),
+                  )
+                  .toList(),
+            );
+          }).toList(),
+        );
+      },
+    );
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('Lista dei Bot')),
-      body: FutureBuilder<Map<String, List<Bot>>>(
-        future: _remoteBots,
-        builder: (context, remoteSnapshot) {
-          return FutureBuilder<List<Bot>>(
-            future: _localBots,
-            builder: (context, localSnapshot) {
-              if (remoteSnapshot.connectionState == ConnectionState.waiting ||
-                  localSnapshot.connectionState == ConnectionState.waiting) {
-                return Center(child: CircularProgressIndicator());
-              }
-
-              if (remoteSnapshot.hasError) {
-                return Center(
-                    child: Text('Errore remoto: ${remoteSnapshot.error}'));
-              }
-
-              if (localSnapshot.hasError) {
-                return Center(
-                    child: Text('Errore locale: ${localSnapshot.error}'));
-              }
-
-              final remoteData = remoteSnapshot.data ?? {};
-              final localData = localSnapshot.data ?? [];
-
-              return ListView(
-                children: [
-                  ExpansionTile(
-                    title: Text('Local Bots'),
-                    children: localData.map((bot) {
-                      return BotCard(
-                        bot: bot,
-                        onTap: () {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (_) => BotDetailView(bot: bot),
-                            ),
-                          );
-                        },
-                      );
-                    }).toList(),
-                  ),
-                  ExpansionTile(
-                    title: Text('Remote Bots'),
-                    children: remoteData.entries.map((entry) {
-                      final language = entry.key;
-                      final bots = entry.value;
-
-                      return ExpansionTile(
-                        title: Text(language),
-                        children: bots.map((bot) {
-                          return BotCard(
-                            bot: bot,
-                            onTap: () {
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                  builder: (_) => BotDetailView(bot: bot),
-                                ),
-                              );
-                            },
-                          );
-                        }).toList(),
-                      );
-                    }).toList(),
-                  ),
-                ],
-              );
-            },
-          );
-        },
+      appBar: AppBar(
+        title: const Text('Gestione Bot'),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: BotCategory.values
+              .map((category) => Tab(text: _labelForCategory(category)))
+              .toList(),
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children:
+            BotCategory.values.map(_buildCategoryView).toList(growable: false),
       ),
     );
   }

--- a/lib/frontend/widgets/pages/home_page_view.dart
+++ b/lib/frontend/widgets/pages/home_page_view.dart
@@ -1,70 +1,121 @@
 import 'package:flutter/material.dart';
-import 'package:carousel_slider/carousel_slider.dart';
-import 'package:flutter/gestures.dart';
+import '../../models/bot_navigation.dart';
 
 class HomePage extends StatefulWidget {
   @override
   State<HomePage> createState() => _HomePageState();
 }
 
-class _HomePageState extends State<HomePage> {
-  final CarouselSliderController _carouselController =
-      CarouselSliderController();
-
-  final sections = [
-    _Section(
-      title: 'Portfolio',
-      description: 'Visualizza il tuo portafoglio di assets',
-      routeName: '/portfolio',
+class _HomePageState extends State<HomePage>
+    with SingleTickerProviderStateMixin {
+  final List<_Category> _categories = const [
+    _Category(
+      title: 'Scaricati',
+      description:
+          'Consulta i bot che hai già scaricato e salvato nel database locale.',
+      icon: Icons.download_done_outlined,
+      category: BotCategory.downloaded,
     ),
-    _Section(
-      title: 'Bot List',
-      description: 'Gestisci e configura i tuoi bot',
-      routeName: '/bots',
+    _Category(
+      title: 'Online',
+      description:
+          'Scopri i bot disponibili online tramite le API e scaricane di nuovi.',
+      icon: Icons.cloud_outlined,
+      category: BotCategory.online,
     ),
-    _Section(
-      title: 'Test1',
-      description: 'Gestisci e configura i tuoi bot',
-      routeName: '/test1',
-    ),
-    _Section(
-      title: 'Test2',
-      description: 'Gestisci e configura i tuoi bot',
-      routeName: '/test2',
-    ),
-    _Section(
-      title: 'Test3',
-      description: 'Gestisci e configura i tuoi bot',
-      routeName: '/test3',
+    _Category(
+      title: 'Locali',
+      description:
+          'Gestisci i bot presenti direttamente nel filesystem della macchina.',
+      icon: Icons.folder_outlined,
+      category: BotCategory.local,
     ),
   ];
 
-  int _currentIndex = 0;
+  late final TabController _tabController;
+  int _selectedIndex = 0;
 
-  void _onScroll(PointerSignalEvent event) {
-    if (event is PointerScrollEvent) {
-      if (event.scrollDelta.dy > 0) {
-        // Scroll down -> next slide
-        setState(() {
-          _currentIndex = (_currentIndex + 1).clamp(0, sections.length - 1);
-        });
-        _carouselController.animateToPage(
-          _currentIndex,
-          duration: Duration(milliseconds: 200),
-          curve: Curves.easeInOut,
-        );
-      } else if (event.scrollDelta.dy < 0) {
-        // Scroll up -> previous slide
-        setState(() {
-          _currentIndex = (_currentIndex - 1).clamp(0, sections.length - 1);
-        });
-        _carouselController.animateToPage(
-          _currentIndex,
-          duration: Duration(milliseconds: 200),
-          curve: Curves.easeInOut,
-        );
-      }
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: _categories.length, vsync: this);
+    _tabController.addListener(_handleTabSelection);
+  }
+
+  @override
+  void dispose() {
+    _tabController.removeListener(_handleTabSelection);
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  void _handleTabSelection() {
+    if (!_tabController.indexIsChanging) {
+      setState(() {
+        _selectedIndex = _tabController.index;
+      });
     }
+  }
+
+  void _onDestinationSelected(int index) {
+    if (_selectedIndex == index) return;
+    setState(() {
+      _selectedIndex = index;
+      if (_tabController.index != index) {
+        _tabController.index = index;
+      }
+    });
+  }
+
+  void _openBots(BotCategory category) {
+    Navigator.pushNamed(
+      context,
+      '/bots',
+      arguments: BotListArguments(initialCategory: category),
+    );
+  }
+
+  Widget _buildCategoryContent(_Category category) {
+    return Padding(
+      key: ValueKey(category.category),
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(category.icon, size: 32, color: Colors.blueAccent),
+              const SizedBox(width: 12),
+              Text(
+                category.title,
+                style: const TextStyle(
+                  fontSize: 28,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Text(
+            category.description,
+            style: const TextStyle(
+              fontSize: 16,
+              color: Colors.black54,
+            ),
+          ),
+          const Spacer(),
+          Align(
+            alignment: Alignment.bottomRight,
+            child: ElevatedButton.icon(
+              onPressed: () => _openBots(category.category),
+              icon: const Icon(Icons.arrow_forward),
+              label: const Text('Apri elenco'),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 
   @override
@@ -75,7 +126,7 @@ class _HomePageState extends State<HomePage> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
+            const Text(
               'HOME - Cosa vuoi fare?',
               style: TextStyle(
                 fontSize: 26,
@@ -83,31 +134,67 @@ class _HomePageState extends State<HomePage> {
                 color: Colors.black87,
               ),
             ),
-            SizedBox(height: 40),
+            const SizedBox(height: 24),
             Expanded(
-              child: Center(
-                child: SizedBox(
-                  width: 800,
-                  child: Listener(
-                    onPointerSignal: _onScroll,
-                    child: CarouselSlider.builder(
-                      carouselController: _carouselController,
-                      itemCount: sections.length,
-                      itemBuilder: (context, index, realIdx) {
-                        return SectionCard(section: sections[index]);
-                      },
-                      options: CarouselOptions(
-                        height: 300,
-                        enlargeCenterPage: true,
-                        enableInfiniteScroll: true,
-                        viewportFraction: 0.33,
-                        autoPlay: false,
-                        scrollDirection: Axis.horizontal,
-                        initialPage: _currentIndex,
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  if (constraints.maxWidth >= 800) {
+                    return Row(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        NavigationRail(
+                          selectedIndex: _selectedIndex,
+                          onDestinationSelected: _onDestinationSelected,
+                          labelType: NavigationRailLabelType.all,
+                          destinations: _categories
+                              .map(
+                                (category) => NavigationRailDestination(
+                                  icon: Icon(category.icon),
+                                  selectedIcon: Icon(
+                                    category.icon,
+                                    color: Colors.blueAccent,
+                                  ),
+                                  label: Text(category.title),
+                                ),
+                              )
+                              .toList(),
+                        ),
+                        const VerticalDivider(width: 1),
+                        Expanded(
+                          child: AnimatedSwitcher(
+                            duration: const Duration(milliseconds: 200),
+                            child: _buildCategoryContent(
+                              _categories[_selectedIndex],
+                            ),
+                          ),
+                        ),
+                      ],
+                    );
+                  }
+
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      TabBar(
+                        controller: _tabController,
+                        labelColor: Colors.blueAccent,
+                        unselectedLabelColor: Colors.grey,
+                        tabs: _categories
+                            .map((category) => Tab(text: category.title))
+                            .toList(),
                       ),
-                    ),
-                  ),
-                ),
+                      const SizedBox(height: 16),
+                      Expanded(
+                        child: TabBarView(
+                          controller: _tabController,
+                          children: _categories
+                              .map(_buildCategoryContent)
+                              .toList(),
+                        ),
+                      ),
+                    ],
+                  );
+                },
               ),
             ),
           ],
@@ -117,77 +204,16 @@ class _HomePageState extends State<HomePage> {
   }
 }
 
-class _Section {
+class _Category {
   final String title;
   final String description;
-  final String routeName;
+  final IconData icon;
+  final BotCategory category;
 
-  _Section({
+  const _Category({
     required this.title,
     required this.description,
-    required this.routeName,
+    required this.icon,
+    required this.category,
   });
-}
-
-class SectionCard extends StatefulWidget {
-  final _Section section;
-
-  const SectionCard({Key? key, required this.section}) : super(key: key);
-
-  @override
-  _SectionCardState createState() => _SectionCardState();
-}
-
-class _SectionCardState extends State<SectionCard> {
-  bool _hovering = false;
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () => Navigator.pushNamed(context, widget.section.routeName),
-      child: MouseRegion(
-        cursor: SystemMouseCursors.click,
-        onEnter: (_) => setState(() => _hovering = true),
-        onExit: (_) => setState(() => _hovering = false),
-        child: AnimatedContainer(
-          duration: Duration(milliseconds: 200),
-          curve: Curves.easeInOut,
-          width: 240,
-          padding: const EdgeInsets.all(20),
-          decoration: BoxDecoration(
-            color: _hovering ? Colors.blue.shade50 : Colors.white,
-            borderRadius: BorderRadius.circular(16),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black26,
-                blurRadius: _hovering ? 12 : 6,
-                spreadRadius: _hovering ? 3 : 1,
-                offset: Offset(0, _hovering ? 6 : 3),
-              ),
-            ],
-          ),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                widget.section.title,
-                style: TextStyle(
-                  fontSize: 22,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              SizedBox(height: 12),
-              Text(
-                widget.section.description,
-                style: TextStyle(
-                  fontSize: 16,
-                  color: Colors.grey[500],
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,6 @@ dependencies:
   http: ^1.2.2
   path_provider: ^2.1.3
   bitsdojo_window: ^0.1.6
-  carousel_slider: ^5.0.0
   url_launcher: ^6.3.1
 
 flutter:


### PR DESCRIPTION
## Summary
- replace the home carousel with a responsive NavigationRail/TabBar experience for downloaded, online and local bot categories
- split the bot list page into dedicated tab views fed by new downloaded/online/local data sources and support deep-link navigation
- expose backend endpoints for downloaded and filesystem bots while cleaning up the unused carousel dependency

## Testing
- not run (flutter command unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f2ac83d85c832b80b837822f65bb65