### PR TITLE
Add execution log handling and viewer

### DIFF
--- a/lib/backend/server/services/execution_service.dart
+++ b/lib/backend/server/services/execution_service.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:intl/intl.dart';
+
+import 'package:scriptagher/shared/constants/LOGS.dart';
+import 'package:scriptagher/shared/custom_logger.dart';
+import 'package:scriptagher/shared/logging/log_metadata.dart';
+
+import '../models/bot.dart';
+
+class ExecutionResult {
+  ExecutionResult({
+    required this.exitCode,
+    required this.logFile,
+    required this.metadata,
+  });
+
+  final int exitCode;
+  final File logFile;
+  final LogMetadata metadata;
+}
+
+class ExecutionService {
+  ExecutionService({CustomLogger? logger}) : _logger = logger ?? CustomLogger();
+
+  final CustomLogger _logger;
+
+  /// Executes the provided [bot] by running its start command inside the bot
+  /// directory.
+  ///
+  /// Every execution generates an isolated log file that captures stdout and
+  /// stderr while also forwarding the messages to the application logger.
+  Future<ExecutionResult> runBot(Bot bot) async {
+    final identifier = bot.id?.toString() ?? bot.botName;
+    final metadata = LogMetadata(botId: identifier, startTime: DateTime.now());
+    final logFile = await _logger.createRunLogFile(metadata);
+    final logSink = logFile.openWrite(mode: FileMode.append);
+
+    Future<void> writeLine(String prefix, String line) async {
+      final timestamp = DateFormat('yyyy-MM-dd HH:mm:ss').format(DateTime.now());
+      logSink.writeln('[$timestamp][$prefix] $line');
+      await logSink.flush();
+    }
+
+    final botConfig = File(bot.sourcePath);
+    final workingDirectory = botConfig.parent;
+
+    if (!await workingDirectory.exists()) {
+      final errorMessage =
+          'Working directory not found: ${workingDirectory.path}';
+      _logger.error(LOGS.EXECUTION_SERVICE, errorMessage, metadata: metadata);
+      await writeLine('ERROR', errorMessage);
+      await logSink.close();
+      throw FileSystemException(errorMessage, workingDirectory.path);
+    }
+
+    _logger.info(LOGS.EXECUTION_SERVICE,
+        'Starting execution of ${bot.botName} using "${bot.startCommand}"',
+        metadata: metadata);
+    await writeLine('INFO', 'Starting execution');
+
+    try {
+      final process = await Process.start(
+        _shellExecutable,
+        _shellArguments(bot.startCommand),
+        workingDirectory: workingDirectory.path,
+        runInShell: Platform.isWindows,
+      );
+
+      final stdoutFuture = _pipeStream(
+        stream: process.stdout,
+        onLog: (line) {
+          _logger.info(LOGS.EXECUTION_SERVICE, 'STDOUT: $line',
+              metadata: metadata);
+        },
+        onWrite: (line) => writeLine('STDOUT', line),
+      );
+
+      final stderrFuture = _pipeStream(
+        stream: process.stderr,
+        onLog: (line) {
+          _logger.error(LOGS.EXECUTION_SERVICE, 'STDERR: $line',
+              metadata: metadata);
+        },
+        onWrite: (line) => writeLine('STDERR', line),
+      );
+
+      final exitCode = await process.exitCode;
+      await Future.wait([stdoutFuture, stderrFuture]);
+
+      final completedMetadata = metadata.copyWith(
+        exitCode: exitCode,
+        endTime: DateTime.now(),
+      );
+
+      final summary = 'Execution completed with exit code $exitCode';
+      _logger.info(LOGS.EXECUTION_SERVICE, summary, metadata: completedMetadata);
+      await writeLine('INFO', summary);
+
+      logSink.writeln(completedMetadata.buildCompletionSection());
+      await logSink.close();
+
+      return ExecutionResult(
+        exitCode: exitCode,
+        logFile: logFile,
+        metadata: completedMetadata,
+      );
+    } catch (e) {
+      final failureMetadata = metadata.copyWith(endTime: DateTime.now());
+      final errorMessage = 'Failed to execute bot ${bot.botName}: $e';
+      _logger.error(LOGS.EXECUTION_SERVICE, errorMessage,
+          metadata: failureMetadata);
+      await writeLine('ERROR', errorMessage);
+      await logSink.close();
+      rethrow;
+    }
+  }
+
+  static String get _shellExecutable => Platform.isWindows ? 'cmd' : '/bin/sh';
+
+  static List<String> _shellArguments(String command) {
+    return Platform.isWindows ? ['/c', command] : ['-c', command];
+  }
+
+  static Future<void> _pipeStream({
+    required Stream<List<int>> stream,
+    required void Function(String line) onLog,
+    required FutureOr<void> Function(String line) onWrite,
+  }) async {
+    final decodedStream = stream
+        .transform(utf8.decoder)
+        .transform(const LineSplitter());
+
+    await for (final line in decodedStream) {
+      final trimmed = line.trimRight();
+      if (trimmed.isEmpty) {
+        continue;
+      }
+      await onWrite(trimmed);
+      onLog(trimmed);
+    }
+  }
+}

