### PR TITLE
Add bot creation tutorial documentation and UI entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,186 +1,71 @@
-# Progetto Flutter
+# Scriptagher
 
-## Descrizione
-Questo progetto è una semplice applicazione mobile/desktop/web sviluppata con Flutter. Flutter è un framework open-source che permette di creare app per dispositivi mobili, desktop e web da una singola base di codice. Questo README include informazioni su come eseguire, configurare, testare e distribuire l'app su diverse piattaforme (Android, iOS, Linux, Windows e altre).
+Scriptagher è un'applicazione Flutter con backend integrato (Shelf) pensata per scoprire, scaricare ed eseguire bot di trading o automazione. Il progetto include una UI desktop/web, un server locale che comunica con GitHub per recuperare i pacchetti dei bot e un database SQLite per conservarne i metadati.
 
-## Struttura del Progetto
-La struttura di base di un'app Flutter è la seguente:
+## Contenuti
+- [Prerequisiti](#prerequisiti)
+- [Avvio rapido](#avvio-rapido)
+- [Struttura del progetto](#struttura-del-progetto)
+- [Flusso di gestione dei bot](#flusso-di-gestione-dei-bot)
+- [Guida "Crea il tuo bot"](#guida-crea-il-tuo-bot)
+- [Test](#test)
+- [Risorse aggiuntive](#risorse-aggiuntive)
 
-```sh
-/ScriptAgher
-├── android/ # Configurazione e codice per Android 
-├── ios/ # Configurazione e codice per iOS 
-├── lib/ # Codice Dart (logica dell'app) 
-│ ├── main.dart # Punto di ingresso dell'app 
-├── test/ # Test dell'app 
-├── web/ # Configurazione e codice per il Web 
-├── linux/ # Codice specifico per Linux 
-├── windows/ # Codice specifico per Windows 
-├── macos/ # Codice specifico per macOS 
-└── pubspec.yaml # File di configurazione di Flutter
-```
+## Prerequisiti
 
+- [Flutter SDK](https://docs.flutter.dev/get-started/install) 3.5 o superiore
+- Dart SDK (incluso con Flutter)
+- Strumenti di piattaforma specifici (Android Studio/Xcode se necessari)
 
-### Dipendenze
-1. **Flutter SDK**: Assicurati di avere l'ultima versione stabile di Flutter installata sul tuo sistema. Puoi scaricarla e configurarla dal sito ufficiale di Flutter: https://flutter.dev.
-   
-2. **Editor**: Puoi usare qualsiasi editor di testo, ma ti consigliamo di usare [VS Code](https://code.visualstudio.com/) o [Android Studio](https://developer.android.com/studio) per ottenere un supporto completo per Flutter.
+## Avvio rapido
 
-## Come Eseguire il Progetto
-
-### 1. **Installare le dipendenze**
-Dopo aver clonato il progetto, esegui il comando seguente per installare tutte le dipendenze necessarie:
-```sh
+```bash
 flutter pub get
-```
-
-### 2. **Eseguire l'app**
-Per avviare l'app su un emulatore o dispositivo fisico:
-
-- Su Android:
-```sh
 flutter run
 ```
 
-- Su iOS (richiede un ambiente macOS con Xcode):
-```sh
-flutter run
+Il backend Shelf viene avviato automaticamente da `lib/main.dart` all'avvio dell'app.
+
+## Struttura del progetto
+
+```
+lib/
+├── main.dart                      # bootstrap frontend + backend
+├── backend/                       # server Shelf, database e servizi bot
+├── frontend/                      # widget, pagine e servizi Flutter
+├── shared/                        # utilità condivise, logger, costanti
+assets/                            # risorse statiche
+start_project.sh                   # script di bootstrap opzionale
+docs/                              # documentazione tecnica
 ```
 
-- Su Windows/Linux/macOS:
-```sh
-flutter run -d <windows|linux|macos>
-```
+## Flusso di gestione dei bot
 
-### 3. **Eseguire i Test**
-Per eseguire i test automatizzati dell'app:
-```sh
+1. **Discovery** – `BotGetService` interroga il repository GitHub `gh-pages/bots/bots.json` per ottenere l'elenco dei bot.
+2. **Download** – Quando l'utente sceglie un bot, `BotDownloadService` scarica l'archivio `.zip`, lo estrae in `data/remote/<linguaggio>/<bot>` e registra i metadati in SQLite.
+3. **Catalogo locale** – L'endpoint `/localbots` unisce i bot salvati nel database e quelli trovati nella cartella `localbots/`.
+4. **Esecuzione** – La UI mostra `startCommand` e altri dettagli da `Bot.json`; il runner (in sviluppo) userà quel comando per avviare il processo del bot.
+
+## Guida "Crea il tuo bot"
+
+Per istruzioni dettagliate su:
+- Struttura consigliata di un pacchetto bot
+- Esempio completo di `Bot.json`
+- Flusso di download ed esecuzione end-to-end
+- Best practice di sicurezza per sviluppatori di bot
+
+consulta la documentazione dedicata in [`docs/creating-your-bot.md`](docs/creating-your-bot.md). La guida è richiamabile anche dalla UI (Home e pagine Bot).
+
+## Test
+
+Esegui la suite di test unitari Flutter:
+
+```bash
 flutter test
 ```
 
-## Configurazione
+## Risorse aggiuntive
 
-### 1. **Configurazione per Android**
-Assicurati che la tua macchina abbia l'ambiente di sviluppo Android configurato, con Android Studio e il relativo emulatore o un dispositivo fisico collegato.
-
-- Per costruire un APK per Android:
-```sh
-flutter build apk --release
-```
-
-- Per costruire un AAB (Android App Bundle):
-```sh
-flutter build appbundle --release
-```
-
-### 2. **Configurazione per iOS**
-Su macOS, per configurare l'ambiente iOS, è necessario Xcode.
-
-- Per costruire l'app per iOS:
-```sh
-flutter build ios --release
-```
-
-### 3. **Configurazione per Linux**
-Assicurati di avere le dipendenze necessarie per compilare applicazioni Flutter su Linux, come GTK3.
-
-- Per costruire l'app per Linux:
-```sh
-flutter build linux
-```
-
-### 4. **Configurazione per Windows**
-Flutter supporta lo sviluppo di app Windows su Windows 10 o versioni successive.
-
-- Per costruire l'app per Windows:
-```sh
-flutter build windows
-```
-
-### 5. **Configurazione per macOS**
-Per distribuire su macOS, assicurati di avere Xcode installato.
-
-- Per costruire l'app per macOS:
-```sh
-flutter build macos
-```
-
-## Distribuzione
-
-### 1. **Distribuire su Android**
-Per distribuire su Android, puoi generare un file APK o un Android App Bundle (AAB).
-
-#### Creare un APK:
-```sh
-flutter build apk --release
-```
-
-Distribuisci l'APK manualmente o caricalo su Google Play Store.
-
-#### Creare un AAB:
-```sh
-flutter build appbundle --release
-```
-
-Carica il file AAB su Google Play Store tramite la console di Google Play Developer.
-
-### 2. **Distribuire su iOS**
-Per distribuire su iOS, dovrai usare Xcode per creare un file `.ipa` e pubblicarlo su App Store o TestFlight.
-
-#### Creare un file IPA:
-1. Apri il progetto iOS in Xcode (`ios/Runner.xcworkspace`).
-2. Seleziona il dispositivo di destinazione.
-3. Vai su **Product > Archive** per creare il pacchetto.
-4. Carica l'IPA su App Store Connect per la distribuzione.
-
-### 3. **Distribuire su Linux**
-Per creare un pacchetto `.deb` o `.AppImage` su Linux:
-
-1. Costruisci il progetto:
-```sh
-flutter build linux
-```
-
-2. Crea un pacchetto `.deb`:
-```sh
-dpkg-deb --build build/linux/x64/release/bundle
-```
-
-3. Crea un pacchetto `.AppImage` utilizzando uno strumento come `AppImageKit`.
-
-Distribuisci il file `.deb` tramite un repository di pacchetti o il file `.AppImage` su un server.
-
-### 4. **Distribuire su Windows**
-Per distribuire l'app su Windows, puoi creare un file `.exe` e un installer personalizzato.
-
-1. Costruisci il progetto per Windows:
-```sh
-flutter build windows
-```
-
-2. Crea un installer personalizzato con **Inno Setup** o **NSIS**.
-- Scarica e configura Inno Setup: https://jrsoftware.org/isinfo.php.
-- Scrivi uno script `.iss` per includere l'eseguibile e altre dipendenze, quindi compila l'installer.
-
-### 5. **Distribuire su macOS**
-Per distribuire su macOS, puoi creare un pacchetto `.dmg` o `.pkg`.
-
-1. Costruisci il progetto per macOS:
-```sh
-flutter build macos
-```
-
-2. Usa strumenti come **create-dmg** per creare un file `.dmg`.
-
-### 6. **Distribuire su Web**
-Per distribuire l'app sul web, esegui il comando:
-```sh
-flutter build web
-```
-
-Carica i file generati nella cartella `build/web` su un server web per renderli accessibili tramite un browser.
-
-## Considerazioni Finali
-- Ogni piattaforma (Android, iOS, Linux, Windows, macOS) ha il suo proprio flusso di lavoro e requisiti di distribuzione.
-- Flutter rende possibile la creazione di un'app con un'unica base di codice per più piattaforme, ma la configurazione specifica di ciascuna piattaforma richiede attenzione ai dettagli.
-- Per la distribuzione su Android e iOS, la pubblicazione tramite Google Play Store e App Store è il metodo standard.
+- [Documentazione Flutter](https://docs.flutter.dev/)
+- [Pacchetto Shelf](https://pub.dev/packages/shelf)
+- [Repository dei bot (ramo gh-pages)](https://github.com/diegofcj/scriptagher/tree/gh-pages/bots)

--- a/docs/creating-your-bot.md
+++ b/docs/creating-your-bot.md
@@ -1,0 +1,100 @@
+# Guida allo sviluppo di un bot Scriptagher
+
+Questa guida descrive come è organizzato l'ecosistema dei bot di Scriptagher, come confezionare correttamente un pacchetto con `Bot.json` e quali buone pratiche seguire per mantenerlo sicuro.
+
+## Architettura in breve
+
+1. **Repository remoto dei bot** – L'app legge la lista di bot pubblici dal ramo `gh-pages` del repository GitHub (`bots/bots.json`). Ogni bot è organizzato per linguaggio (`bots/<linguaggio>/<nomeBot>/`).
+2. **Backend locale** – Il server Shelf (`lib/backend/server`) scarica i bot richiesti tramite `BotDownloadService`. Il pacchetto `.zip` viene salvato in `data/remote/<linguaggio>/<nomeBot>/`, estratto e registrato nel database locale (`BotDatabase`).
+3. **Frontend Flutter** – Le pagine `BotList` e `BotDetailView` mostrano le informazioni contenute in `Bot.json`. Il comando di avvio (`startCommand`) verrà usato dal runner per eseguire il bot.
+4. **Bot locali** – Ogni bot scaricato viene salvato anche nel filesystem (`localbots/<linguaggio>/<nomeBot>/`) e reso disponibile tramite l'endpoint `/localbots`.
+
+Lo schema riassuntivo del flusso di download ed esecuzione è il seguente:
+
+```text
+GitHub (bots.json & .zip)
+        │
+        ▼
+BotGetService ──► BotDownloadService ──► data/remote/<linguaggio>/<nomeBot>
+        │                                   │
+        │                                   ├─► Estrazione Bot.json + sorgenti
+        │                                   └─► Registrazione nel database locale
+        ▼
+Frontend Flutter (BotList/BotDetailView) ──► Avvio bot tramite startCommand
+```
+
+## Struttura consigliata del pacchetto bot
+
+Ogni bot deve essere distribuito come archivio `.zip` con la seguente struttura minima:
+
+```
+<NomeBot>.zip
+└── <NomeBot>/
+    ├── Bot.json
+    ├── README.md (opzionale)
+    ├── src/ (cartella o file con il codice del bot)
+    └── assets/ (opzionale per configurazioni o modelli)
+```
+
+### Esempio di `Bot.json`
+
+```json
+{
+  "botName": "TrendFollower",
+  "description": "Esegue ordini seguendo il trend delle medie mobili.",
+  "language": "python",
+  "version": "1.0.0",
+  "entryPoint": "src/main.py",
+  "startCommand": "python src/main.py --config config.yaml",
+  "dependencies": [
+    "pandas==2.2.2",
+    "numpy==2.0.1"
+  ],
+  "environment": {
+    "PYTHONUNBUFFERED": "1"
+  },
+  "permissions": {
+    "network": false,
+    "filesystem": "read"
+  },
+  "author": {
+    "name": "Team Scriptagher",
+    "contact": "devs@example.com"
+  }
+}
+```
+
+**Campi obbligatori**
+
+- `botName`: Nome mostrato nella UI.
+- `description`: Breve descrizione mostrata in `BotDetailView`.
+- `startCommand`: Comando che il runner dovrà eseguire (ad esempio `python src/main.py`).
+- `language`: Linguaggio del bot, deve corrispondere alla cartella che lo contiene.
+
+Gli altri campi sono opzionali ma fortemente raccomandati per fornire contesto, dipendenze e requisiti di esecuzione.
+
+## Flusso di download ed esecuzione
+
+1. L'utente seleziona un bot dalla UI (`BotList`).
+2. Il frontend chiama il backend (`/bots/{language}/{botName}`) che scarica lo zip da GitHub e lo estrae in `data/remote`.
+3. `BotDownloadService` legge `Bot.json`, crea/aggiorna la voce nel database (`BotDatabase`) e salva la copia locale.
+4. Il frontend mostra i dettagli del bot (`BotDetailView`). Quando l'utente sceglie **Esegui Bot**, il comando `startCommand` viene preparato per l'esecuzione dal runner (integrazione futura).
+5. Se il bot è già presente in locale, il backend lo restituisce direttamente senza riscaricarlo, permettendo l'esecuzione offline.
+
+## Best practice di sicurezza
+
+- **Firma e verifica**: pubblica gli archivi `.zip` firmati digitalmente o accompagnati da hash (SHA-256) e valida l'integrità prima dell'estrazione.
+- **Dipendenze controllate**: dichiara le dipendenze nel `Bot.json` e bloccale a versioni specifiche. Evita dipendenze non verificate.
+- **Principio del minimo privilegio**: esegui il bot in un ambiente isolato (container, virtualenv, sandbox) con accesso limitato a rete e filesystem. Utilizza il campo `permissions` per documentare le necessità.
+- **Gestione delle credenziali**: non inserire segreti all'interno del pacchetto. Affidati a variabili d'ambiente o secret manager locali.
+- **Logging e audit**: implementa log chiari delle azioni del bot (senza dati sensibili) per permettere audit successivi.
+- **Aggiornamenti**: incrementa `version` e `changelog` ad ogni modifica, in modo che il backend possa riconoscere release differenti.
+- **Revisione manuale**: prima di caricare un bot, effettua code review e analisi statica (es. linters, scanner di sicurezza).
+
+## Risorse utili
+
+- [Documentazione Flutter](https://docs.flutter.dev/)
+- [Pacchetto shelf](https://pub.dev/packages/shelf)
+- [Repository dei bot Scriptagher](https://github.com/diegofcj/scriptagher/tree/gh-pages/bots)
+
+Per ulteriori dettagli o contributi, consulta anche il file `README.md` principale del progetto.

--- a/lib/frontend/widgets/pages/bot_detail_view.dart
+++ b/lib/frontend/widgets/pages/bot_detail_view.dart
@@ -19,14 +19,31 @@ class BotDetailView extends StatelessWidget {
           children: [
             Text(
               'Nome: ${bot.botName}',
-              style: Theme.of(context).textTheme.headlineMedium,  // Cambiato headline5 in headlineMedium
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineMedium, // Cambiato headline5 in headlineMedium
             ),
             SizedBox(height: 10),
             Text(
               'Descrizione: ${bot.description}',
-              style: Theme.of(context).textTheme.bodyLarge,  // Cambiato bodyText1 in bodyLarge
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyLarge, // Cambiato bodyText1 in bodyLarge
             ),
             SizedBox(height: 20),
+            Text(
+              'Linguaggio: ${bot.language}',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            SizedBox(height: 12),
+            SelectableText(
+              'Start command: ${bot.startCommand}',
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(fontFamily: 'monospace'),
+            ),
+            SizedBox(height: 24),
             ElevatedButton(
               onPressed: () {
                 // Azione quando si vuole eseguire l'operazione sul bot
@@ -35,6 +52,12 @@ class BotDetailView extends StatelessWidget {
                 );
               },
               child: Text('Esegui Bot'),
+            ),
+            SizedBox(height: 16),
+            TextButton.icon(
+              onPressed: () => Navigator.pushNamed(context, '/create-bot'),
+              icon: const Icon(Icons.school_outlined),
+              label: const Text('Impara a creare un nuovo bot'),
             ),
           ],
         ),

--- a/lib/frontend/widgets/pages/bot_list_view.dart
+++ b/lib/frontend/widgets/pages/bot_list_view.dart
@@ -25,7 +25,19 @@ class _BotListState extends State<BotList> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('Lista dei Bot')),
+      appBar: AppBar(
+        title: Text('Lista dei Bot'),
+        actions: [
+          TextButton.icon(
+            onPressed: () => Navigator.pushNamed(context, '/create-bot'),
+            icon: const Icon(Icons.school_outlined),
+            label: const Text('Crea il tuo bot'),
+            style: TextButton.styleFrom(
+              foregroundColor: Colors.white,
+            ),
+          ),
+        ],
+      ),
       body: FutureBuilder<Map<String, List<Bot>>>(
         future: _remoteBots,
         builder: (context, remoteSnapshot) {

--- a/lib/frontend/widgets/pages/create_bot_tutorial_view.dart
+++ b/lib/frontend/widgets/pages/create_bot_tutorial_view.dart
@@ -1,0 +1,247 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class CreateBotTutorialPage extends StatelessWidget {
+  CreateBotTutorialPage({super.key});
+
+  final Uri _docsUrl = Uri.parse(
+    'https://github.com/diegofcj/scriptagher/blob/main/docs/creating-your-bot.md',
+  );
+
+  Future<void> _openDocs(BuildContext context) async {
+    if (!await launchUrl(_docsUrl, mode: LaunchMode.externalApplication)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Impossibile aprire la guida online.'),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Crea il tuo bot'),
+        actions: [
+          TextButton.icon(
+            onPressed: () => _openDocs(context),
+            icon: const Icon(Icons.open_in_new),
+            label: const Text('Apri guida completa'),
+            style: TextButton.styleFrom(
+              foregroundColor: Colors.white,
+            ),
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Metti in produzione il tuo bot con Scriptagher',
+              style: theme.textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Questa guida rapida riepiloga la struttura minima di un bot, '
+              'il ciclo di download/esecuzione e le migliori pratiche di sicurezza. '
+              'Trovi maggiori dettagli nella documentazione completa.',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 32),
+            _Section(
+              title: '1. Architettura in breve',
+              children: const [
+                _Bullet(
+                  'Repository remoto GitHub: il file bots.json elenca i bot suddivisi per linguaggio.',
+                ),
+                _Bullet(
+                  'Backend locale (Shelf): scarica e registra i bot tramite BotDownloadService e BotDatabase.',
+                ),
+                _Bullet(
+                  'Frontend Flutter: mostra le informazioni del bot e prepara il comando di avvio (startCommand).',
+                ),
+                _Bullet(
+                  'Cartella localbots/: conserva le copie scaricate per l\'utilizzo offline.',
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            _Section(
+              title: '2. Struttura del pacchetto .zip',
+              children: [
+                Text(
+                  'Comprimi la cartella del bot mantenendo questa struttura:',
+                  style: theme.textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 12),
+                const _CodeBlock(
+                  '''<NomeBot>.zip
+└── <NomeBot>/
+    ├── Bot.json
+    ├── README.md (opzionale)
+    ├── src/ (codice sorgente)
+    └── assets/ (configurazioni o modelli opzionali)''',
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  'Il nome della cartella principale deve corrispondere al nome del bot e '
+                  'alla cartella indicata in bots.json sul repository remoto.',
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            _Section(
+              title: '3. Esempio di Bot.json',
+              children: const [
+                _CodeBlock(
+                  '''{
+  "botName": "TrendFollower",
+  "description": "Esegue ordini seguendo il trend delle medie mobili.",
+  "language": "python",
+  "version": "1.0.0",
+  "entryPoint": "src/main.py",
+  "startCommand": "python src/main.py --config config.yaml",
+  "dependencies": [
+    "pandas==2.2.2",
+    "numpy==2.0.1"
+  ],
+  "environment": {
+    "PYTHONUNBUFFERED": "1"
+  },
+  "permissions": {
+    "network": false,
+    "filesystem": "read"
+  },
+  "author": {
+    "name": "Team Scriptagher",
+    "contact": "devs@example.com"
+  }
+}''',
+                ),
+                SizedBox(height: 12),
+                _Bullet('Campi obbligatori: botName, description, language, startCommand.'),
+                _Bullet(
+                  'Documenta il comando di avvio esatto che il runner dovrà eseguire (ad es. python src/main.py).',
+                ),
+                _Bullet(
+                  'Usa i campi opzionali per chiarire dipendenze, permessi richiesti e informazioni sull\'autore.',
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            _Section(
+              title: '4. Flusso di download ed esecuzione',
+              children: const [
+                _Bullet('La UI chiama l\'endpoint /bots per elencare le opzioni disponibili.'),
+                _Bullet('BotDownloadService scarica lo zip, lo estrae in data/remote/<linguaggio>/<nomeBot> e registra il bot in SQLite.'),
+                _Bullet('Le copie vengono replicate in localbots/ per essere mostrate in BotList e disponibili offline.'),
+                _Bullet('Quando premi "Esegui Bot", lo startCommand viene passato al runner locale (integrazione in sviluppo).'),
+              ],
+            ),
+            const SizedBox(height: 24),
+            _Section(
+              title: '5. Sicurezza e best practice',
+              children: const [
+                _Bullet('Firma o pubblica hash degli archivi .zip e verifica l\'integrità prima dell\'estrazione.'),
+                _Bullet('Blocca le dipendenze a versioni specifiche e preferisci repository affidabili.'),
+                _Bullet('Esegui i bot in ambienti isolati con privilegi minimi e documenta le necessità nei campi permissions.'),
+                _Bullet('Non inserire credenziali nel pacchetto: usa variabili d\'ambiente o secret manager locali.'),
+                _Bullet('Aggiungi logging e audit trail non sensibili per monitorare l\'attività del bot.'),
+                _Bullet('Aggiorna version e changelog a ogni release per distinguere facilmente le build.'),
+                _Bullet('Sottoponi il codice a review e scanner di sicurezza prima di pubblicarlo.'),
+              ],
+            ),
+            const SizedBox(height: 32),
+            OutlinedButton.icon(
+              onPressed: () => _openDocs(context),
+              icon: const Icon(Icons.menu_book_outlined),
+              label: const Text('Leggi la documentazione completa'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Section extends StatelessWidget {
+  const _Section({required this.title, required this.children});
+
+  final String title;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 12),
+        ...children,
+      ],
+    );
+  }
+}
+
+class _Bullet extends StatelessWidget {
+  const _Bullet(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('• '),
+          Expanded(
+            child: Text(
+              text,
+              style: theme.textTheme.bodyMedium,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CodeBlock extends StatelessWidget {
+  const _CodeBlock(this.code);
+
+  final String code;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceVariant.withOpacity(0.4),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: theme.dividerColor.withOpacity(0.4)),
+      ),
+      child: SelectableText(
+        code,
+        style: const TextStyle(fontFamily: 'monospace'),
+      ),
+    );
+  }
+}

--- a/lib/frontend/widgets/pages/home_page_view.dart
+++ b/lib/frontend/widgets/pages/home_page_view.dart
@@ -13,6 +13,12 @@ class _HomePageState extends State<HomePage> {
 
   final sections = [
     _Section(
+      title: 'Crea il tuo bot',
+      description:
+          'Tutorial passo passo su struttura, Bot.json e best practice.',
+      routeName: '/create-bot',
+    ),
+    _Section(
       title: 'Portfolio',
       description: 'Visualizza il tuo portafoglio di assets',
       routeName: '/portfolio',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:scriptagher/frontend/widgets/pages/bot_list_view.dart';
 import 'package:scriptagher/frontend/widgets/pages/test1.dart';
 import 'package:scriptagher/frontend/widgets/pages/test2.dart';
 import 'package:scriptagher/frontend/widgets/pages/test3.dart';
+import 'package:scriptagher/frontend/widgets/pages/create_bot_tutorial_view.dart';
 
 
 // La tua vista principale di Flutter
@@ -78,12 +79,13 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
 
       routes: {
-        '/home':     (_) => HomePage(),       // la tua HomePage con il carosello
-        '/portfolio':(_) => Portfolio(),  // la pagina Portfolio
-        '/bots':     (_) => BotList(),   // la pagina Bots List
-        '/test1':     (_) => test1(),   // la pagina Bots List
-        '/test2':     (_) => test2(),   // la pagina test1 List
-        '/test3':     (_) => test3(),   // la pagina test1 List
+        '/home': (_) => HomePage(), // la tua HomePage con il carosello
+        '/portfolio': (_) => Portfolio(), // la pagina Portfolio
+        '/bots': (_) => BotList(), // la pagina Bots List
+        '/create-bot': (_) => CreateBotTutorialPage(),
+        '/test1': (_) => test1(), // la pagina Bots List
+        '/test2': (_) => test2(), // la pagina test1 List
+        '/test3': (_) => test3(), // la pagina test1 List
       },
 
       debugShowCheckedModeBanner: false,


### PR DESCRIPTION
## Summary
- add a dedicated docs/creating-your-bot.md guide with bot structure, Bot.json example, and security best practices
- refresh the top-level README with bot management flow details and link the in-app tutorial
- introduce an in-app "Crea il tuo bot" tutorial page and link it from the home, list, and detail bot views

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f2ac8c3cac832b9fd65e19b65eaea2