### PR TITLE
Add execution service and desktop bot start flow

### DIFF
--- a/lib/backend/server/routes.dart
+++ b/lib/backend/server/routes.dart
@@ -20,6 +20,8 @@ class BotRoutes {
 
     router.get('/localbots', botController.fetchLocalBots);
 
+    router.post('/bots/start', botController.startBot);
+
     return router;
   }
 }

--- a/lib/backend/server/server.dart
+++ b/lib/backend/server/server.dart
@@ -6,6 +6,7 @@ import 'package:scriptagher/shared/constants/LOGS.dart';
 import 'controllers/bot_controller.dart';
 import 'services/bot_get_service.dart';
 import 'services/bot_download_service.dart';
+import 'services/execution_service.dart';
 import 'db/bot_database.dart';
 import 'routes.dart';
 import 'package:scriptagher/backend/server/api_integration/github_api.dart';
@@ -19,7 +20,9 @@ Future<void> startServer() async {
   // Istanzia il BotService e BotController
   final botGetService = BotGetService(botDatabase, gitHubApi);
   final botDownloadService = BotDownloadService();
-  final botController = BotController(botDownloadService, botGetService);
+  final executionService = ExecutionService();
+  final botController =
+      BotController(botDownloadService, botGetService, executionService);
 
   // Ottieni il router con le rotte definite
   final botRoutes = BotRoutes(botController);
@@ -55,6 +58,9 @@ Middleware _logCustomRequests(CustomLogger logger) {
         // Logga il corpo della richiesta solo per POST o PUT
         final requestBody = await request.readAsString();
         logger.info(LOGS.REQUEST_LOG, 'Request Body: $requestBody');
+
+        final updatedRequest = request.change(body: requestBody);
+        return innerHandler(updatedRequest);
       }
 
       return innerHandler(request);

--- a/lib/backend/server/services/execution_service.dart
+++ b/lib/backend/server/services/execution_service.dart
@@ -1,0 +1,145 @@
+import 'dart:io';
+
+import 'package:scriptagher/backend/server/models/bot.dart';
+import 'package:scriptagher/shared/constants/LOGS.dart';
+import 'package:scriptagher/shared/custom_logger.dart';
+
+class ExecutionService {
+  ExecutionService();
+
+  final CustomLogger _logger = CustomLogger();
+
+  Future<int> startBot(Bot bot) async {
+    try {
+      _logger.info(
+        LOGS.EXECUTION_SERVICE,
+        'Starting bot ${bot.botName} with language ${bot.language}',
+      );
+
+      final process = await _startProcess(bot);
+
+      _logger.info(
+        LOGS.EXECUTION_SERVICE,
+        'Started process with pid ${process.pid} for bot ${bot.botName}',
+      );
+
+      return process.pid;
+    } on UnsupportedError catch (e) {
+      _logger.error(LOGS.EXECUTION_SERVICE, e.message ?? e.toString());
+      rethrow;
+    } catch (e) {
+      _logger.error(
+          LOGS.EXECUTION_SERVICE, 'Error starting bot ${bot.botName}: $e');
+      rethrow;
+    }
+  }
+
+  Future<Process> _startProcess(Bot bot) {
+    final language = bot.language.toLowerCase().trim();
+    final command = bot.startCommand.trim().isNotEmpty
+        ? bot.startCommand.trim()
+        : bot.sourcePath.trim();
+
+    if (command.isEmpty) {
+      throw UnsupportedError('Missing start command for bot ${bot.botName}');
+    }
+
+    switch (language) {
+      case 'node':
+      case 'javascript':
+        return _startNodeProcess(bot.botName, command);
+      case 'python':
+      case 'python3':
+        return _startPythonProcess(bot.botName, command);
+      case 'bash':
+      case 'shell':
+      case 'sh':
+        return Process.start('bash', ['-c', command]);
+      default:
+        throw UnsupportedError('Unsupported language: ${bot.language}');
+    }
+  }
+
+  Future<Process> _startNodeProcess(String botName, String command) {
+    final tokens = _splitCommand(command);
+    if (tokens.isEmpty) {
+      throw UnsupportedError('Missing start command for bot $botName');
+    }
+
+    final first = tokens.first.toLowerCase();
+    if (first == 'npm' || first == 'yarn' || first == 'pnpm') {
+      return Process.start('bash', ['-c', command]);
+    }
+
+    if (first == 'node') {
+      tokens.removeAt(0);
+    }
+
+    if (tokens.isEmpty) {
+      throw UnsupportedError('Missing Node script for bot $botName');
+    }
+
+    return Process.start('node', tokens);
+  }
+
+  Future<Process> _startPythonProcess(String botName, String command) {
+    final tokens = _splitCommand(command);
+    if (tokens.isEmpty) {
+      throw UnsupportedError('Missing start command for bot $botName');
+    }
+
+    final first = tokens.first.toLowerCase();
+    if (first == 'python' || first == 'python3' || first == 'python2') {
+      tokens.removeAt(0);
+    }
+
+    if (tokens.isEmpty) {
+      throw UnsupportedError('Missing Python script for bot $botName');
+    }
+
+    return Process.start('python3', tokens);
+  }
+
+  List<String> _splitCommand(String command) {
+    final result = <String>[];
+    final buffer = StringBuffer();
+    bool inSingleQuotes = false;
+    bool inDoubleQuotes = false;
+
+    for (int i = 0; i < command.length; i++) {
+      final char = command[i];
+
+      if (char == "'" && !inDoubleQuotes) {
+        inSingleQuotes = !inSingleQuotes;
+        continue;
+      }
+
+      if (char == '"' && !inSingleQuotes) {
+        inDoubleQuotes = !inDoubleQuotes;
+        continue;
+      }
+
+      if (char == '\\' && i + 1 < command.length) {
+        i++;
+        buffer.write(command[i]);
+        continue;
+      }
+
+      if (char.trim().isEmpty && !inSingleQuotes && !inDoubleQuotes) {
+        if (buffer.isNotEmpty) {
+          result.add(buffer.toString());
+          buffer.clear();
+        }
+        continue;
+      }
+
+      buffer.write(char);
+    }
+
+    if (buffer.isNotEmpty) {
+      result.add(buffer.toString());
+    }
+
+    return result;
+  }
+}

--- a/lib/frontend/services/bot_execution_service.dart
+++ b/lib/frontend/services/bot_execution_service.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../models/bot.dart';
+
+class BotExecutionService {
+  final String baseUrl;
+
+  BotExecutionService({this.baseUrl = 'http://localhost:8080'});
+
+  Future<int> startBot(Bot bot) async {
+    final url = Uri.parse('$baseUrl/bots/start');
+
+    final response = await http.post(
+      url,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(bot.toMap()),
+    );
+
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      final pid = data['processId'];
+      if (pid is int) {
+        return pid;
+      } else if (pid is num) {
+        return pid.toInt();
+      }
+      throw Exception('Invalid response format');
+    } else {
+      throw Exception('Failed to start bot: ${response.body}');
+    }
+  }
+}