--- a/lib/frontend/widgets/pages/bot_detail_view.dart
+++ b/lib/frontend/widgets/pages/bot_detail_view.dart
@@ -1,16 +1,101 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import 'package:scriptagher/shared/utils/log_storage.dart';
+
 import '../../models/bot.dart';
 
-class BotDetailView extends StatelessWidget {
+class BotDetailView extends StatefulWidget {
   final Bot bot;
 
-  BotDetailView({required this.bot});
+  BotDetailView({super.key, required this.bot});
+
+  @override
+  State<BotDetailView> createState() => _BotDetailViewState();
+}
+
+class _BotDetailViewState extends State<BotDetailView> {
+  late Future<List<RunLogEntry>> _logsFuture;
+
+  String get _botIdentifier =>
+      widget.bot.id?.toString() ?? widget.bot.botName;
+
+  @override
+  void initState() {
+    super.initState();
+    _logsFuture = LogStorage.fetchRunLogs(_botIdentifier);
+  }
+
+  Future<void> _refreshLogs() async {
+    setState(() {
+      _logsFuture = LogStorage.fetchRunLogs(_botIdentifier);
+    });
+    try {
+      await _logsFuture;
+    } catch (_) {
+      // L'errore verrà gestito dal FutureBuilder mostrando il messaggio adeguato.
+    }
+  }
+
+  Future<void> _openLog(BuildContext context, RunLogEntry entry) async {
+    final content = await LogStorage.readLogContent(entry);
+    if (!mounted) return;
+    await showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(entry.fileName),
+        content: SizedBox(
+          width: double.maxFinite,
+          child: SingleChildScrollView(
+            child: SelectableText(content.isEmpty
+                ? 'Il log è vuoto.'
+                : content),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Chiudi'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _exportLog(BuildContext context, RunLogEntry entry) async {
+    try {
+      final exportedFile = await LogStorage.exportLogFile(entry);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+              'Log esportato in: ${exportedFile.path}'),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Errore durante l\'esportazione: $e'),
+        ),
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
+    final dateFormatter = DateFormat('dd/MM/yyyy HH:mm');
+
     return Scaffold(
       appBar: AppBar(
-        title: Text(bot.botName),
+        title: Text(widget.bot.botName),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Aggiorna log',
+            onPressed: _refreshLogs,
+          ),
+        ],
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
@@ -18,23 +103,73 @@ class BotDetailView extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              'Nome: ${bot.botName}',
-              style: Theme.of(context).textTheme.headlineMedium,  // Cambiato headline5 in headlineMedium
+              'Nome: ${widget.bot.botName}',
+              style: Theme.of(context).textTheme.headlineMedium,
             ),
-            SizedBox(height: 10),
+            const SizedBox(height: 10),
             Text(
-              'Descrizione: ${bot.description}',
-              style: Theme.of(context).textTheme.bodyLarge,  // Cambiato bodyText1 in bodyLarge
+              'Descrizione: ${widget.bot.description}',
+              style: Theme.of(context).textTheme.bodyLarge,
             ),
-            SizedBox(height: 20),
+            const SizedBox(height: 20),
             ElevatedButton(
               onPressed: () {
-                // Azione quando si vuole eseguire l'operazione sul bot
                 ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(content: Text('Esegui bot: ${bot.botName}')),
+                  SnackBar(
+                      content: Text('Esegui bot: ${widget.bot.botName}')),
                 );
               },
-              child: Text('Esegui Bot'),
+              child: const Text('Esegui Bot'),
+            ),
+            const SizedBox(height: 30),
+            Text(
+              'Log Esecuzioni',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            Expanded(
+              child: FutureBuilder<List<RunLogEntry>>(
+                future: _logsFuture,
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.waiting) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+
+                  if (snapshot.hasError) {
+                    return Center(
+                      child: Text(
+                          'Errore durante il caricamento dei log: ${snapshot.error}'),
+                    );
+                  }
+
+                  final logs = snapshot.data ?? [];
+                  if (logs.isEmpty) {
+                    return const Center(
+                      child: Text('Nessun log disponibile per questo bot.'),
+                    );
+                  }
+
+                  return ListView.separated(
+                    itemCount: logs.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (context, index) {
+                      final entry = logs[index];
+                      final modified = dateFormatter.format(entry.lastModified);
+                      return ListTile(
+                        leading: const Icon(Icons.description_outlined),
+                        title: Text(entry.fileName),
+                        subtitle: Text('Ultima modifica: $modified'),
+                        onTap: () => _openLog(context, entry),
+                        trailing: IconButton(
+                          icon: const Icon(Icons.download_outlined),
+                          tooltip: 'Esporta log',
+                          onPressed: () => _exportLog(context, entry),
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
             ),
           ],
         ),

--- a/lib/shared/logging/log_metadata.dart
+++ b/lib/shared/logging/log_metadata.dart
@@ -1,0 +1,91 @@
+import 'package:intl/intl.dart';
+
+/// Metadata attached to a bot execution log.
+class LogMetadata {
+  /// Identifier of the bot. When an integer [botId] is not available the
+  /// bot's name should be used.
+  final String botId;
+
+  /// Timestamp representing when the execution started.
+  final DateTime startTime;
+
+  /// Optional exit code produced by the execution.
+  final int? exitCode;
+
+  /// Optional timestamp that marks when the execution finished.
+  final DateTime? endTime;
+
+  const LogMetadata({
+    required this.botId,
+    required this.startTime,
+    this.exitCode,
+    this.endTime,
+  });
+
+  /// Creates a copy of the metadata adding optional information.
+  LogMetadata copyWith({
+    int? exitCode,
+    DateTime? endTime,
+  }) {
+    return LogMetadata(
+      botId: botId,
+      startTime: startTime,
+      exitCode: exitCode ?? this.exitCode,
+      endTime: endTime ?? this.endTime,
+    );
+  }
+
+  /// Sanitises the identifier so that it can be used safely as a directory or
+  /// file name component.
+  static String sanitizeIdentifier(String value) {
+    final sanitized = value.replaceAll(RegExp(r'[^A-Za-z0-9_-]+'), '_');
+    return sanitized.isEmpty ? 'bot' : sanitized;
+  }
+
+  /// Identifier that is safe to be used for directory names.
+  String get sanitizedBotId => sanitizeIdentifier(botId);
+
+  /// Unique identifier for this execution run.
+  String get runId => DateFormat('yyyyMMdd_HHmmss').format(startTime);
+
+  /// File name that should be used for the log file associated with this run.
+  String get fileName => '${sanitizedBotId}_$runId.log';
+
+  /// Formats the metadata as a suffix for textual log messages.
+  String describe() {
+    final buffer = StringBuffer('[botId:$botId][runId:$runId]');
+    if (exitCode != null) {
+      buffer.write('[exitCode:$exitCode]');
+    }
+    if (endTime != null) {
+      buffer.write('[ended:${DateFormat('yyyy-MM-dd HH:mm:ss').format(endTime!)}]');
+    }
+    return buffer.toString();
+  }
+
+  /// Returns a header suitable to be written at the top of the run log file.
+  String buildHeader() {
+    final formatter = DateFormat('yyyy-MM-dd HH:mm:ss');
+    final buffer = StringBuffer()
+      ..writeln('Bot ID: $botId')
+      ..writeln('Run ID: $runId')
+      ..writeln('Started: ${formatter.format(startTime)}')
+      ..writeln('');
+    return buffer.toString();
+  }
+
+  /// Returns the summary section that should be appended once the execution
+  /// completes.
+  String buildCompletionSection() {
+    final formatter = DateFormat('yyyy-MM-dd HH:mm:ss');
+    final buffer = StringBuffer();
+    if (endTime != null) {
+      buffer.writeln('Finished: ${formatter.format(endTime!)}');
+    }
+    if (exitCode != null) {
+      buffer.writeln('Exit code: $exitCode');
+    }
+    buffer.writeln('');
+    return buffer.toString();
+  }
+}

--- a/lib/shared/utils/log_storage.dart
+++ b/lib/shared/utils/log_storage.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+import '../custom_logger.dart';
+
+/// Represents a single log file on disk alongside some metadata used by the UI.
+class RunLogEntry {
+  RunLogEntry({required this.file, required this.lastModified});
+
+  final File file;
+  final DateTime lastModified;
+
+  String get fileName => file.uri.pathSegments.isNotEmpty
+      ? file.uri.pathSegments.last
+      : file.path;
+}
+
+class LogStorage {
+  /// Returns a list of run log entries for the provided bot identifier sorted by
+  /// last modification date (newest first).
+  static Future<List<RunLogEntry>> fetchRunLogs(String botIdentifier) async {
+    final directory = await CustomLogger.getRunLogsDirectory(botIdentifier);
+
+    if (!await directory.exists()) {
+      return [];
+    }
+
+    final entries = <RunLogEntry>[];
+    await for (final entity in directory.list()) {
+      if (entity is File && entity.path.toLowerCase().endsWith('.log')) {
+        final modified = await entity.lastModified();
+        entries.add(RunLogEntry(file: entity, lastModified: modified));
+      }
+    }
+
+    entries.sort((a, b) => b.lastModified.compareTo(a.lastModified));
+    return entries;
+  }
+
+  /// Reads the content of a specific log file.
+  static Future<String> readLogContent(RunLogEntry entry) async {
+    return entry.file.readAsString();
+  }
+
+  /// Copies the provided log file into the user's downloads directory (when
+  /// available) and returns the new file instance.
+  static Future<File> exportLogFile(RunLogEntry entry) async {
+    Directory? downloads;
+    try {
+      downloads = await getDownloadsDirectory();
+    } catch (_) {
+      downloads = null;
+    }
+    final targetDirectory =
+        downloads ?? await getApplicationDocumentsDirectory();
+    final targetFile = File('${targetDirectory.path}/${entry.fileName}');
+    return entry.file.copy(targetFile.path);
+  }
+}


### PR DESCRIPTION
## Summary
- create an execution service that captures stdout/stderr into per-run log files while emitting structured logger metadata
- extend the shared logging utilities to support run metadata and expose helpers for retrieving log files
- update the bot detail UI with a run log list that supports viewing and exporting previous executions

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f2ac8b5de0832ba3da46104abcf860