### PR TITLE
Implement SSE streaming for bot execution output

### DIFF
--- a/lib/backend/server/db/bot_database.dart
+++ b/lib/backend/server/db/bot_database.dart
@@ -268,4 +268,32 @@ class BotDatabase {
     final db = await database;
     await db.delete('local_bots');
   }
+
+  Future<Bot?> findBotByName(String language, String botName) async {
+    final db = await database;
+
+    final result = await db.query(
+      'bots',
+      where: 'bot_name = ? AND language = ?',
+      whereArgs: [botName, language],
+      limit: 1,
+    );
+
+    if (result.isNotEmpty) {
+      return Bot.fromMap(result.first);
+    }
+
+    final localResult = await db.query(
+      'local_bots',
+      where: 'bot_name = ? AND language = ?',
+      whereArgs: [botName, language],
+      limit: 1,
+    );
+
+    if (localResult.isNotEmpty) {
+      return Bot.fromMap(localResult.first);
+    }
+
+    return null;
+  }
 }

--- a/lib/backend/server/services/execution_service.dart
+++ b/lib/backend/server/services/execution_service.dart
@@ -1,0 +1,166 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:shelf/shelf.dart';
+import 'package:scriptagher/shared/constants/LOGS.dart';
+import 'package:scriptagher/shared/custom_logger.dart';
+
+import '../db/bot_database.dart';
+import '../models/bot.dart';
+
+class ExecutionService {
+  ExecutionService(this._botDatabase);
+
+  final BotDatabase _botDatabase;
+  final CustomLogger _logger = CustomLogger();
+
+  Future<Response> streamExecution(
+      Request request, String language, String botName) async {
+    final Bot? bot = await _botDatabase.findBotByName(language, botName);
+
+    if (bot == null || bot.startCommand.trim().isEmpty) {
+      final errorMessage =
+          'Bot $language/$botName not found or missing start command.';
+      _logger.error(LOGS.EXECUTION_SERVICE, errorMessage);
+      return Response.notFound(jsonEncode({'error': errorMessage}));
+    }
+
+    final controller = StreamController<List<int>>();
+    final logSink = await _prepareLogSink(bot);
+    Process? process;
+    var closed = false;
+    StreamSubscription<String>? stdoutSub;
+    StreamSubscription<String>? stderrSub;
+
+    void addEvent(Map<String, dynamic> event) {
+      final payload = 'data: ${jsonEncode(event)}\n\n';
+      controller.add(utf8.encode(payload));
+    }
+
+    Future<void> closeResources() async {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      await stdoutSub?.cancel();
+      await stderrSub?.cancel();
+      try {
+        await logSink.flush();
+      } finally {
+        await logSink.close();
+      }
+      await controller.close();
+    }
+
+    Future(() async {
+      try {
+        addEvent({
+          'type': 'status',
+          'message': 'starting',
+        });
+
+        process = await Process.start(
+          '/bin/sh',
+          ['-c', bot.startCommand],
+          workingDirectory: _resolveWorkingDirectory(bot),
+          runInShell: false,
+        );
+
+        _logger.info(LOGS.EXECUTION_SERVICE,
+            'Started execution for ${bot.language}/${bot.botName}.');
+
+        stdoutSub = process!.stdout
+            .transform(utf8.decoder)
+            .transform(const LineSplitter())
+            .listen((line) {
+          _handleLine(logSink, line,
+              isError: false, emitter: (event) => addEvent(event));
+        });
+
+        stderrSub = process!.stderr
+            .transform(utf8.decoder)
+            .transform(const LineSplitter())
+            .listen((line) {
+          _handleLine(logSink, line,
+              isError: true, emitter: (event) => addEvent(event));
+        });
+
+        final exitCode = await process!.exitCode;
+
+        addEvent({
+          'type': 'status',
+          'message': 'finished',
+          'code': exitCode,
+        });
+
+        logSink.writeln('[status] exit code: $exitCode');
+        await closeResources();
+      } catch (e, stack) {
+        _logger.error(LOGS.EXECUTION_SERVICE,
+            'Execution failed for ${bot.language}/${bot.botName}: $e');
+        logSink.writeln('[error] $e');
+        logSink.writeln(stack.toString());
+        addEvent({
+          'type': 'error',
+          'message': e.toString(),
+        });
+        await closeResources();
+      }
+    });
+
+    controller.onCancel = () async {
+      _logger.info(LOGS.EXECUTION_SERVICE,
+          'Stream cancelled for ${bot.language}/${bot.botName}.');
+      process?.kill();
+      await closeResources();
+    };
+
+    return Response.ok(
+      controller.stream,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+        'Access-Control-Allow-Origin': '*',
+      },
+    );
+  }
+
+  Future<IOSink> _prepareLogSink(Bot bot) async {
+    final timestamp = DateTime.now().toIso8601String().replaceAll(':', '-');
+    final directory =
+        Directory('logs/executions/${bot.language}/${bot.botName}');
+    await directory.create(recursive: true);
+    final file = File('${directory.path}/run_$timestamp.log');
+    return file.openWrite(mode: FileMode.append);
+  }
+
+  void _handleLine(IOSink logSink, String line,
+      {required bool isError,
+      required void Function(Map<String, dynamic> event) emitter}) {
+    final entryType = isError ? 'stderr' : 'stdout';
+    logSink.writeln('[$entryType] $line');
+    emitter({
+      'type': entryType,
+      'message': line,
+    });
+  }
+
+  String? _resolveWorkingDirectory(Bot bot) {
+    try {
+      final sourceFile = File(bot.sourcePath);
+      if (sourceFile.existsSync()) {
+        return sourceFile.parent.path;
+      }
+
+      final sourceDir = Directory(bot.sourcePath);
+      if (sourceDir.existsSync()) {
+        return sourceDir.path;
+      }
+    } catch (_) {
+      // Ignored: fallback to default working directory.
+    }
+    return null;
+  }
+}

