### PR TITLE
Add process management endpoints and UI controls

### DIFF
--- a/lib/backend/server/routes.dart
+++ b/lib/backend/server/routes.dart
@@ -1,5 +1,6 @@
 import 'package:shelf/shelf.dart';
 import 'package:shelf_router/shelf_router.dart';
+
 import 'controllers/bot_controller.dart';
 
 class BotRoutes {
@@ -10,15 +11,22 @@ class BotRoutes {
   Router get router {
     final router = Router();
 
-    router.get(
-        '/bots/<language>/<botName>',
+    router.get('/bots/<language>/<botName>',
         (Request request, String language, String botName) =>
             botController.downloadBot(request, language, botName));
 
-    router.get('/bots',
-        (Request request) => botController.fetchAvailableBots(request));
+    router.get(
+        '/bots', (Request request) => botController.fetchAvailableBots(request));
 
     router.get('/localbots', botController.fetchLocalBots);
+
+    router.post('/bots/<language>/<botName>/stop',
+        (Request request, String language, String botName) =>
+            botController.stopBot(request, language, botName));
+
+    router.post('/bots/<language>/<botName>/kill',
+        (Request request, String language, String botName) =>
+            botController.killBot(request, language, botName));
 
     return router;
   }

--- a/lib/backend/server/server.dart
+++ b/lib/backend/server/server.dart
@@ -1,14 +1,17 @@
 import 'dart:async';
+
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as io;
-import 'package:scriptagher/shared/custom_logger.dart';
 import 'package:scriptagher/shared/constants/LOGS.dart';
+import 'package:scriptagher/shared/custom_logger.dart';
+
+import 'api_integration/github_api.dart';
 import 'controllers/bot_controller.dart';
-import 'services/bot_get_service.dart';
-import 'services/bot_download_service.dart';
 import 'db/bot_database.dart';
 import 'routes.dart';
-import 'package:scriptagher/backend/server/api_integration/github_api.dart';
+import 'services/bot_download_service.dart';
+import 'services/bot_get_service.dart';
+import 'services/execution_service.dart';
 
 Future<void> startServer() async {
   // Crea un'istanza del CustomLogger
@@ -19,7 +22,9 @@ Future<void> startServer() async {
   // Istanzia il BotService e BotController
   final botGetService = BotGetService(botDatabase, gitHubApi);
   final botDownloadService = BotDownloadService();
-  final botController = BotController(botDownloadService, botGetService);
+  final executionService = ExecutionService();
+  final botController =
+      BotController(botDownloadService, botGetService, executionService);
 
   // Ottieni il router con le rotte definite
   final botRoutes = BotRoutes(botController);

--- a/lib/backend/server/services/execution_service.dart
+++ b/lib/backend/server/services/execution_service.dart
@@ -1,0 +1,115 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:scriptagher/shared/constants/LOGS.dart';
+import 'package:scriptagher/shared/custom_logger.dart';
+
+class ExecutionService {
+  final CustomLogger _logger = CustomLogger();
+  final Map<String, Process> _runningProcesses = {};
+  final Map<String, int?> _processExitCodes = {};
+
+  String _processKey(String language, String botName) => '$language::$botName';
+
+  /// Registers a [process] for a given [language] and [botName].
+  ///
+  /// If another process with the same key is already running it will be
+  /// replaced. The exit code is tracked and the handle removed once the process
+  /// completes.
+  void registerProcess(
+    String language,
+    String botName,
+    Process process,
+  ) {
+    final key = _processKey(language, botName);
+
+    _logger.info(
+      LOGS.EXECUTION_SERVICE,
+      'Registered process handle for $key (pid: ${process.pid}).',
+    );
+    _runningProcesses[key] = process;
+    _processExitCodes.remove(key);
+
+    process.exitCode.then((code) {
+      _logger.info(
+        LOGS.EXECUTION_SERVICE,
+        'Process for $key completed with exit code $code.',
+      );
+      _processExitCodes[key] = code;
+      _runningProcesses.remove(key);
+    }).catchError((error) {
+      _logger.error(
+        LOGS.EXECUTION_SERVICE,
+        'Error while waiting for exit code of $key: $error',
+      );
+      _runningProcesses.remove(key);
+    });
+  }
+
+  /// Returns whether a process for the given [language] and [botName] is still
+  /// running.
+  bool isRunning(String language, String botName) =>
+      _runningProcesses.containsKey(_processKey(language, botName));
+
+  /// Sends a [ProcessSignal.sigterm] to the running process.
+  bool stopBot(String language, String botName) {
+    final process = _runningProcesses[_processKey(language, botName)];
+    if (process == null) {
+      return false;
+    }
+    _logger.info(
+      LOGS.EXECUTION_SERVICE,
+      'Sending SIGTERM to process ${process.pid} ($language/$botName).',
+    );
+    return process.kill(ProcessSignal.sigterm);
+  }
+
+  /// Sends a [ProcessSignal.sigkill] to the running process.
+  bool killBot(String language, String botName) {
+    final process = _runningProcesses[_processKey(language, botName)];
+    if (process == null) {
+      return false;
+    }
+    _logger.warn(
+      LOGS.EXECUTION_SERVICE,
+      'Sending SIGKILL to process ${process.pid} ($language/$botName).',
+    );
+    return process.kill(ProcessSignal.sigkill);
+  }
+
+  /// Returns the cached exit code for the given process, if available.
+  int? getExitCode(String language, String botName) =>
+      _processExitCodes[_processKey(language, botName)];
+
+  /// Waits for the process to finish and returns the exit code. A [timeout]
+  /// (default 5 seconds) can be provided to avoid waiting indefinitely.
+  Future<int?> waitForExitCode(
+    String language,
+    String botName, {
+    Duration timeout = const Duration(seconds: 5),
+  }) async {
+    final key = _processKey(language, botName);
+
+    if (_processExitCodes.containsKey(key)) {
+      return _processExitCodes[key];
+    }
+
+    final process = _runningProcesses[key];
+    if (process == null) {
+      return _processExitCodes[key];
+    }
+
+    try {
+      final exitCode = await process.exitCode.timeout(timeout);
+      _processExitCodes[key] = exitCode;
+      _runningProcesses.remove(key);
+      return exitCode;
+    } on TimeoutException {
+      _logger.warn(
+        LOGS.EXECUTION_SERVICE,
+        'Timeout while waiting exit code for $key.',
+      );
+      return null;
+    }
+  }
+}

--- a/lib/frontend/services/bot_execution_service.dart
+++ b/lib/frontend/services/bot_execution_service.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+class BotExecutionService {
+  final String baseUrl;
+
+  BotExecutionService({this.baseUrl = 'http://localhost:8080'});
+
+  Future<int?> stopBot(String language, String botName) async {
+    final response = await _sendCommand(language, botName, 'stop');
+    return response['exitCode'] as int?;
+  }
+
+  Future<int?> killBot(String language, String botName) async {
+    final response = await _sendCommand(language, botName, 'kill');
+    return response['exitCode'] as int?;
+  }
+
+  Future<Map<String, dynamic>> _sendCommand(
+      String language, String botName, String action) async {
+    final url = Uri.parse('$baseUrl/bots/$language/$botName/$action');
+    final response = await http.post(url);
+
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body) as Map<String, dynamic>;
+    } else if (response.statusCode == 404) {
+      throw Exception('Process not found for $language/$botName');
+    } else {
+      throw Exception(
+          'Failed to $action bot. Status code: ${response.statusCode}');
+    }
+  }
+}

--- a/lib/frontend/widgets/pages/bot_detail_view.dart
+++ b/lib/frontend/widgets/pages/bot_detail_view.dart
@@ -1,13 +1,51 @@
 import 'package:flutter/material.dart';
-import '../../models/bot.dart';
 
-class BotDetailView extends StatelessWidget {
+import '../../models/bot.dart';
+import '../../services/bot_execution_service.dart';
+
+class BotDetailView extends StatefulWidget {
   final Bot bot;
 
-  BotDetailView({required this.bot});
+  const BotDetailView({super.key, required this.bot});
+
+  @override
+  State<BotDetailView> createState() => _BotDetailViewState();
+}
+
+class _BotDetailViewState extends State<BotDetailView> {
+  final BotExecutionService _executionService = BotExecutionService();
+  int? _exitCode;
+  String? _errorMessage;
+  bool _isProcessing = false;
+
+  Future<void> _handleAction(Future<int?> Function() action) async {
+    setState(() {
+      _isProcessing = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final exitCode = await action();
+      setState(() {
+        _exitCode = exitCode;
+      });
+    } catch (e) {
+      setState(() {
+        _errorMessage = e.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isProcessing = false;
+        });
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
+    final bot = widget.bot;
+
     return Scaffold(
       appBar: AppBar(
         title: Text(bot.botName),
@@ -19,23 +57,62 @@ class BotDetailView extends StatelessWidget {
           children: [
             Text(
               'Nome: ${bot.botName}',
-              style: Theme.of(context).textTheme.headlineMedium,  // Cambiato headline5 in headlineMedium
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineMedium, // Cambiato headline5 in headlineMedium
             ),
-            SizedBox(height: 10),
+            const SizedBox(height: 10),
             Text(
               'Descrizione: ${bot.description}',
-              style: Theme.of(context).textTheme.bodyLarge,  // Cambiato bodyText1 in bodyLarge
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyLarge, // Cambiato bodyText1 in bodyLarge
             ),
-            SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: () {
-                // Azione quando si vuole eseguire l'operazione sul bot
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(content: Text('Esegui bot: ${bot.botName}')),
-                );
-              },
-              child: Text('Esegui Bot'),
+            const SizedBox(height: 20),
+            Text(
+              'Codice di uscita: ${_exitCode ?? 'non disponibile'}',
+              style: Theme.of(context).textTheme.bodyLarge,
             ),
+            if (_errorMessage != null) ...[
+              const SizedBox(height: 10),
+              Text(
+                _errorMessage!,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ],
+            const SizedBox(height: 20),
+            if (_isProcessing)
+              const Center(child: CircularProgressIndicator())
+            else
+              Row(
+                children: [
+                  ElevatedButton(
+                    onPressed: () {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                            content: Text('Esegui bot: ${bot.botName}')),
+                      );
+                    },
+                    child: const Text('Esegui Bot'),
+                  ),
+                  const SizedBox(width: 12),
+                  ElevatedButton(
+                    onPressed: () => _handleAction(() =>
+                        _executionService.stopBot(bot.language, bot.botName)),
+                    child: const Text('Stop'),
+                  ),
+                  const SizedBox(width: 12),
+                  ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor:
+                          Theme.of(context).colorScheme.errorContainer,
+                    ),
+                    onPressed: () => _handleAction(() =>
+                        _executionService.killBot(bot.language, bot.botName)),
+                    child: const Text('Kill'),
+                  ),
+                ],
+              ),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- add a backend execution service that tracks process handles, supports termination signals, and exposes exit codes
- expose new /stop and /kill bot endpoints through the router and controller using the execution service
- surface exit code and Stop/Kill controls in the bot detail view backed by a frontend execution service

## Testing
- Not run (Dart/Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f2ac87dfa4832b96afdf059e8cc30c