### PR TITLE
Add bot metadata support and detail view actions

### DIFF
--- a/lib/backend/server/controllers/bot_controller.dart
+++ b/lib/backend/server/controllers/bot_controller.dart
@@ -26,7 +26,7 @@ class BotController {
       // Rispondi con la lista di bot in formato JSON
       return Response.ok(
           json.encode(availableBots
-              .map((bot) => bot.toMap())
+              .map((bot) => bot.toJson())
               .toList()), // Converte ogni bot in una mappa JSON
           headers: {'Content-Type': 'application/json'});
     } catch (e) {
@@ -54,7 +54,7 @@ class BotController {
           LOGS.BOT_SERVICE, 'Downloaded bot ${bot.botName} successfully.');
 
       // Rispondi con i dettagli del bot come JSON
-      return Response.ok(json.encode(bot.toMap()),
+      return Response.ok(json.encode(bot.toJson()),
           headers: {'Content-Type': 'application/json'});
     } catch (e) {
       logger.error(LOGS.BOT_SERVICE, 'Error downloading bot: $e');
@@ -75,7 +75,7 @@ class BotController {
 
       logger.info(LOGS.BOT_SERVICE, 'Fetched ${localBots.length} local bots.');
       return Response.ok(
-        json.encode(localBots.map((bot) => bot.toMap()).toList()),
+        json.encode(localBots.map((bot) => bot.toJson()).toList()),
         headers: {'Content-Type': 'application/json'},
       );
     } catch (e) {

--- a/lib/backend/server/models/bot.dart
+++ b/lib/backend/server/models/bot.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 class Bot {
   final int? id;
   final String botName;
@@ -5,6 +7,10 @@ class Bot {
   final String startCommand;
   final String sourcePath;
   final String language;
+  final String author;
+  final String version;
+  final List<String> permissions;
+  final List<String> platformCompatibility;
 
   Bot({
     this.id,
@@ -13,12 +19,20 @@ class Bot {
     required this.startCommand,
     required this.sourcePath,
     required this.language,
-  });
+    this.author = '',
+    this.version = '',
+    List<String>? permissions,
+    List<String>? platformCompatibility,
+  })  : permissions = permissions ?? const [],
+        platformCompatibility = platformCompatibility ?? const [];
 
-  // Metodo factory per creare una nuova versione di Bot con dettagli aggiornati
   Bot copyWith({
     String? description,
     String? startCommand,
+    String? author,
+    String? version,
+    List<String>? permissions,
+    List<String>? platformCompatibility,
   }) {
     return Bot(
       id: id,
@@ -27,10 +41,15 @@ class Bot {
       startCommand: startCommand ?? this.startCommand,
       sourcePath: sourcePath,
       language: language,
+      author: author ?? this.author,
+      version: version ?? this.version,
+      permissions: permissions ?? this.permissions,
+      platformCompatibility:
+          platformCompatibility ?? this.platformCompatibility,
     );
   }
 
-  Map<String, dynamic> toMap() {
+  Map<String, dynamic> toDbMap() {
     return {
       'id': id,
       'bot_name': botName,
@@ -38,6 +57,25 @@ class Bot {
       'start_command': startCommand,
       'source_path': sourcePath,
       'language': language,
+      'author': author,
+      'version': version,
+      'permissions': jsonEncode(permissions),
+      'platform_compatibility': jsonEncode(platformCompatibility),
+    };
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'bot_name': botName,
+      'description': description,
+      'start_command': startCommand,
+      'source_path': sourcePath,
+      'language': language,
+      'author': author,
+      'version': version,
+      'permissions': permissions,
+      'platform_compatibility': platformCompatibility,
     };
   }
 
@@ -49,6 +87,31 @@ class Bot {
       startCommand: map['start_command'] ?? '',
       sourcePath: map['source_path'],
       language: map['language'],
+      author: map['author'] ?? '',
+      version: map['version'] ?? '',
+      permissions: _decodeList(map['permissions']),
+      platformCompatibility:
+          _decodeList(map['platform_compatibility']),
     );
+  }
+
+  static List<String> _decodeList(dynamic value) {
+    if (value == null) {
+      return const [];
+    }
+    if (value is List) {
+      return value.map((e) => e.toString()).toList();
+    }
+    if (value is String && value.isNotEmpty) {
+      try {
+        final decoded = jsonDecode(value);
+        if (decoded is List) {
+          return decoded.map((e) => e.toString()).toList();
+        }
+      } catch (_) {
+        return value.split(',').map((e) => e.trim()).where((e) => e.isNotEmpty).toList();
+      }
+    }
+    return const [];
   }
 }

--- a/lib/frontend/models/bot.dart
+++ b/lib/frontend/models/bot.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 class Bot {
   final int? id;
   final String botName;
@@ -5,6 +7,10 @@ class Bot {
   final String startCommand;
   final String sourcePath;
   final String language;
+  final String author;
+  final String version;
+  final List<String> permissions;
+  final List<String> platformCompatibility;
 
   Bot({
     this.id,
@@ -13,12 +19,20 @@ class Bot {
     required this.startCommand,
     required this.sourcePath,
     required this.language,
-  });
+    this.author = '',
+    this.version = '',
+    List<String>? permissions,
+    List<String>? platformCompatibility,
+  })  : permissions = permissions ?? const [],
+        platformCompatibility = platformCompatibility ?? const [];
 
-  // Metodo factory per creare una nuova versione di Bot con dettagli aggiornati
   Bot copyWith({
     String? description,
     String? startCommand,
+    String? author,
+    String? version,
+    List<String>? permissions,
+    List<String>? platformCompatibility,
   }) {
     return Bot(
       id: id,
@@ -27,6 +41,11 @@ class Bot {
       startCommand: startCommand ?? this.startCommand,
       sourcePath: sourcePath,
       language: language,
+      author: author ?? this.author,
+      version: version ?? this.version,
+      permissions: permissions ?? this.permissions,
+      platformCompatibility:
+          platformCompatibility ?? this.platformCompatibility,
     );
   }
 
@@ -38,6 +57,25 @@ class Bot {
       'start_command': startCommand,
       'source_path': sourcePath,
       'language': language,
+      'author': author,
+      'version': version,
+      'permissions': permissions,
+      'platform_compatibility': platformCompatibility,
+    };
+  }
+
+  Map<String, dynamic> toDbMap() {
+    return {
+      'id': id,
+      'bot_name': botName,
+      'description': description,
+      'start_command': startCommand,
+      'source_path': sourcePath,
+      'language': language,
+      'author': author,
+      'version': version,
+      'permissions': jsonEncode(permissions),
+      'platform_compatibility': jsonEncode(platformCompatibility),
     };
   }
 
@@ -49,16 +87,48 @@ class Bot {
       startCommand: map['start_command'] ?? '',
       sourcePath: map['source_path'],
       language: map['language'],
+      author: map['author'] ?? '',
+      version: map['version'] ?? '',
+      permissions: _decodeList(map['permissions']),
+      platformCompatibility:
+          _decodeList(map['platform_compatibility']),
     );
   }
 
   factory Bot.fromJson(Map<String, dynamic> json) {
     return Bot(
-      botName: json['bot_name'] ?? '',
+      id: json['id'],
+      botName: json['bot_name'] ?? json['botName'] ?? '',
       description: json['description'] ?? '',
-      startCommand: json['start_command'] ?? '',
-      sourcePath: json['source_path'] ?? '',
+      startCommand: json['start_command'] ?? json['startCommand'] ?? '',
+      sourcePath: json['source_path'] ?? json['sourcePath'] ?? '',
       language: json['language'] ?? '',
+      author: json['author'] ?? '',
+      version: json['version'] ?? '',
+      permissions: _decodeList(json['permissions']),
+      platformCompatibility: _decodeList(
+        json['platform_compatibility'] ?? json['platformCompatibility'],
+      ),
     );
+  }
+
+  static List<String> _decodeList(dynamic value) {
+    if (value == null) {
+      return const [];
+    }
+    if (value is List) {
+      return value.map((e) => e.toString()).toList();
+    }
+    if (value is String && value.isNotEmpty) {
+      try {
+        final decoded = jsonDecode(value);
+        if (decoded is List) {
+          return decoded.map((e) => e.toString()).toList();
+        }
+      } catch (_) {
+        return value.split(',').map((e) => e.trim()).where((e) => e.isNotEmpty).toList();
+      }
+    }
+    return const [];
   }
 }

--- a/lib/frontend/services/bot_action_service.dart
+++ b/lib/frontend/services/bot_action_service.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+
+import 'package:scriptagher/shared/constants/APIS.dart';
+
+import '../models/bot.dart';
+
+class BotActionService {
+  final String baseUrl;
+  final http.Client _client;
+
+  BotActionService({this.baseUrl = 'http://localhost:8080', http.Client? client})
+      : _client = client ?? http.Client();
+
+  Future<Bot> downloadBot(String language, String botName) async {
+    final url = Uri.parse('$baseUrl/bots/$language/$botName');
+    final response = await _client.get(url);
+
+    if (response.statusCode != 200) {
+      throw HttpException(
+          'Impossibile completare il download (status ${response.statusCode}).');
+    }
+
+    final Map<String, dynamic> data = jsonDecode(response.body);
+    return Bot.fromJson(data);
+  }
+
+  Future<void> openBotFolder(Bot bot) async {
+    final folderPath =
+        '${APIS.BOT_DIR_DATA_REMOTE}/${bot.language}/${bot.botName}';
+    final directory = Directory(folderPath);
+
+    if (!await directory.exists()) {
+      throw FileSystemException('Cartella non trovata', folderPath);
+    }
+
+    if (Platform.isMacOS) {
+      await Process.run('open', [directory.path]);
+    } else if (Platform.isWindows) {
+      await Process.run('explorer', [directory.path.replaceAll('/', '\\')]);
+    } else {
+      await Process.run('xdg-open', [directory.path]);
+    }
+  }
+
+  Future<void> runBot(Bot bot) async {
+    final command = bot.startCommand.trim();
+    if (command.isEmpty) {
+      throw const FormatException('Nessun comando di avvio disponibile.');
+    }
+
+    if (Platform.isWindows) {
+      await Process.start('cmd.exe', ['/c', command],
+          workingDirectory: Directory.current.path);
+    } else {
+      await Process.start('/bin/sh', ['-c', command],
+          workingDirectory: Directory.current.path);
+    }
+  }
+}

--- a/lib/frontend/widgets/pages/bot_detail_view.dart
+++ b/lib/frontend/widgets/pages/bot_detail_view.dart
@@ -1,43 +1,287 @@
 import 'package:flutter/material.dart';
-import '../../models/bot.dart';
 
-class BotDetailView extends StatelessWidget {
+import '../../models/bot.dart';
+import '../../services/bot_action_service.dart';
+import '../../services/bot_get_service.dart';
+
+class BotDetailView extends StatefulWidget {
   final Bot bot;
 
-  BotDetailView({required this.bot});
+  const BotDetailView({super.key, required this.bot});
+
+  @override
+  State<BotDetailView> createState() => _BotDetailViewState();
+}
+
+class _BotDetailViewState extends State<BotDetailView> {
+  final BotGetService _botGetService = BotGetService();
+  final BotActionService _botActionService = BotActionService();
+
+  Bot? _localBot;
+  bool _isDownloading = false;
+  bool _isInstalled = false;
+  bool _isUpdateAvailable = false;
+  String? _errorMessage;
+
+  Bot get _displayBot => _localBot ?? widget.bot;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadLocalState();
+  }
+
+  Future<void> _loadLocalState() async {
+    try {
+      final localBots = await _botGetService.fetchLocalBotsFlat();
+      Bot? match;
+      try {
+        match = localBots.firstWhere(
+          (bot) =>
+              bot.botName == widget.bot.botName &&
+              bot.language.toLowerCase() == widget.bot.language.toLowerCase(),
+        );
+      } catch (_) {
+        match = null;
+      }
+
+      if (!mounted) return;
+
+      setState(() {
+        _localBot = match;
+        _isInstalled = match != null;
+        _isUpdateAvailable = match != null && widget.bot.version.isNotEmpty
+            ? widget.bot.version != match.version
+            : false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _errorMessage = 'Errore nel caricamento dei bot locali: $e';
+      });
+    }
+  }
+
+  Future<void> _handleDownloadOrUpdate() async {
+    setState(() {
+      _isDownloading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final downloadedBot = await _botActionService.downloadBot(
+        widget.bot.language,
+        widget.bot.botName,
+      );
+
+      if (!mounted) return;
+      setState(() {
+        _localBot = downloadedBot;
+        _isInstalled = true;
+        _isUpdateAvailable = widget.bot.version.isNotEmpty
+            ? widget.bot.version != downloadedBot.version
+            : false;
+      });
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            _isUpdateAvailable
+                ? 'Aggiornamento completato per ${widget.bot.botName}.'
+                : 'Download completato per ${widget.bot.botName}.',
+          ),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _errorMessage = 'Operazione fallita: $e';
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Errore durante il download: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isDownloading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _handleOpenFolder() async {
+    try {
+      await _botActionService.openBotFolder(_displayBot);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Cartella aperta per ${widget.bot.botName}.')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _errorMessage = 'Impossibile aprire la cartella: $e';
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Errore apertura cartella: $e')),
+      );
+    }
+  }
+
+  Future<void> _handleRun() async {
+    try {
+      await _botActionService.runBot(_displayBot);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Esecuzione avviata per ${widget.bot.botName}.')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _errorMessage = 'Impossibile eseguire il bot: $e';
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Errore durante l\'esecuzione: $e')),
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
+    final bot = _displayBot;
+    final metadataStyle = Theme.of(context).textTheme.bodyMedium;
+
     return Scaffold(
       appBar: AppBar(
         title: Text(bot.botName),
+        actions: [
+          if (_isInstalled)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: Chip(
+                label: Text(
+                  _isUpdateAvailable ? 'Aggiornamento disponibile' : 'Installato',
+                  style: const TextStyle(color: Colors.white),
+                ),
+                backgroundColor:
+                    _isUpdateAvailable ? Colors.orange : Colors.green,
+              ),
+            ),
+        ],
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              'Nome: ${bot.botName}',
-              style: Theme.of(context).textTheme.headlineMedium,  // Cambiato headline5 in headlineMedium
-            ),
-            SizedBox(height: 10),
-            Text(
-              'Descrizione: ${bot.description}',
-              style: Theme.of(context).textTheme.bodyLarge,  // Cambiato bodyText1 in bodyLarge
-            ),
-            SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: () {
-                // Azione quando si vuole eseguire l'operazione sul bot
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(content: Text('Esegui bot: ${bot.botName}')),
-                );
-              },
-              child: Text('Esegui Bot'),
-            ),
-          ],
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                bot.botName,
+                style: Theme.of(context).textTheme.headlineMedium,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                bot.description.isNotEmpty
+                    ? bot.description
+                    : 'Nessuna descrizione disponibile.',
+                style: Theme.of(context).textTheme.bodyLarge,
+              ),
+              const SizedBox(height: 16),
+              if (_isDownloading) const LinearProgressIndicator(),
+              if (_errorMessage != null) ...[
+                const SizedBox(height: 12),
+                Text(
+                  _errorMessage!,
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),
+                ),
+              ],
+              const SizedBox(height: 24),
+              _buildMetadataRow('Autore', bot.author, metadataStyle),
+              _buildMetadataRow('Versione', bot.version, metadataStyle),
+              _buildMetadataRow(
+                'Permessi richiesti',
+                bot.permissions.isNotEmpty
+                    ? bot.permissions.join(', ')
+                    : 'Nessuno',
+                metadataStyle,
+              ),
+              _buildMetadataRow(
+                'Compatibilità piattaforme',
+                bot.platformCompatibility.isNotEmpty
+                    ? bot.platformCompatibility.join(', ')
+                    : 'Non specificata',
+                metadataStyle,
+              ),
+              _buildMetadataRow(
+                'Comando di avvio',
+                bot.startCommand.isNotEmpty
+                    ? bot.startCommand
+                    : 'Non specificato',
+                metadataStyle,
+              ),
+              const SizedBox(height: 24),
+              Wrap(
+                spacing: 12,
+                runSpacing: 12,
+                children: [
+                  ElevatedButton.icon(
+                    onPressed: _isDownloading
+                        ? null
+                        : _handleDownloadOrUpdate,
+                    icon: _isDownloading
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.download),
+                    label: Text(_isInstalled
+                        ? (_isUpdateAvailable ? 'Aggiorna' : 'Reinstalla')
+                        : 'Scarica'),
+                  ),
+                  OutlinedButton.icon(
+                    onPressed: _isInstalled && !_isDownloading
+                        ? _handleOpenFolder
+                        : null,
+                    icon: const Icon(Icons.folder_open),
+                    label: const Text('Apri cartella'),
+                  ),
+                  OutlinedButton.icon(
+                    onPressed: _isInstalled && !_isDownloading
+                        ? _handleRun
+                        : null,
+                    icon: const Icon(Icons.play_arrow),
+                    label: const Text('Esegui'),
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildMetadataRow(
+      String label, String value, TextStyle? metadataStyle) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8.0),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 200,
+            child: Text(
+              '$label:',
+              style: metadataStyle?.copyWith(fontWeight: FontWeight.bold),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value.isNotEmpty ? value : '—',
+              style: metadataStyle,
+            ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add metadata fields for bots across frontend and backend, including persistence updates
- expose the new metadata in API responses and download workflows
- refresh the bot detail view with metadata display and download, open folder, and run actions

## Testing
- flutter test *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2ac865cb0832bb539643280419e30