--- a/lib/frontend/widgets/pages/bot_detail_view.dart
+++ b/lib/frontend/widgets/pages/bot_detail_view.dart
@@ -1,16 +1,185 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
 import '../../models/bot.dart';
 
-class BotDetailView extends StatelessWidget {
-  final Bot bot;
+class BotDetailView extends StatefulWidget {
+  const BotDetailView({super.key, required this.bot, this.baseUrl = 'http://localhost:8080'});
 
-  BotDetailView({required this.bot});
+  final Bot bot;
+  final String baseUrl;
+
+  @override
+  State<BotDetailView> createState() => _BotDetailViewState();
+}
+
+class _BotDetailViewState extends State<BotDetailView> {
+  final ScrollController _scrollController = ScrollController();
+  final List<_ConsoleEntry> _entries = [];
+
+  http.Client? _client;
+  StreamSubscription<String>? _subscription;
+  bool _autoScroll = true;
+  bool _isRunning = false;
+  String _buffer = '';
+  String? _error;
+
+  @override
+  void dispose() {
+    _stopExecution();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _startExecution() async {
+    _stopExecution();
+    setState(() {
+      _entries.clear();
+      _error = null;
+      _isRunning = true;
+    });
+
+    final client = http.Client();
+    _client = client;
+
+    final uri = Uri.parse(
+        '${widget.baseUrl}/bots/${Uri.encodeComponent(widget.bot.language)}/${Uri.encodeComponent(widget.bot.botName)}/stream');
+
+    try {
+      final request = http.Request('GET', uri)
+        ..headers['Accept'] = 'text/event-stream';
+      final response = await client.send(request);
+
+      if (response.statusCode != 200) {
+        setState(() {
+          _error =
+              'Impossibile avviare il bot. Codice risposta: ${response.statusCode}';
+          _isRunning = false;
+        });
+        _stopExecution();
+        return;
+      }
+
+      _subscription = response.stream
+          .transform(utf8.decoder)
+          .listen(_processChunk, onError: (Object error, StackTrace _) {
+        if (!mounted) return;
+        setState(() {
+          _error = 'Errore di connessione: $error';
+          _isRunning = false;
+        });
+        _stopExecution();
+      }, onDone: () {
+        if (!mounted) return;
+        setState(() {
+          _isRunning = false;
+        });
+        _stopExecution();
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = 'Errore durante l\'avvio: $e';
+        _isRunning = false;
+      });
+      _stopExecution();
+    }
+  }
+
+  void _stopExecution({bool closeClient = true}) {
+    _subscription?.cancel();
+    _subscription = null;
+    if (closeClient) {
+      _client?.close();
+      _client = null;
+    }
+  }
+
+  void _processChunk(String chunk) {
+    _buffer += chunk;
+
+    while (true) {
+      final separatorIndex = _buffer.indexOf('\n\n');
+      if (separatorIndex == -1) {
+        break;
+      }
+
+      final rawEvent = _buffer.substring(0, separatorIndex);
+      _buffer = _buffer.substring(separatorIndex + 2);
+
+      final lines = rawEvent.split('\n');
+      for (final line in lines) {
+        if (line.startsWith('data:')) {
+          final payload = line.substring(5).trim();
+          if (payload.isEmpty) continue;
+          _handleEvent(payload);
+        }
+      }
+    }
+  }
+
+  void _handleEvent(String payload) {
+    try {
+      final decoded = jsonDecode(payload) as Map<String, dynamic>;
+      final type = decoded['type']?.toString() ?? 'stdout';
+      final message = decoded['message']?.toString() ?? '';
+      final code = decoded['code'];
+
+      if (type == 'status') {
+        final display =
+            code != null ? '$message (code: $code)' : message;
+        _appendEntry(_ConsoleEntry(
+          message: display,
+          type: type,
+        ));
+        if (message == 'finished') {
+          setState(() {
+            _isRunning = false;
+          });
+        }
+        return;
+      }
+
+      _appendEntry(_ConsoleEntry(message: message, type: type));
+    } catch (e) {
+      _appendEntry(
+          _ConsoleEntry(message: 'Evento non valido: $payload', type: 'stderr'));
+    }
+  }
+
+  void _appendEntry(_ConsoleEntry entry) {
+    if (!mounted) return;
+    setState(() {
+      _entries.add(entry);
+    });
+
+    if (_autoScroll) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!_scrollController.hasClients) return;
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 150),
+          curve: Curves.easeOut,
+        );
+      });
+    }
+  }
+
+  void _clearLog() {
+    setState(() {
+      _entries.clear();
+      _error = null;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(bot.botName),
+        title: Text(widget.bot.botName),
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
@@ -18,27 +187,103 @@ class BotDetailView extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              'Nome: ${bot.botName}',
-              style: Theme.of(context).textTheme.headlineMedium,  // Cambiato headline5 in headlineMedium
+              'Nome: ${widget.bot.botName}',
+              style: Theme.of(context).textTheme.headlineMedium,
             ),
-            SizedBox(height: 10),
+            const SizedBox(height: 10),
             Text(
-              'Descrizione: ${bot.description}',
-              style: Theme.of(context).textTheme.bodyLarge,  // Cambiato bodyText1 in bodyLarge
+              'Descrizione: ${widget.bot.description}',
+              style: Theme.of(context).textTheme.bodyLarge,
             ),
-            SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: () {
-                // Azione quando si vuole eseguire l'operazione sul bot
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(content: Text('Esegui bot: ${bot.botName}')),
-                );
-              },
-              child: Text('Esegui Bot'),
+            const SizedBox(height: 20),
+            Row(
+              children: [
+                ElevatedButton(
+                  onPressed: _isRunning ? null : _startExecution,
+                  child: Text(_isRunning ? 'Esecuzione in corso...' : 'Esegui Bot'),
+                ),
+                const SizedBox(width: 16),
+                OutlinedButton(
+                  onPressed: _entries.isEmpty && _error == null ? null : _clearLog,
+                  child: const Text('Pulisci log'),
+                ),
+                const Spacer(),
+                Row(
+                  children: [
+                    const Text('Auto-scroll'),
+                    Switch(
+                      value: _autoScroll,
+                      onChanged: (value) {
+                        setState(() {
+                          _autoScroll = value;
+                        });
+                      },
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            if (_error != null) ...[
+              const SizedBox(height: 12),
+              Text(
+                _error!,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ],
+            const SizedBox(height: 20),
+            Expanded(
+              child: Container(
+                decoration: BoxDecoration(
+                  color: Colors.black,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: Colors.grey.shade700),
+                ),
+                padding: const EdgeInsets.all(12),
+                child: _entries.isEmpty
+                    ? const Center(
+                        child: Text(
+                          'Nessun output disponibile. Avvia il bot per vedere i log.',
+                          style: TextStyle(color: Colors.white70),
+                          textAlign: TextAlign.center,
+                        ),
+                      )
+                    : ListView.builder(
+                        controller: _scrollController,
+                        itemCount: _entries.length,
+                        itemBuilder: (context, index) {
+                          final entry = _entries[index];
+                          return Text(
+                            entry.message,
+                            style: TextStyle(
+                              color: entry.color,
+                              fontFamily: 'monospace',
+                            ),
+                          );
+                        },
+                      ),
+              ),
             ),
           ],
         ),
       ),
     );
+  }
+}
+
+class _ConsoleEntry {
+  _ConsoleEntry({required this.message, required this.type});
+
+  final String message;
+  final String type;
+
+  Color get color {
+    switch (type) {
+      case 'stderr':
+        return Colors.redAccent;
+      case 'status':
+        return Colors.blueAccent;
+      default:
+        return Colors.greenAccent;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add an execution service that runs bots, streams stdout/stderr through SSE, and persists run logs
- expose the new execution stream endpoint on the backend server with database lookup support
- upgrade the bot detail view with a live console widget that consumes the execution stream

## Testing
- not run (Flutter/Dart tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f2ac87465c832b9556d90d8cd8948a