### PR TITLE
Add bot upload endpoint and frontend importer

### DIFF
--- a/lib/backend/server/exceptions/bot_upload_exception.dart
+++ b/lib/backend/server/exceptions/bot_upload_exception.dart
@@ -1,0 +1,9 @@
+class BotUploadException implements Exception {
+  BotUploadException(this.message, {this.statusCode = 400});
+
+  final String message;
+  final int statusCode;
+
+  @override
+  String toString() => 'BotUploadException: $message';
+}

--- a/lib/backend/server/models/bot.dart
+++ b/lib/backend/server/models/bot.dart
@@ -5,6 +5,7 @@ class Bot {
   final String startCommand;
   final String sourcePath;
   final String language;
+  final String origin;
 
   Bot({
     this.id,
@@ -13,12 +14,14 @@ class Bot {
     required this.startCommand,
     required this.sourcePath,
     required this.language,
+    required this.origin,
   });
 
   // Metodo factory per creare una nuova versione di Bot con dettagli aggiornati
   Bot copyWith({
     String? description,
     String? startCommand,
+    String? origin,
   }) {
     return Bot(
       id: id,
@@ -27,6 +30,7 @@ class Bot {
       startCommand: startCommand ?? this.startCommand,
       sourcePath: sourcePath,
       language: language,
+      origin: origin ?? this.origin,
     );
   }
 
@@ -38,6 +42,7 @@ class Bot {
       'start_command': startCommand,
       'source_path': sourcePath,
       'language': language,
+      'origin': origin,
     };
   }
 
@@ -49,6 +54,7 @@ class Bot {
       startCommand: map['start_command'] ?? '',
       sourcePath: map['source_path'],
       language: map['language'],
+      origin: map['origin'] ?? 'Remoto',
     );
   }
 }

--- a/lib/backend/server/routes.dart
+++ b/lib/backend/server/routes.dart
@@ -19,6 +19,7 @@ class BotRoutes {
         (Request request) => botController.fetchAvailableBots(request));
 
     router.get('/localbots', botController.fetchLocalBots);
+    router.post('/bots/upload', botController.uploadBot);
 
     return router;
   }

--- a/lib/backend/server/server.dart
+++ b/lib/backend/server/server.dart
@@ -6,6 +6,7 @@ import 'package:scriptagher/shared/constants/LOGS.dart';
 import 'controllers/bot_controller.dart';
 import 'services/bot_get_service.dart';
 import 'services/bot_download_service.dart';
+import 'services/bot_upload_service.dart';
 import 'db/bot_database.dart';
 import 'routes.dart';
 import 'package:scriptagher/backend/server/api_integration/github_api.dart';
