### PR TITLE
Implement bot cache timestamps and refresh flow

### DIFF
--- a/lib/backend/server/controllers/bot_controller.dart
+++ b/lib/backend/server/controllers/bot_controller.dart
@@ -14,11 +14,18 @@ class BotController {
   BotController(this.botDownloadService, this.botGetService);
 
   // Endpoint per ottenere la lista dei bot disponibili remoti
-  Future<Response> fetchAvailableBots(Request request) async {
+  Future<Response> fetchAvailableBots(Request request,
+      {bool forceRefreshOverride = false}) async {
     try {
       logger.info(LOGS.BOT_SERVICE, 'Fetching list of available bots...');
-      final List<Bot> availableBots = await botGetService
-          .fetchAvailableBots(); // Restituisce una lista di bot con tutti i dettagli
+      final queryRefresh = request.url.queryParameters['refresh'];
+      final bool queryWantsRefresh =
+          queryRefresh != null && queryRefresh.toLowerCase() == 'true';
+      final bool forceRefresh = forceRefreshOverride || queryWantsRefresh;
+
+      final List<Bot> availableBots = await botGetService.fetchAvailableBots(
+          forceRefresh:
+              forceRefresh); // Restituisce una lista di bot con tutti i dettagli
 
       // Logga i dettagli della risposta
       logger.info(LOGS.BOT_SERVICE, 'Fetched ${availableBots.length} bots.');
@@ -38,6 +45,10 @@ class BotController {
           }),
           headers: {'Content-Type': 'application/json'});
     }
+  }
+
+  Future<Response> refreshAvailableBots(Request request) {
+    return fetchAvailableBots(request, forceRefreshOverride: true);
   }
 
   // Endpoint per scaricare un bot specifico

--- a/lib/backend/server/routes.dart
+++ b/lib/backend/server/routes.dart
@@ -18,6 +18,9 @@ class BotRoutes {
     router.get('/bots',
         (Request request) => botController.fetchAvailableBots(request));
 
+    router.get('/bots/refresh',
+        (Request request) => botController.refreshAvailableBots(request));
+
     router.get('/localbots', botController.fetchLocalBots);
 
     return router;

--- a/lib/frontend/services/bot_get_service.dart
+++ b/lib/frontend/services/bot_get_service.dart
@@ -7,8 +7,9 @@ class BotGetService {
 
   BotGetService({this.baseUrl = 'http://localhost:8080'});
 
-  Future<Map<String, List<Bot>>> fetchBots() async {
-    final url = Uri.parse('$baseUrl/bots');
+  Future<Map<String, List<Bot>>> fetchBots({bool forceRefresh = false}) async {
+    final String path = forceRefresh ? '$baseUrl/bots?refresh=true' : '$baseUrl/bots';
+    final url = Uri.parse(path);
 
     try {
       final response = await http.get(url);


### PR DESCRIPTION
## Summary
- add fetch metadata storage to the bot database including last remote fetch timestamps
- serve cached bots when fresh and allow forcing refresh through query parameters or a dedicated endpoint
- expose refresh controls in the Flutter bot list view and trigger forced refreshes from the frontend service

## Testing
- not run (environment missing Dart/Flutter tooling)

------
https://chatgpt.com/codex/tasks/task_e_68f2ac84352c832b8db8ad0ad4d917d4