### PR TITLE
Add manifest validation and local bot import endpoint

### DIFF
--- a/lib/backend/server/controllers/bot_controller.dart
+++ b/lib/backend/server/controllers/bot_controller.dart
@@ -1,10 +1,12 @@
 import 'dart:convert';
+import 'dart:io';
 import 'package:shelf/shelf.dart';
 import 'package:scriptagher/shared/custom_logger.dart';
 import 'package:scriptagher/shared/constants/LOGS.dart';
 import '../services/bot_get_service.dart';
 import '../services/bot_download_service.dart';
 import '../models/bot.dart';
+import 'package:scriptagher/shared/exceptions/bot_manifest_validation_exception.dart';
 
 class BotController {
   final CustomLogger logger = CustomLogger();
@@ -56,6 +58,16 @@ class BotController {
       // Rispondi con i dettagli del bot come JSON
       return Response.ok(json.encode(bot.toMap()),
           headers: {'Content-Type': 'application/json'});
+    } on BotManifestValidationException catch (e) {
+      logger.error(LOGS.BOT_SERVICE, 'Manifest validation failed: ${e.message}');
+      return Response(
+        400,
+        body: json.encode({
+          'error': 'Invalid bot manifest',
+          'message': e.message,
+        }),
+        headers: {'Content-Type': 'application/json'},
+      );
     } catch (e) {
       logger.error(LOGS.BOT_SERVICE, 'Error downloading bot: $e');
       return Response.internalServerError(
@@ -83,6 +95,99 @@ class BotController {
       return Response.internalServerError(
         body: json.encode({
           'error': 'Error fetching local bots',
+          'message': e.toString(),
+        }),
+        headers: {'Content-Type': 'application/json'},
+      );
+    }
+  }
+
+  Future<Response> importLocalBot(Request request) async {
+    try {
+      final body = await request.readAsString();
+      final payload = json.decode(body);
+
+      if (payload is! Map<String, dynamic>) {
+        return Response(
+          400,
+          body: json.encode({
+            'error': 'Invalid request body',
+            'message': 'Expected a JSON object with import details',
+          }),
+          headers: {'Content-Type': 'application/json'},
+        );
+      }
+
+      final language = payload['language'];
+      final botDirectory = payload['botDirectory'] ?? payload['path'];
+
+      if (language is! String || language.trim().isEmpty) {
+        return Response(
+          400,
+          body: json.encode({
+            'error': 'Invalid language',
+            'message': 'The language field must be a non-empty string',
+          }),
+          headers: {'Content-Type': 'application/json'},
+        );
+      }
+
+      if (botDirectory is! String || botDirectory.trim().isEmpty) {
+        return Response(
+          400,
+          body: json.encode({
+            'error': 'Invalid bot directory',
+            'message': 'Provide the botDirectory path containing the manifest',
+          }),
+          headers: {'Content-Type': 'application/json'},
+        );
+      }
+
+      final bot = await botDownloadService.importLocalBot(
+        language.trim(),
+        botDirectory.trim(),
+      );
+
+      return Response.ok(
+        json.encode(bot.toMap()),
+        headers: {'Content-Type': 'application/json'},
+      );
+    } on BotManifestValidationException catch (e) {
+      logger.error(LOGS.BOT_SERVICE, 'Manifest validation failed: ${e.message}');
+      return Response(
+        400,
+        body: json.encode({
+          'error': 'Invalid bot manifest',
+          'message': e.message,
+        }),
+        headers: {'Content-Type': 'application/json'},
+      );
+    } on FormatException catch (e) {
+      logger.error(LOGS.BOT_SERVICE, 'Invalid JSON body: $e');
+      return Response(
+        400,
+        body: json.encode({
+          'error': 'Invalid request body',
+          'message': 'Unable to parse JSON payload',
+        }),
+        headers: {'Content-Type': 'application/json'},
+      );
+    } on FileSystemException catch (e) {
+      logger.error(LOGS.BOT_SERVICE, 'Filesystem error during import: $e');
+      return Response(
+        400,
+        body: json.encode({
+          'error': 'Local import error',
+          'message': e.message ?? 'Required files were not found',
+          'path': e.path,
+        }),
+        headers: {'Content-Type': 'application/json'},
+      );
+    } catch (e) {
+      logger.error(LOGS.BOT_SERVICE, 'Error importing local bot: $e');
+      return Response.internalServerError(
+        body: json.encode({
+          'error': 'Error importing local bot',
           'message': e.toString(),
         }),
         headers: {'Content-Type': 'application/json'},

--- a/lib/backend/server/routes.dart
+++ b/lib/backend/server/routes.dart
@@ -20,6 +20,8 @@ class BotRoutes {
 
     router.get('/localbots', botController.fetchLocalBots);
 
+    router.post('/localbots/import', botController.importLocalBot);
+
     return router;
   }
 }

--- a/lib/shared/exceptions/bot_manifest_validation_exception.dart
+++ b/lib/shared/exceptions/bot_manifest_validation_exception.dart
@@ -1,0 +1,37 @@
+class BotManifestValidationException implements Exception {
+  final List<String> missingFields;
+  final Map<String, String> invalidFields;
+
+  BotManifestValidationException({
+    List<String>? missingFields,
+    Map<String, String>? invalidFields,
+  })  : missingFields = List.unmodifiable(missingFields ?? const []),
+        invalidFields = Map.unmodifiable(invalidFields ?? const {});
+
+  String get message {
+    final buffer = StringBuffer('Bot manifest validation failed');
+
+    if (missingFields.isNotEmpty) {
+      buffer.write(
+          ": missing required field${missingFields.length > 1 ? 's' : ''} "
+          "${missingFields.join(', ')}");
+    }
+
+    if (invalidFields.isNotEmpty) {
+      if (missingFields.isNotEmpty) {
+        buffer.write('; ');
+      } else {
+        buffer.write(': ');
+      }
+      final descriptions = invalidFields.entries
+          .map((entry) => "${entry.key} (${entry.value})")
+          .join(', ');
+      buffer.write('invalid field values -> $descriptions');
+    }
+
+    return buffer.toString();
+  }
+
+  @override
+  String toString() => 'BotManifestValidationException: $message';
+}

--- a/lib/shared/utils/BotUtils.dart
+++ b/lib/shared/utils/BotUtils.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:scriptagher/shared/custom_logger.dart';
+import 'package:scriptagher/shared/exceptions/bot_manifest_validation_exception.dart';
 
 class BotUtils {
   static final logger = CustomLogger();
@@ -14,7 +15,15 @@ class BotUtils {
       }
 
       String content = await botJsonFile.readAsString();
-      return json.decode(content);
+      final decoded = json.decode(content);
+      if (decoded is! Map<String, dynamic>) {
+        throw BotManifestValidationException(
+          invalidFields: {
+            'manifest': 'expected a JSON object but received ${decoded.runtimeType}'
+          },
+        );
+      }
+      return validateBotManifest(Map<String, dynamic>.from(decoded));
     } catch (e) {
       logger.error('BotUtils', 'Error reading bot.json: $e');
       rethrow;
@@ -30,5 +39,87 @@ class BotUtils {
       return await botJson.exists();
     }
     return false;
+  }
+
+  static const List<String> _possibleNameKeys = ['botName', 'name'];
+
+  static Map<String, dynamic> validateBotManifest(Map<String, dynamic> manifest) {
+    final missingFields = <String>[];
+    final invalidFields = <String, String>{};
+
+    String? resolvedNameKey;
+    for (final key in _possibleNameKeys) {
+      if (manifest.containsKey(key)) {
+        resolvedNameKey = key;
+        break;
+      }
+    }
+
+    if (resolvedNameKey == null) {
+      missingFields.add('name');
+    }
+
+    String? nameValue;
+    if (resolvedNameKey != null) {
+      final value = manifest[resolvedNameKey];
+      if (value is String && value.trim().isNotEmpty) {
+        nameValue = value.trim();
+      } else {
+        invalidFields['name'] = 'must be a non-empty string';
+      }
+    }
+
+    final versionValue = manifest['version'];
+    if (versionValue == null) {
+      missingFields.add('version');
+    } else if (versionValue is! String || versionValue.trim().isEmpty) {
+      invalidFields['version'] = 'must be a non-empty string';
+    }
+
+    final permissionsValue = manifest['permissions'];
+    List<String>? permissions;
+    if (permissionsValue == null) {
+      missingFields.add('permissions');
+    } else if (permissionsValue is List) {
+      final invalidEntries = permissionsValue.where((element) {
+        if (element is! String) {
+          return true;
+        }
+        return element.trim().isEmpty;
+      });
+      if (invalidEntries.isNotEmpty) {
+        invalidFields['permissions'] =
+            'must contain only non-empty string values';
+      } else {
+        permissions = permissionsValue.map((e) => (e as String).trim()).toList();
+      }
+    } else {
+      invalidFields['permissions'] = 'must be a list of strings';
+    }
+
+    final hashValue = manifest['hash'];
+    if (hashValue == null) {
+      missingFields.add('hash');
+    } else if (hashValue is! String || hashValue.trim().isEmpty) {
+      invalidFields['hash'] = 'must be a non-empty string';
+    }
+
+    if (missingFields.isNotEmpty || invalidFields.isNotEmpty) {
+      throw BotManifestValidationException(
+        missingFields: missingFields,
+        invalidFields: invalidFields,
+      );
+    }
+
+    final validatedManifest = Map<String, dynamic>.from(manifest);
+    if (nameValue != null) {
+      validatedManifest['botName'] = nameValue;
+      validatedManifest['name'] = nameValue;
+    }
+    if (permissions != null) {
+      validatedManifest['permissions'] = permissions;
+    }
+
+    return validatedManifest;
   }
 }

--- a/test/bot_utils_test.dart
+++ b/test/bot_utils_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scriptagher/shared/exceptions/bot_manifest_validation_exception.dart';
+import 'package:scriptagher/shared/utils/BotUtils.dart';
+
+void main() {
+  group('BotUtils.validateBotManifest', () {
+    test('returns manifest when all required fields are valid', () {
+      final manifest = {
+        'botName': 'ExampleBot',
+        'version': '1.0.0',
+        'permissions': ['filesystem', 'network'],
+        'hash': 'abc123',
+        'description': 'Sample bot',
+      };
+
+      final validated = BotUtils.validateBotManifest(manifest);
+
+      expect(validated['botName'], 'ExampleBot');
+      expect(validated['version'], '1.0.0');
+      expect(validated['permissions'], ['filesystem', 'network']);
+      expect(validated['hash'], 'abc123');
+    });
+
+    test('throws when required fields are missing or invalid', () {
+      final manifest = {
+        'name': '',
+        'version': '',
+        'permissions': [1, ''],
+      };
+
+      expect(
+        () => BotUtils.validateBotManifest(manifest),
+        throwsA(isA<BotManifestValidationException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- enforce manifest schema validation with a dedicated exception
- surface manifest validation errors from download and new local import endpoints
- add tests covering valid and invalid bot manifest scenarios

## Testing
- flutter test *(fails: flutter command not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2ac85bbcc832b97da2b488c8e55f4