### PR TITLE
Add compatibility metadata and runtime checks

### DIFF
--- a/assets/templates/Bot.json
+++ b/assets/templates/Bot.json
@@ -1,0 +1,17 @@
+{
+  "botName": "ExampleBot",
+  "description": "Esempio di bot con compatibilità esplicita",
+  "startCommand": "python main.py",
+  "language": "python",
+  "compat": {
+    "desktop": {
+      "supported": true,
+      "runner": "python",
+      "runnerArgs": ["--version"]
+    },
+    "browser": {
+      "supported": false,
+      "reason": "Richiede l'esecuzione di processi locali"
+    }
+  }
+}

--- a/lib/backend/server/controllers/bot_controller.dart
+++ b/lib/backend/server/controllers/bot_controller.dart
@@ -26,7 +26,7 @@ class BotController {
       // Rispondi con la lista di bot in formato JSON
       return Response.ok(
           json.encode(availableBots
-              .map((bot) => bot.toMap())
+              .map((bot) => bot.toJson())
               .toList()), // Converte ogni bot in una mappa JSON
           headers: {'Content-Type': 'application/json'});
     } catch (e) {
@@ -54,7 +54,7 @@ class BotController {
           LOGS.BOT_SERVICE, 'Downloaded bot ${bot.botName} successfully.');
 
       // Rispondi con i dettagli del bot come JSON
-      return Response.ok(json.encode(bot.toMap()),
+      return Response.ok(json.encode(bot.toJson()),
           headers: {'Content-Type': 'application/json'});
     } catch (e) {
       logger.error(LOGS.BOT_SERVICE, 'Error downloading bot: $e');
@@ -75,7 +75,7 @@ class BotController {
 
       logger.info(LOGS.BOT_SERVICE, 'Fetched ${localBots.length} local bots.');
       return Response.ok(
-        json.encode(localBots.map((bot) => bot.toMap()).toList()),
+        json.encode(localBots.map((bot) => bot.toJson()).toList()),
         headers: {'Content-Type': 'application/json'},
       );
     } catch (e) {

--- a/lib/backend/server/models/bot.dart
+++ b/lib/backend/server/models/bot.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 class Bot {
   final int? id;
   final String botName;
@@ -5,6 +7,7 @@ class Bot {
   final String startCommand;
   final String sourcePath;
   final String language;
+  final BotCompatibility? compat;
 
   Bot({
     this.id,
@@ -13,12 +16,14 @@ class Bot {
     required this.startCommand,
     required this.sourcePath,
     required this.language,
+    this.compat,
   });
 
   // Metodo factory per creare una nuova versione di Bot con dettagli aggiornati
   Bot copyWith({
     String? description,
     String? startCommand,
+    BotCompatibility? compat,
   }) {
     return Bot(
       id: id,
@@ -27,10 +32,11 @@ class Bot {
       startCommand: startCommand ?? this.startCommand,
       sourcePath: sourcePath,
       language: language,
+      compat: compat ?? this.compat,
     );
   }
 
-  Map<String, dynamic> toMap() {
+  Map<String, dynamic> toJson() {
     return {
       'id': id,
       'bot_name': botName,
@@ -38,6 +44,19 @@ class Bot {
       'start_command': startCommand,
       'source_path': sourcePath,
       'language': language,
+      'compat': compat?.toJson(),
+    };
+  }
+
+  Map<String, dynamic> toDbMap() {
+    return {
+      'id': id,
+      'bot_name': botName,
+      'description': description,
+      'start_command': startCommand,
+      'source_path': sourcePath,
+      'language': language,
+      'compat': compat != null ? jsonEncode(compat!.toJson()) : null,
     };
   }
 
@@ -49,6 +68,150 @@ class Bot {
       startCommand: map['start_command'] ?? '',
       sourcePath: map['source_path'],
       language: map['language'],
+      compat: BotCompatibility.fromDynamic(map['compat']),
+    );
+  }
+}
+
+class BotCompatibility {
+  final DesktopCompatibility? desktop;
+  final BrowserCompatibility? browser;
+
+  BotCompatibility({this.desktop, this.browser});
+
+  BotCompatibility copyWith({
+    DesktopCompatibility? desktop,
+    BrowserCompatibility? browser,
+  }) {
+    return BotCompatibility(
+      desktop: desktop ?? this.desktop,
+      browser: browser ?? this.browser,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      if (desktop != null) 'desktop': desktop!.toJson(),
+      if (browser != null) 'browser': browser!.toJson(),
+    };
+  }
+
+  static BotCompatibility? fromDynamic(dynamic data) {
+    if (data == null) {
+      return null;
+    }
+    if (data is String && data.trim().isEmpty) {
+      return null;
+    }
+
+    Map<String, dynamic>? json;
+    if (data is String) {
+      try {
+        final decoded = jsonDecode(data);
+        if (decoded == null) {
+          return null;
+        }
+        json = Map<String, dynamic>.from(decoded as Map);
+      } catch (_) {
+        return null;
+      }
+    } else if (data is Map<String, dynamic>) {
+      json = data;
+    } else {
+      return null;
+    }
+
+    return BotCompatibility(
+      desktop: json!['desktop'] != null
+          ? DesktopCompatibility.fromJson(
+              Map<String, dynamic>.from(json['desktop']))
+          : null,
+      browser: json['browser'] != null
+          ? BrowserCompatibility.fromJson(
+              Map<String, dynamic>.from(json['browser']))
+          : null,
+    );
+  }
+}
+
+class DesktopCompatibility {
+  final bool? supported;
+  final String? runner;
+  final List<String> runnerArgs;
+  final bool? runnerAvailable;
+  final String? runnerVersion;
+  final String? runnerError;
+
+  DesktopCompatibility({
+    this.supported,
+    this.runner,
+    List<String>? runnerArgs,
+    this.runnerAvailable,
+    this.runnerVersion,
+    this.runnerError,
+  }) : runnerArgs = runnerArgs ?? const ['--version'];
+
+  DesktopCompatibility copyWith({
+    bool? supported,
+    String? runner,
+    List<String>? runnerArgs,
+    bool? runnerAvailable,
+    String? runnerVersion,
+    String? runnerError,
+  }) {
+    return DesktopCompatibility(
+      supported: supported ?? this.supported,
+      runner: runner ?? this.runner,
+      runnerArgs: runnerArgs ?? this.runnerArgs,
+      runnerAvailable: runnerAvailable ?? this.runnerAvailable,
+      runnerVersion: runnerVersion ?? this.runnerVersion,
+      runnerError: runnerError ?? this.runnerError,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      if (supported != null) 'supported': supported,
+      if (runner != null) 'runner': runner,
+      if (runnerArgs.isNotEmpty) 'runnerArgs': runnerArgs,
+      if (runnerAvailable != null) 'runnerAvailable': runnerAvailable,
+      if (runnerVersion != null) 'runnerVersion': runnerVersion,
+      if (runnerError != null) 'runnerError': runnerError,
+    };
+  }
+
+  factory DesktopCompatibility.fromJson(Map<String, dynamic> json) {
+    final args = json['runnerArgs'];
+    return DesktopCompatibility(
+      supported: json['supported'],
+      runner: json['runner'],
+      runnerArgs: args != null
+          ? List<String>.from(args.map((arg) => arg.toString()))
+          : null,
+      runnerAvailable: json['runnerAvailable'],
+      runnerVersion: json['runnerVersion'],
+      runnerError: json['runnerError'],
+    );
+  }
+}
+
+class BrowserCompatibility {
+  final bool supported;
+  final String? reason;
+
+  BrowserCompatibility({required this.supported, this.reason});
+
+  Map<String, dynamic> toJson() {
+    return {
+      'supported': supported,
+      if (reason != null) 'reason': reason,
+    };
+  }
+
+  factory BrowserCompatibility.fromJson(Map<String, dynamic> json) {
+    return BrowserCompatibility(
+      supported: json['supported'] ?? true,
+      reason: json['reason'],
     );
   }
 }

--- a/lib/backend/server/server.dart
+++ b/lib/backend/server/server.dart
@@ -9,6 +9,7 @@ import 'services/bot_download_service.dart';
 import 'db/bot_database.dart';
 import 'routes.dart';
 import 'package:scriptagher/backend/server/api_integration/github_api.dart';
+import 'services/system_compatibility_service.dart';
 
 Future<void> startServer() async {
   // Crea un'istanza del CustomLogger
@@ -16,8 +17,10 @@ Future<void> startServer() async {
 
   final botDatabase = BotDatabase();
   final GitHubApi gitHubApi = GitHubApi();
+  final systemCompatibilityService = SystemCompatibilityService();
   // Istanzia il BotService e BotController
-  final botGetService = BotGetService(botDatabase, gitHubApi);
+  final botGetService =
+      BotGetService(botDatabase, gitHubApi, systemCompatibilityService);
   final botDownloadService = BotDownloadService();
   final botController = BotController(botDownloadService, botGetService);
 

--- a/lib/backend/server/services/system_compatibility_service.dart
+++ b/lib/backend/server/services/system_compatibility_service.dart
@@ -1,0 +1,94 @@
+import 'dart:async';
+import 'dart:io';
+
+class RunnerCheckResult {
+  final String command;
+  final List<String> args;
+  final bool isAvailable;
+  final String? version;
+  final String? error;
+  final DateTime checkedAt;
+
+  RunnerCheckResult({
+    required this.command,
+    required this.args,
+    required this.isAvailable,
+    this.version,
+    this.error,
+    DateTime? checkedAt,
+  }) : checkedAt = checkedAt ?? DateTime.now();
+}
+
+class SystemCompatibilityService {
+  static final SystemCompatibilityService _instance =
+      SystemCompatibilityService._internal();
+
+  final Map<String, RunnerCheckResult> _runnerResults = {};
+
+  SystemCompatibilityService._internal();
+
+  factory SystemCompatibilityService() => _instance;
+
+  Future<RunnerCheckResult> checkRunner(String command,
+      {List<String> args = const ['--version']}) async {
+    final cacheKey = _cacheKey(command, args);
+    if (_runnerResults.containsKey(cacheKey)) {
+      return _runnerResults[cacheKey]!;
+    }
+
+    try {
+      final result = await Process.run(command, args);
+      final isAvailable = result.exitCode == 0;
+      final output = _extractOutput(result.stdout, result.stderr);
+
+      final checkResult = RunnerCheckResult(
+        command: command,
+        args: args,
+        isAvailable: isAvailable,
+        version: isAvailable ? output : null,
+        error: isAvailable
+            ? null
+            : output.isEmpty
+                ? result.stderr?.toString()
+                : output,
+      );
+
+      _runnerResults[cacheKey] = checkResult;
+      return checkResult;
+    } on ProcessException catch (e) {
+      final checkResult = RunnerCheckResult(
+        command: command,
+        args: args,
+        isAvailable: false,
+        error: e.message,
+      );
+      _runnerResults[cacheKey] = checkResult;
+      return checkResult;
+    } catch (e) {
+      final checkResult = RunnerCheckResult(
+        command: command,
+        args: args,
+        isAvailable: false,
+        error: e.toString(),
+      );
+      _runnerResults[cacheKey] = checkResult;
+      return checkResult;
+    }
+  }
+
+  RunnerCheckResult? getRunnerResult(String command,
+      {List<String> args = const ['--version']}) {
+    final cacheKey = _cacheKey(command, args);
+    return _runnerResults[cacheKey];
+  }
+
+  String _cacheKey(String command, List<String> args) {
+    return '$command ${args.join(' ')}';
+  }
+
+  String _extractOutput(dynamic stdout, dynamic stderr) {
+    final stdoutStr = stdout?.toString().trim() ?? '';
+    final stderrStr = stderr?.toString().trim() ?? '';
+    return stdoutStr.isNotEmpty ? stdoutStr : stderrStr;
+  }
+}

--- a/lib/frontend/models/bot.dart
+++ b/lib/frontend/models/bot.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 class Bot {
   final int? id;
   final String botName;
@@ -5,6 +7,7 @@ class Bot {
   final String startCommand;
   final String sourcePath;
   final String language;
+  final BotCompatibility? compat;
 
   Bot({
     this.id,
@@ -13,12 +16,14 @@ class Bot {
     required this.startCommand,
     required this.sourcePath,
     required this.language,
+    this.compat,
   });
 
   // Metodo factory per creare una nuova versione di Bot con dettagli aggiornati
   Bot copyWith({
     String? description,
     String? startCommand,
+    BotCompatibility? compat,
   }) {
     return Bot(
       id: id,
@@ -27,6 +32,7 @@ class Bot {
       startCommand: startCommand ?? this.startCommand,
       sourcePath: sourcePath,
       language: language,
+      compat: compat ?? this.compat,
     );
   }
 
@@ -38,6 +44,7 @@ class Bot {
       'start_command': startCommand,
       'source_path': sourcePath,
       'language': language,
+      'compat': compat?.toJson(),
     };
   }
 
@@ -49,6 +56,7 @@ class Bot {
       startCommand: map['start_command'] ?? '',
       sourcePath: map['source_path'],
       language: map['language'],
+      compat: BotCompatibility.fromDynamic(map['compat']),
     );
   }
 
@@ -59,6 +67,122 @@ class Bot {
       startCommand: json['start_command'] ?? '',
       sourcePath: json['source_path'] ?? '',
       language: json['language'] ?? '',
+      compat: BotCompatibility.fromDynamic(json['compat']),
+    );
+  }
+}
+
+class BotCompatibility {
+  final DesktopCompatibility? desktop;
+  final BrowserCompatibility? browser;
+
+  BotCompatibility({this.desktop, this.browser});
+
+  Map<String, dynamic> toJson() {
+    return {
+      if (desktop != null) 'desktop': desktop!.toJson(),
+      if (browser != null) 'browser': browser!.toJson(),
+    };
+  }
+
+  static BotCompatibility? fromDynamic(dynamic data) {
+    if (data == null) {
+      return null;
+    }
+    if (data is String && data.trim().isEmpty) {
+      return null;
+    }
+
+    Map<String, dynamic>? json;
+    if (data is String) {
+      try {
+        final decoded = jsonDecode(data);
+        if (decoded == null) {
+          return null;
+        }
+        json = Map<String, dynamic>.from(decoded as Map);
+      } catch (_) {
+        return null;
+      }
+    } else if (data is Map<String, dynamic>) {
+      json = data;
+    } else {
+      return null;
+    }
+
+    return BotCompatibility(
+      desktop: json!['desktop'] != null
+          ? DesktopCompatibility.fromJson(
+              Map<String, dynamic>.from(json['desktop']))
+          : null,
+      browser: json['browser'] != null
+          ? BrowserCompatibility.fromJson(
+              Map<String, dynamic>.from(json['browser']))
+          : null,
+    );
+  }
+}
+
+class DesktopCompatibility {
+  final bool? supported;
+  final String? runner;
+  final List<String> runnerArgs;
+  final bool? runnerAvailable;
+  final String? runnerVersion;
+  final String? runnerError;
+
+  DesktopCompatibility({
+    this.supported,
+    this.runner,
+    List<String>? runnerArgs,
+    this.runnerAvailable,
+    this.runnerVersion,
+    this.runnerError,
+  }) : runnerArgs = runnerArgs ?? const ['--version'];
+
+  Map<String, dynamic> toJson() {
+    return {
+      if (supported != null) 'supported': supported,
+      if (runner != null) 'runner': runner,
+      if (runnerArgs.isNotEmpty) 'runnerArgs': runnerArgs,
+      if (runnerAvailable != null) 'runnerAvailable': runnerAvailable,
+      if (runnerVersion != null) 'runnerVersion': runnerVersion,
+      if (runnerError != null) 'runnerError': runnerError,
+    };
+  }
+
+  factory DesktopCompatibility.fromJson(Map<String, dynamic> json) {
+    final args = json['runnerArgs'];
+    return DesktopCompatibility(
+      supported: json['supported'],
+      runner: json['runner'],
+      runnerArgs: args != null
+          ? List<String>.from(args.map((arg) => arg.toString()))
+          : null,
+      runnerAvailable: json['runnerAvailable'],
+      runnerVersion: json['runnerVersion'],
+      runnerError: json['runnerError'],
+    );
+  }
+}
+
+class BrowserCompatibility {
+  final bool supported;
+  final String? reason;
+
+  BrowserCompatibility({required this.supported, this.reason});
+
+  Map<String, dynamic> toJson() {
+    return {
+      'supported': supported,
+      if (reason != null) 'reason': reason,
+    };
+  }
+
+  factory BrowserCompatibility.fromJson(Map<String, dynamic> json) {
+    return BrowserCompatibility(
+      supported: json['supported'] ?? true,
+      reason: json['reason'],
     );
   }
 }

--- a/lib/frontend/widgets/components/bot_card_component.dart
+++ b/lib/frontend/widgets/components/bot_card_component.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../models/bot.dart';
+import 'compatibility_badges.dart';
 
 class BotCard extends StatelessWidget {
   final Bot bot;
@@ -13,9 +14,27 @@ class BotCard extends StatelessWidget {
       margin: EdgeInsets.symmetric(vertical: 8, horizontal: 16),
       child: ListTile(
         title: Text(bot.botName),
-        subtitle: Text(bot.description),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(bot.description),
+            if (_hasCompatBadges(bot)) SizedBox(height: 8),
+            CompatibilityBadges(bot: bot),
+          ],
+        ),
         onTap: onTap,
       ),
     );
+  }
+
+  bool _hasCompatBadges(Bot bot) {
+    final desktop = bot.compat?.desktop;
+    final browser = bot.compat?.browser;
+
+    final hasDesktopStatus = desktop?.runnerAvailable != null;
+    final browserUnsupported = browser?.supported == false;
+
+    return hasDesktopStatus || browserUnsupported;
   }
 }

--- a/lib/frontend/widgets/components/compatibility_badges.dart
+++ b/lib/frontend/widgets/components/compatibility_badges.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import '../../models/bot.dart';
+
+class CompatibilityBadges extends StatelessWidget {
+  final Bot bot;
+  final bool showHeading;
+
+  const CompatibilityBadges({super.key, required this.bot, this.showHeading = false});
+
+  @override
+  Widget build(BuildContext context) {
+    final badges = _buildBadges(context);
+
+    if (badges.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final content = Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: badges,
+    );
+
+    if (!showHeading) {
+      return content;
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Compatibilità',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const SizedBox(height: 8),
+        content,
+      ],
+    );
+  }
+
+  List<Widget> _buildBadges(BuildContext context) {
+    final theme = Theme.of(context);
+    final desktop = bot.compat?.desktop;
+    final browser = bot.compat?.browser;
+
+    final compatibleColor = theme.colorScheme.tertiaryContainer;
+    final compatibleTextColor = theme.colorScheme.onTertiaryContainer;
+    final warningColor = theme.colorScheme.errorContainer;
+    final warningTextColor = theme.colorScheme.onErrorContainer;
+    final neutralColor = theme.colorScheme.surfaceVariant;
+    final neutralTextColor = theme.colorScheme.onSurfaceVariant;
+
+    final badges = <Widget>[];
+
+    if (desktop?.runnerAvailable == true) {
+      badges.add(_statusChip(
+        label: 'Compatibile',
+        background: compatibleColor,
+        foreground: compatibleTextColor,
+        icon: Icons.check_circle,
+      ));
+    } else if (desktop?.runnerAvailable == false) {
+      final runnerLabel = desktop?.runner != null
+          ? 'Runner mancante (${desktop!.runner})'
+          : 'Runner mancante';
+      badges.add(_statusChip(
+        label: runnerLabel,
+        background: warningColor,
+        foreground: warningTextColor,
+        icon: Icons.warning_amber,
+      ));
+    }
+
+    if (browser?.supported == false) {
+      badges.add(_statusChip(
+        label: 'Non supportato nel browser',
+        background: neutralColor,
+        foreground: neutralTextColor,
+        icon: Icons.block,
+      ));
+    }
+
+    return badges;
+  }
+
+  Widget _statusChip({
+    required String label,
+    required Color background,
+    required Color foreground,
+    required IconData icon,
+  }) {
+    return Chip(
+      avatar: Icon(icon, size: 18, color: foreground),
+      label: Text(label, style: TextStyle(color: foreground)),
+      backgroundColor: background,
+      shape: const StadiumBorder(),
+    );
+  }
+}

--- a/lib/frontend/widgets/pages/bot_detail_view.dart
+++ b/lib/frontend/widgets/pages/bot_detail_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../models/bot.dart';
+import '../components/compatibility_badges.dart';
 
 class BotDetailView extends StatelessWidget {
   final Bot bot;
@@ -26,6 +27,8 @@ class BotDetailView extends StatelessWidget {
               'Descrizione: ${bot.description}',
               style: Theme.of(context).textTheme.bodyLarge,  // Cambiato bodyText1 in bodyLarge
             ),
+            SizedBox(height: 16),
+            CompatibilityBadges(bot: bot, showHeading: true),
             SizedBox(height: 20),
             ElevatedButton(
               onPressed: () {


### PR DESCRIPTION
## Summary
- extend bot models and manifest template to include compat metadata
- add a system compatibility service that runs desktop runner checks and stores results
- surface compatibility badges in the UI when showing bot details or list entries

## Testing
- dart format lib *(fails: dart not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f2ac896c14832bb0087e24ddf37136