--- a/lib/frontend/widgets/pages/bot_detail_view.dart
+++ b/lib/frontend/widgets/pages/bot_detail_view.dart
@@ -1,13 +1,56 @@
 import 'package:flutter/material.dart';
 import '../../models/bot.dart';
+import '../../services/bot_execution_service.dart';
 
-class BotDetailView extends StatelessWidget {
+class BotDetailView extends StatefulWidget {
   final Bot bot;
 
   BotDetailView({required this.bot});
 
   @override
+  State<BotDetailView> createState() => _BotDetailViewState();
+}
+
+class _BotDetailViewState extends State<BotDetailView> {
+  final BotExecutionService _executionService = BotExecutionService();
+  bool _isStarting = false;
+  String? _statusMessage;
+
+  Future<void> _startBot() async {
+    if (_isStarting) return;
+    setState(() {
+      _isStarting = true;
+      _statusMessage = null;
+    });
+
+    try {
+      final pid = await _executionService.startBot(widget.bot);
+      if (!mounted) return;
+      setState(() {
+        _statusMessage = 'Processo avviato con PID: $pid';
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Bot avviato (PID: $pid)')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _statusMessage = 'Errore durante l\'avvio: $e';
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Errore durante l\'avvio: $e')),
+      );
+    } finally {
+      if (!mounted) return;
+      setState(() {
+        _isStarting = false;
+      });
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final bot = widget.bot;
     return Scaffold(
       appBar: AppBar(
         title: Text(bot.botName),
@@ -19,23 +62,31 @@ class BotDetailView extends StatelessWidget {
           children: [
             Text(
               'Nome: ${bot.botName}',
-              style: Theme.of(context).textTheme.headlineMedium,  // Cambiato headline5 in headlineMedium
+              style: Theme.of(context).textTheme.headlineMedium,
             ),
             SizedBox(height: 10),
             Text(
               'Descrizione: ${bot.description}',
-              style: Theme.of(context).textTheme.bodyLarge,  // Cambiato bodyText1 in bodyLarge
+              style: Theme.of(context).textTheme.bodyLarge,
             ),
             SizedBox(height: 20),
             ElevatedButton(
-              onPressed: () {
-                // Azione quando si vuole eseguire l'operazione sul bot
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(content: Text('Esegui bot: ${bot.botName}')),
-                );
-              },
-              child: Text('Esegui Bot'),
+              onPressed: _isStarting ? null : _startBot,
+              child: _isStarting
+                  ? SizedBox(
+                      height: 16,
+                      width: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : Text('Esegui Bot'),
             ),
+            if (_statusMessage != null) ...[
+              SizedBox(height: 20),
+              Text(
+                _statusMessage!,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+            ]
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- introduce an execution service that runs bot processes with the appropriate runtime
- expose a /bots/start endpoint returning the spawned process id
- connect the desktop bot detail view to the new endpoint with status messaging

## Testing
- not run (environment missing Dart SDK)

------
https://chatgpt.com/codex/tasks/task_e_68f2ac86d83c832b9080214977e80902