@@ -19,7 +20,9 @@ Future<void> startServer() async {
   // Istanzia il BotService e BotController
   final botGetService = BotGetService(botDatabase, gitHubApi);
   final botDownloadService = BotDownloadService();
-  final botController = BotController(botDownloadService, botGetService);
+  final botUploadService = BotUploadService(botDatabase);
+  final botController =
+      BotController(botDownloadService, botGetService, botUploadService);
 
   // Ottieni il router con le rotte definite
   final botRoutes = BotRoutes(botController);
@@ -52,9 +55,8 @@ Middleware _logCustomRequests(CustomLogger logger) {
 
       // Logga i dettagli della richiesta, come i parametri
       if (request.method == 'POST' || request.method == 'PUT') {
-        // Logga il corpo della richiesta solo per POST o PUT
-        final requestBody = await request.readAsString();
-        logger.info(LOGS.REQUEST_LOG, 'Request Body: $requestBody');
+        logger.info(LOGS.REQUEST_LOG,
+            'Headers: ${request.headers} - Content-Length: ${request.contentLength}');
       }
 
       return innerHandler(request);

--- a/lib/backend/server/services/bot_download_service.dart
+++ b/lib/backend/server/services/bot_download_service.dart
@@ -40,6 +40,7 @@ class BotDownloadService {
       startCommand: botDetails['startCommand'],
       sourcePath: botJsonPath,
       language: language,
+      origin: 'Remoto',
     );
     await botDatabase.insertBot(bot);
     await botZip.delete();

--- a/lib/backend/server/services/bot_get_service.dart
+++ b/lib/backend/server/services/bot_get_service.dart
@@ -35,6 +35,7 @@ class BotGetService {
             startCommand: 'No start command',
             sourcePath: path,
             language: language,
+            origin: 'Remoto',
           );
 
           // Aggiorna ulteriormente con informazioni più precise
@@ -137,6 +138,7 @@ class BotGetService {
           startCommand: startCommand,
           sourcePath: sourceFile.path,
           language: language,
+          origin: 'Locali',
         );
 
         bots.add(bot);

--- a/lib/backend/server/services/bot_upload_service.dart
+++ b/lib/backend/server/services/bot_upload_service.dart
@@ -1,0 +1,195 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:http_parser/http_parser.dart';
+import 'package:mime/mime.dart';
+import 'package:path/path.dart' as p;
+import 'package:shelf/shelf.dart';
+import 'package:scriptagher/shared/constants/LOGS.dart';
+import 'package:scriptagher/shared/custom_logger.dart';
+import 'package:scriptagher/shared/utils/BotUtils.dart';
+import 'package:scriptagher/shared/utils/ZipUtils.dart';
+
+import '../db/bot_database.dart';
+import '../exceptions/bot_upload_exception.dart';
+import '../models/bot.dart';
+
+class BotUploadService {
+  BotUploadService(this._botDatabase);
+
+  final BotDatabase _botDatabase;
+  final CustomLogger logger = CustomLogger();
+
+  Future<Bot> handleUpload(Request request) async {
+    logger.info(LOGS.BOT_SERVICE, 'Processing bot upload request.');
+
+    final contentType = request.headers['content-type'];
+    if (contentType == null ||
+        !contentType.toLowerCase().startsWith('multipart/form-data')) {
+      throw BotUploadException('Content-Type multipart/form-data richiesto.');
+    }
+
+    final boundary = _extractBoundary(contentType);
+    if (boundary == null || boundary.isEmpty) {
+      throw BotUploadException('Boundary multipart non trovato.');
+    }
+
+    final transformer = MimeMultipartTransformer(boundary);
+    final parts = await transformer.bind(request.read()).toList();
+
+    if (parts.isEmpty) {
+      throw BotUploadException('Nessun file trovato nella richiesta.');
+    }
+
+    File? uploadedFile;
+    final tempDir = await Directory.systemTemp.createTemp('bot_upload_');
+    try {
+      for (final part in parts) {
+        final formData = HttpMultipartFormData.parse(part);
+        final name = formData.contentDisposition.parameters['name'];
+        if (name != 'file') {
+          // Ignora campi diversi dal file principale.
+          await _drainStream(formData);
+          continue;
+        }
+
+        final filename =
+            formData.contentDisposition.parameters['filename'] ?? 'upload.zip';
+        final bytes = await _collectBytes(formData);
+        final filePath = p.join(tempDir.path, filename);
+        final file = File(filePath);
+        await file.writeAsBytes(bytes);
+        uploadedFile = file;
+        break;
+      }
+
+      if (uploadedFile == null) {
+        throw BotUploadException('Campo file non presente nella richiesta.');
+      }
+
+      final extractionDir = Directory(p.join(tempDir.path, 'extracted'));
+      await extractionDir.create(recursive: true);
+
+      await _extractUploadedAsset(uploadedFile, extractionDir);
+
+      final manifestFile = await _findManifest(extractionDir);
+      if (manifestFile == null) {
+        throw BotUploadException('File Bot.json non trovato nell\'archivio.');
+      }
+
+      final manifest = await BotUtils.fetchBotDetails(manifestFile.path);
+      _validateManifest(manifest);
+
+      final botName = manifest['botName'] as String;
+      final language = manifest['language'] as String;
+      final description = manifest['description'] as String;
+      final startCommand = manifest['startCommand'] as String;
+
+      final botSourceDir = manifestFile.parent;
+      final targetDir =
+          Directory(p.join('localbots', language, botName));
+
+      if (await targetDir.exists()) {
+        await targetDir.delete(recursive: true);
+      }
+      await targetDir.create(recursive: true);
+
+      await _copyDirectory(botSourceDir, targetDir);
+
+      final localManifestPath = p.join(targetDir.path, 'Bot.json');
+      final bot = Bot(
+        botName: botName,
+        description: description,
+        startCommand: startCommand,
+        sourcePath: localManifestPath,
+        language: language,
+        origin: 'Locali',
+      );
+
+      await _botDatabase.insertOrUpdateLocalBot(bot);
+
+      logger.info(LOGS.BOT_SERVICE,
+          LOGS.BOT_UPLOADED.replaceFirst('%s', '$botName ($language)'));
+
+      return bot;
+    } on BotUploadException {
+      rethrow;
+    } catch (e) {
+      logger.error(LOGS.BOT_SERVICE, 'Errore durante l\'upload: $e');
+      throw BotUploadException('Errore interno durante l\'upload del bot.',
+          statusCode: 500);
+    } finally {
+      try {
+        await tempDir.delete(recursive: true);
+      } catch (_) {
+        logger.warn(LOGS.BOT_SERVICE, 'Impossibile cancellare la cartella temporanea.');
+      }
+    }
+  }
+
+  String? _extractBoundary(String contentType) {
+    final mimeType = HeaderValue.parse(contentType);
+    return mimeType.parameters['boundary'];
+  }
+
+  Future<List<int>> _collectBytes(HttpMultipartFormData data) async {
+    final buffer = <int>[];
+    await for (final chunk in data) {
+      buffer.addAll(chunk);
+    }
+    return buffer;
+  }
+
+  Future<void> _drainStream(Stream<List<int>> stream) async {
+    await for (final _ in stream) {
+      // discard
+    }
+  }
+
+  Future<void> _extractUploadedAsset(File uploadedFile, Directory destination) async {
+    if (uploadedFile.path.toLowerCase().endsWith('.zip')) {
+      await ZipUtils.unzipFile(uploadedFile.path, destination.path);
+    } else {
+      // If the user uploaded a single manifest or loose files, move them as-is.
+      final targetPath = p.join(destination.path, p.basename(uploadedFile.path));
+      await uploadedFile.copy(targetPath);
+    }
+  }
+
+  Future<File?> _findManifest(Directory root) async {
+    await for (final entity in root.list(recursive: true, followLinks: false)) {
+      if (entity is File &&
+          p.basename(entity.path).toLowerCase() == 'bot.json') {
+        return entity;
+      }
+    }
+    return null;
+  }
+
+  void _validateManifest(Map<String, dynamic> manifest) {
+    const requiredKeys = ['botName', 'language', 'description', 'startCommand'];
+    for (final key in requiredKeys) {
+      if (!manifest.containsKey(key) || manifest[key] == null) {
+        throw BotUploadException('Manifest mancante del campo obbligatorio: $key');
+      }
+      if (manifest[key] is String && (manifest[key] as String).trim().isEmpty) {
+        throw BotUploadException('Il campo "$key" nel manifest non può essere vuoto.');
+      }
+    }
+  }
+
+  Future<void> _copyDirectory(Directory source, Directory destination) async {
+    if (!await destination.exists()) {
+      await destination.create(recursive: true);
+    }
+
+    await for (final entity in source.list(recursive: false)) {
+      final newPath = p.join(destination.path, p.basename(entity.path));
+      if (entity is File) {
+        await entity.copy(newPath);
+      } else if (entity is Directory) {
+        await _copyDirectory(entity, Directory(newPath));
+      }
+    }
+  }
+}

--- a/lib/frontend/models/bot.dart
+++ b/lib/frontend/models/bot.dart
@@ -5,6 +5,7 @@ class Bot {
   final String startCommand;
   final String sourcePath;
   final String language;
+  final String origin;
 
   Bot({
     this.id,
@@ -13,12 +14,14 @@ class Bot {
     required this.startCommand,
     required this.sourcePath,
     required this.language,
+    required this.origin,
   });
 
   // Metodo factory per creare una nuova versione di Bot con dettagli aggiornati
   Bot copyWith({
     String? description,
     String? startCommand,
+    String? origin,
   }) {
     return Bot(
       id: id,
@@ -27,6 +30,7 @@ class Bot {
       startCommand: startCommand ?? this.startCommand,
       sourcePath: sourcePath,
       language: language,
+      origin: origin ?? this.origin,
     );
   }
 
@@ -38,6 +42,7 @@ class Bot {
       'start_command': startCommand,
       'source_path': sourcePath,
       'language': language,
+      'origin': origin,
     };
   }
 
@@ -49,6 +54,7 @@ class Bot {
       startCommand: map['start_command'] ?? '',
       sourcePath: map['source_path'],
       language: map['language'],
+      origin: map['origin'] ?? 'Remoto',
     );
   }
 
@@ -59,6 +65,7 @@ class Bot {
       startCommand: json['start_command'] ?? '',
       sourcePath: json['source_path'] ?? '',
       language: json['language'] ?? '',
+      origin: json['origin'] ?? 'Remoto',
     );
   }
 }

--- a/lib/frontend/services/bot_upload_service.dart
+++ b/lib/frontend/services/bot_upload_service.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive_io.dart';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+
+import '../models/bot.dart';
+
+class BotUploadService {
+  BotUploadService({this.baseUrl = 'http://localhost:8080'});
+
+  final String baseUrl;
+
+  Future<Bot> uploadZip(File file) async {
+    return _sendFile(file);
+  }
+
+  Future<Bot> uploadDirectory(String directoryPath) async {
+    final directory = Directory(directoryPath);
+    if (!directory.existsSync()) {
+      throw Exception('Directory non trovata: $directoryPath');
+    }
+
+    final tempDir = await Directory.systemTemp.createTemp('bot_upload_');
+    final zipPath = p.join(tempDir.path, '${p.basename(directory.path)}.zip');
+
+    final encoder = ZipFileEncoder();
+    encoder.create(zipPath);
+    encoder.addDirectory(directory, includeDirName: true);
+    encoder.close();
+
+    final zipFile = File(zipPath);
+    try {
+      final bot = await _sendFile(zipFile);
+      return bot;
+    } finally {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    }
+  }
+
+  Future<Bot> _sendFile(File file) async {
+    final uri = Uri.parse('$baseUrl/bots/upload');
+    final request = http.MultipartRequest('POST', uri);
+    request.files.add(await http.MultipartFile.fromPath('file', file.path));
+
+    final streamedResponse = await request.send();
+    final responseBody = await streamedResponse.stream.bytesToString();
+
+    if (streamedResponse.statusCode >= 200 && streamedResponse.statusCode < 300) {
+      final data = jsonDecode(responseBody) as Map<String, dynamic>;
+      return Bot.fromJson(data);
+    } else {
+      String message = 'Upload fallito (status ${streamedResponse.statusCode})';
+      try {
+        final error = jsonDecode(responseBody);
+        if (error is Map && error['error'] is String) {
+          message = error['error'] as String;
+        }
+      } catch (_) {
+        // Ignore parse errors.
+      }
+      throw Exception(message);
+    }
+  }
+}

--- a/lib/frontend/widgets/components/bot_card_component.dart
+++ b/lib/frontend/widgets/components/bot_card_component.dart
@@ -13,7 +13,7 @@ class BotCard extends StatelessWidget {
       margin: EdgeInsets.symmetric(vertical: 8, horizontal: 16),
       child: ListTile(
         title: Text(bot.botName),
-        subtitle: Text(bot.description),
+        subtitle: Text('${bot.origin} • ${bot.description}'),
         onTap: onTap,
       ),
     );

--- a/lib/frontend/widgets/pages/bot_list_view.dart
+++ b/lib/frontend/widgets/pages/bot_list_view.dart
@@ -1,6 +1,10 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import '../../models/bot.dart';
 import '../../services/bot_get_service.dart';
+import '../../services/bot_upload_service.dart';
 import '../components/bot_card_component.dart';
 import 'bot_detail_view.dart';
 
@@ -14,6 +18,7 @@ class _BotListState extends State<BotList> {
   late Future<List<Bot>> _localBots;
 
   final BotGetService _botGetService = BotGetService();
+  final BotUploadService _botUploadService = BotUploadService();
 
   @override
   void initState() {
@@ -26,6 +31,11 @@ class _BotListState extends State<BotList> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text('Lista dei Bot')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _showUploadOptions,
+        child: Icon(Icons.upload_file),
+        tooltip: 'Importa bot locale',
+      ),
       body: FutureBuilder<Map<String, List<Bot>>>(
         future: _remoteBots,
         builder: (context, remoteSnapshot) {
@@ -99,5 +109,91 @@ class _BotListState extends State<BotList> {
         },
       ),
     );
+  }
+
+  void _showUploadOptions() {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) {
+        return SafeArea(
+          child: Wrap(
+            children: [
+              ListTile(
+                leading: Icon(Icons.archive_outlined),
+                title: Text('Carica archivio ZIP'),
+                onTap: () {
+                  Navigator.of(context).pop();
+                  _pickZipAndUpload();
+                },
+              ),
+              ListTile(
+                leading: Icon(Icons.folder_open),
+                title: Text('Carica cartella'),
+                onTap: () {
+                  Navigator.of(context).pop();
+                  _pickDirectoryAndUpload();
+                },
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _pickZipAndUpload() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['zip'],
+    );
+    final path = result?.files.single.path;
+    if (path == null) return;
+    final file = File(path);
+    await _uploadBot(() => _botUploadService.uploadZip(file));
+  }
+
+  Future<void> _pickDirectoryAndUpload() async {
+    final directoryPath = await FilePicker.platform.getDirectoryPath();
+    if (directoryPath == null) return;
+    await _uploadBot(() => _botUploadService.uploadDirectory(directoryPath));
+  }
+
+  Future<void> _uploadBot(Future<Bot> Function() uploader) async {
+    if (!mounted) return;
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => const Center(child: CircularProgressIndicator()),
+    );
+
+    Bot? uploadedBot;
+    Object? error;
+
+    try {
+      uploadedBot = await uploader();
+    } catch (e) {
+      error = e;
+    }
+
+    if (!mounted) return;
+    Navigator.of(context, rootNavigator: true).pop();
+
+    if (error != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Errore durante il caricamento: $error')),
+      );
+      return;
+    }
+
+    if (uploadedBot != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+            content:
+                Text('Bot "${uploadedBot.botName}" importato con successo.')),
+      );
+      setState(() {
+        _localBots = _botGetService.fetchLocalBotsFlat();
+      });
+    }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,9 @@ dependencies:
   bitsdojo_window: ^0.1.6
   carousel_slider: ^5.0.0
   url_launcher: ^6.3.1
+  file_picker: ^8.0.5
+  mime: ^1.0.5
+  http_parser: ^4.0.2
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- add a backend bot upload endpoint that extracts archives, validates Bot.json manifests, and persists the bots as local entries
- extend the database schema and bot models with an origin flag so imported bots surface in the local tab
- wire a frontend file picker and upload service to send zip files or directories and refresh the local bot list after successful imports

## Testing
- flutter pub get *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f2ac847830832ba43f50c949b9840a