### PR TITLE
Add metadata-aware bot filters and frontend search

### DIFF
--- a/lib/backend/server/api_integration/github_api.dart
+++ b/lib/backend/server/api_integration/github_api.dart
@@ -16,7 +16,23 @@ class GitHubApi {
       final response = await http.get(Uri.parse('$baseUrl/bots.json'));
 
       if (response.statusCode == 200) {
-        return json.decode(response.body); // Restituisce la mappa dei bot
+        final decoded = json.decode(response.body);
+
+        if (decoded is Map<String, dynamic>) {
+          decoded.forEach((language, bots) {
+            if (bots is List) {
+              for (final bot in bots.whereType<Map>()) {
+                final normalized = _normalizeBotEntry(language, bot);
+                bot
+                  ..clear()
+                  ..addAll(normalized);
+              }
+            }
+          });
+          return decoded;
+        }
+
+        return {};
       } else {
         logger.error('GitHubApi',
             'Failed to fetch bots list. Status code: ${response.statusCode}');
@@ -36,7 +52,11 @@ class GitHubApi {
       final response = await http.get(Uri.parse(botJsonUrl));
 
       if (response.statusCode == 200) {
-        return json.decode(response.body); // Restituisce i dettagli del bot
+        final decoded = json.decode(response.body);
+        if (decoded is Map<String, dynamic>) {
+          return _normalizeBotDetails(decoded);
+        }
+        return {};
       } else {
         logger.error('GitHubApi',
             'Failed to fetch Bot.json for $botName. Status code: ${response.statusCode}');
@@ -46,5 +66,69 @@ class GitHubApi {
       logger.error('GitHubApi', 'Error fetching Bot.json for $botName: $e');
       rethrow;
     }
+  }
+
+  Map<String, dynamic> _normalizeBotEntry(
+      String language, Map<dynamic, dynamic> bot) {
+    final metadata =
+        (bot['metadata'] as Map?)?.cast<String, dynamic>() ??
+            const <String, dynamic>{};
+    final tags = _parseTags(bot['tags'] ?? metadata['tags']);
+
+    final normalizedMetadata = {
+      ...metadata,
+      'tags': tags,
+      'author': metadata['author']?.toString() ?? bot['author']?.toString() ?? '',
+      'version':
+          metadata['version']?.toString() ?? bot['version']?.toString() ?? '',
+    };
+
+    return {
+      ...bot.map((key, value) => MapEntry(key.toString(), value)),
+      'language': bot['language']?.toString() ?? language,
+      'tags': tags,
+      'author': normalizedMetadata['author'],
+      'version': normalizedMetadata['version'],
+      'metadata': normalizedMetadata,
+    };
+  }
+
+  Map<String, dynamic> _normalizeBotDetails(Map<String, dynamic> botDetails) {
+    final metadata =
+        (botDetails['metadata'] as Map?)?.cast<String, dynamic>() ??
+            const <String, dynamic>{};
+    final tags = _parseTags(botDetails['tags'] ?? metadata['tags']);
+
+    final normalizedMetadata = {
+      ...metadata,
+      'tags': tags,
+      'author': metadata['author']?.toString() ?? botDetails['author']?.toString() ?? '',
+      'version': metadata['version']?.toString() ??
+          botDetails['version']?.toString() ??
+          '',
+    };
+
+    return {
+      ...botDetails,
+      'tags': tags,
+      'author': normalizedMetadata['author'],
+      'version': normalizedMetadata['version'],
+      'metadata': normalizedMetadata,
+    };
+  }
+
+  List<String> _parseTags(dynamic tags) {
+    if (tags == null) return [];
+    if (tags is List) {
+      return tags.map((tag) => tag.toString()).toList();
+    }
+    if (tags is String && tags.isNotEmpty) {
+      return tags
+          .split(',')
+          .map((tag) => tag.trim())
+          .where((tag) => tag.isNotEmpty)
+          .toList();
+    }
+    return [];
   }
 }

--- a/lib/backend/server/controllers/bot_controller.dart
+++ b/lib/backend/server/controllers/bot_controller.dart
@@ -26,7 +26,7 @@ class BotController {
       // Rispondi con la lista di bot in formato JSON
       return Response.ok(
           json.encode(availableBots
-              .map((bot) => bot.toMap())
+              .map((bot) => bot.toJson())
               .toList()), // Converte ogni bot in una mappa JSON
           headers: {'Content-Type': 'application/json'});
     } catch (e) {
@@ -54,7 +54,7 @@ class BotController {
           LOGS.BOT_SERVICE, 'Downloaded bot ${bot.botName} successfully.');
 
       // Rispondi con i dettagli del bot come JSON
-      return Response.ok(json.encode(bot.toMap()),
+      return Response.ok(json.encode(bot.toJson()),
           headers: {'Content-Type': 'application/json'});
     } catch (e) {
       logger.error(LOGS.BOT_SERVICE, 'Error downloading bot: $e');
@@ -75,7 +75,7 @@ class BotController {
 
       logger.info(LOGS.BOT_SERVICE, 'Fetched ${localBots.length} local bots.');
       return Response.ok(
-        json.encode(localBots.map((bot) => bot.toMap()).toList()),
+        json.encode(localBots.map((bot) => bot.toJson()).toList()),
         headers: {'Content-Type': 'application/json'},
       );
     } catch (e) {

--- a/lib/backend/server/models/bot.dart
+++ b/lib/backend/server/models/bot.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 class Bot {
   final int? id;
   final String botName;
@@ -5,20 +7,29 @@ class Bot {
   final String startCommand;
   final String sourcePath;
   final String language;
+  final List<String> tags;
+  final String author;
+  final String version;
 
-  Bot({
+  const Bot({
     this.id,
     required this.botName,
     required this.description,
     required this.startCommand,
     required this.sourcePath,
     required this.language,
+    this.tags = const [],
+    this.author = '',
+    this.version = '',
   });
 
   // Metodo factory per creare una nuova versione di Bot con dettagli aggiornati
   Bot copyWith({
     String? description,
     String? startCommand,
+    List<String>? tags,
+    String? author,
+    String? version,
   }) {
     return Bot(
       id: id,
@@ -27,10 +38,13 @@ class Bot {
       startCommand: startCommand ?? this.startCommand,
       sourcePath: sourcePath,
       language: language,
+      tags: tags ?? this.tags,
+      author: author ?? this.author,
+      version: version ?? this.version,
     );
   }
 
-  Map<String, dynamic> toMap() {
+  Map<String, dynamic> toDbMap() {
     return {
       'id': id,
       'bot_name': botName,
@@ -38,10 +52,27 @@ class Bot {
       'start_command': startCommand,
       'source_path': sourcePath,
       'language': language,
+      'tags': jsonEncode(tags),
+      'author': author,
+      'version': version,
     };
   }
 
-  factory Bot.fromMap(Map<String, dynamic> map) {
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'bot_name': botName,
+      'description': description,
+      'start_command': startCommand,
+      'source_path': sourcePath,
+      'language': language,
+      'tags': tags,
+      'author': author,
+      'version': version,
+    };
+  }
+
+  factory Bot.fromDbMap(Map<String, dynamic> map) {
     return Bot(
       id: map['id'],
       botName: map['bot_name'],
@@ -49,6 +80,60 @@ class Bot {
       startCommand: map['start_command'] ?? '',
       sourcePath: map['source_path'],
       language: map['language'],
+      tags: _decodeTags(map['tags']),
+      author: map['author'] ?? '',
+      version: map['version'] ?? '',
     );
+  }
+
+  factory Bot.fromJson(Map<String, dynamic> json) {
+    return Bot(
+      id: json['id'],
+      botName: json['bot_name'] ?? '',
+      description: json['description'] ?? '',
+      startCommand: json['start_command'] ?? '',
+      sourcePath: json['source_path'] ?? '',
+      language: json['language'] ?? '',
+      tags: _decodeTags(json['tags']),
+      author: json['author'] ?? '',
+      version: json['version'] ?? '',
+    );
+  }
+
+  static List<String> _decodeTags(dynamic rawTags) {
+    if (rawTags == null) {
+      return const [];
+    }
+
+    if (rawTags is String && rawTags.isEmpty) {
+      return const [];
+    }
+
+    try {
+      if (rawTags is String) {
+        final decoded = jsonDecode(rawTags);
+        if (decoded is List) {
+          return decoded.map((tag) => tag.toString()).toList();
+        }
+        return rawTags
+            .split(',')
+            .map((tag) => tag.trim())
+            .where((tag) => tag.isNotEmpty)
+            .toList();
+      }
+
+      if (rawTags is List) {
+        return rawTags.map((tag) => tag.toString()).toList();
+      }
+    } catch (_) {
+      return rawTags
+          .toString()
+          .split(',')
+          .map((tag) => tag.trim())
+          .where((tag) => tag.isNotEmpty)
+          .toList();
+    }
+
+    return const [];
   }
 }

--- a/lib/frontend/models/bot.dart
+++ b/lib/frontend/models/bot.dart
@@ -5,20 +5,29 @@ class Bot {
   final String startCommand;
   final String sourcePath;
   final String language;
+  final List<String> tags;
+  final String author;
+  final String version;
 
-  Bot({
+  const Bot({
     this.id,
     required this.botName,
     required this.description,
     required this.startCommand,
     required this.sourcePath,
     required this.language,
+    this.tags = const [],
+    this.author = '',
+    this.version = '',
   });
 
   // Metodo factory per creare una nuova versione di Bot con dettagli aggiornati
   Bot copyWith({
     String? description,
     String? startCommand,
+    List<String>? tags,
+    String? author,
+    String? version,
   }) {
     return Bot(
       id: id,
@@ -27,10 +36,13 @@ class Bot {
       startCommand: startCommand ?? this.startCommand,
       sourcePath: sourcePath,
       language: language,
+      tags: tags ?? this.tags,
+      author: author ?? this.author,
+      version: version ?? this.version,
     );
   }
 
-  Map<String, dynamic> toMap() {
+  Map<String, dynamic> toJson() {
     return {
       'id': id,
       'bot_name': botName,
@@ -38,27 +50,38 @@ class Bot {
       'start_command': startCommand,
       'source_path': sourcePath,
       'language': language,
+      'tags': tags,
+      'author': author,
+      'version': version,
     };
-  }
-
-  factory Bot.fromMap(Map<String, dynamic> map) {
-    return Bot(
-      id: map['id'],
-      botName: map['bot_name'],
-      description: map['description'] ?? '',
-      startCommand: map['start_command'] ?? '',
-      sourcePath: map['source_path'],
-      language: map['language'],
-    );
   }
 
   factory Bot.fromJson(Map<String, dynamic> json) {
     return Bot(
-      botName: json['bot_name'] ?? '',
-      description: json['description'] ?? '',
-      startCommand: json['start_command'] ?? '',
-      sourcePath: json['source_path'] ?? '',
-      language: json['language'] ?? '',
+      id: json['id'],
+      botName: json['bot_name']?.toString() ?? '',
+      description: json['description']?.toString() ?? '',
+      startCommand: json['start_command']?.toString() ?? '',
+      sourcePath: json['source_path']?.toString() ?? '',
+      language: json['language']?.toString() ?? '',
+      tags: _parseTags(json['tags']),
+      author: json['author']?.toString() ?? '',
+      version: json['version']?.toString() ?? '',
     );
+  }
+
+  static List<String> _parseTags(dynamic rawTags) {
+    if (rawTags == null) return const [];
+    if (rawTags is List) {
+      return rawTags.map((tag) => tag.toString()).toList();
+    }
+    if (rawTags is String && rawTags.isNotEmpty) {
+      return rawTags
+          .split(',')
+          .map((tag) => tag.trim())
+          .where((tag) => tag.isNotEmpty)
+          .toList();
+    }
+    return const [];
   }
 }

--- a/lib/frontend/services/bot_get_service.dart
+++ b/lib/frontend/services/bot_get_service.dart
@@ -2,12 +2,52 @@ import 'package:http/http.dart' as http;
 import 'dart:convert';
 import '../models/bot.dart';
 
+class BotFilters {
+  final String query;
+  final String? language;
+  final String? tag;
+  final String? author;
+  final String? version;
+
+  const BotFilters({
+    this.query = '',
+    this.language,
+    this.tag,
+    this.author,
+    this.version,
+  });
+
+  bool get hasFilters {
+    return query.isNotEmpty ||
+        language != null ||
+        tag != null ||
+        author != null ||
+        version != null;
+  }
+
+  BotFilters copyWith({
+    String? query,
+    String? language,
+    String? tag,
+    String? author,
+    String? version,
+  }) {
+    return BotFilters(
+      query: query ?? this.query,
+      language: language ?? this.language,
+      tag: tag ?? this.tag,
+      author: author ?? this.author,
+      version: version ?? this.version,
+    );
+  }
+}
+
 class BotGetService {
   final String baseUrl;
 
   BotGetService({this.baseUrl = 'http://localhost:8080'});
 
-  Future<Map<String, List<Bot>>> fetchBots() async {
+  Future<Map<String, List<Bot>>> fetchBots({BotFilters filters = const BotFilters()}) async {
     final url = Uri.parse('$baseUrl/bots');
 
     try {
@@ -22,7 +62,9 @@ class BotGetService {
           groupedBots.putIfAbsent(bot.language, () => []).add(bot);
         }
 
-        return groupedBots;
+        return filters.hasFilters
+            ? filterGroupedBots(groupedBots, filters)
+            : groupedBots;
       } else {
         throw Exception(
             'Failed to load bots. Status Code: ${response.statusCode}');
@@ -32,12 +74,12 @@ class BotGetService {
     }
   }
 
-  Future<List<Bot>> fetchLocalBotsFlat() async {
-    final grouped = await fetchLocalBots();
+  Future<List<Bot>> fetchLocalBotsFlat({BotFilters filters = const BotFilters()}) async {
+    final grouped = await fetchLocalBots(filters: filters);
     return grouped.values.expand((bots) => bots).toList();
   }
 
-  Future<Map<String, List<Bot>>> fetchLocalBots() async {
+  Future<Map<String, List<Bot>>> fetchLocalBots({BotFilters filters = const BotFilters()}) async {
     final url = Uri.parse('$baseUrl/localbots');
 
     try {
@@ -52,7 +94,9 @@ class BotGetService {
           groupedBots.putIfAbsent(bot.language, () => []).add(bot);
         }
 
-        return groupedBots;
+        return filters.hasFilters
+            ? filterGroupedBots(groupedBots, filters)
+            : groupedBots;
       } else {
         throw Exception(
             'Failed to load local bots. Status Code: ${response.statusCode}');
@@ -60,5 +104,50 @@ class BotGetService {
     } catch (e) {
       throw Exception('Failed to fetch local bots: $e');
     }
+  }
+
+  Map<String, List<Bot>> filterGroupedBots(
+      Map<String, List<Bot>> groupedBots, BotFilters filters) {
+    final Map<String, List<Bot>> filtered = {};
+
+    groupedBots.forEach((language, bots) {
+      final filteredBots = bots.where((bot) => _matchesFilters(bot, filters)).toList();
+      if (filteredBots.isNotEmpty) {
+        filtered[language] = filteredBots;
+      }
+    });
+
+    return filtered;
+  }
+
+  List<Bot> filterBots(List<Bot> bots, BotFilters filters) {
+    return bots.where((bot) => _matchesFilters(bot, filters)).toList();
+  }
+
+  bool _matchesFilters(Bot bot, BotFilters filters) {
+    final query = filters.query.toLowerCase();
+
+    final matchesQuery = query.isEmpty ||
+        bot.botName.toLowerCase().contains(query) ||
+        bot.description.toLowerCase().contains(query) ||
+        bot.language.toLowerCase().contains(query) ||
+        bot.author.toLowerCase().contains(query) ||
+        bot.version.toLowerCase().contains(query) ||
+        bot.tags.any((tag) => tag.toLowerCase().contains(query));
+
+    final matchesLanguage = filters.language == null ||
+        bot.language.toLowerCase() == filters.language!.toLowerCase();
+    final matchesTag = filters.tag == null ||
+        bot.tags.any((tag) => tag.toLowerCase() == filters.tag!.toLowerCase());
+    final matchesAuthor = filters.author == null ||
+        bot.author.toLowerCase() == filters.author!.toLowerCase();
+    final matchesVersion = filters.version == null ||
+        bot.version.toLowerCase() == filters.version!.toLowerCase();
+
+    return matchesQuery &&
+        matchesLanguage &&
+        matchesTag &&
+        matchesAuthor &&
+        matchesVersion;
   }
 }

--- a/lib/frontend/widgets/components/bot_card_component.dart
+++ b/lib/frontend/widgets/components/bot_card_component.dart
@@ -13,7 +13,39 @@ class BotCard extends StatelessWidget {
       margin: EdgeInsets.symmetric(vertical: 8, horizontal: 16),
       child: ListTile(
         title: Text(bot.botName),
-        subtitle: Text(bot.description),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(bot.description),
+            if (bot.author.isNotEmpty || bot.version.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 4.0),
+                child: Text(
+                  [
+                    if (bot.author.isNotEmpty) 'Autore: ${bot.author}',
+                    if (bot.version.isNotEmpty) 'Versione: ${bot.version}',
+                  ].join(' • '),
+                  style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+                ),
+              ),
+            if (bot.tags.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 4.0),
+                child: Wrap(
+                  spacing: 4,
+                  runSpacing: -8,
+                  children: bot.tags
+                      .map((tag) => Chip(
+                            label: Text(tag),
+                            visualDensity: VisualDensity.compact,
+                            materialTapTargetSize:
+                                MaterialTapTargetSize.shrinkWrap,
+                          ))
+                      .toList(),
+                ),
+              ),
+          ],
+        ),
         onTap: onTap,
       ),
     );

--- a/lib/frontend/widgets/components/search_component.dart
+++ b/lib/frontend/widgets/components/search_component.dart
@@ -1,54 +1,64 @@
 import 'package:flutter/material.dart';
 
 class SearchView extends StatefulWidget {
+  final TextEditingController controller;
+  final ValueChanged<String>? onChanged;
+  final VoidCallback? onClear;
+  final String hintText;
+
+  const SearchView({
+    super.key,
+    required this.controller,
+    this.onChanged,
+    this.onClear,
+    this.hintText = 'Cerca un bot',
+  });
+
   @override
-  _SearchViewState createState() => _SearchViewState();
+  State<SearchView> createState() => _SearchViewState();
 }
 
 class _SearchViewState extends State<SearchView> {
-  // Controller per la barra di ricerca
-  TextEditingController _searchController = TextEditingController();
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_controllerListener);
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_controllerListener);
+    super.dispose();
+  }
+
+  void _controllerListener() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text('Cerca Bot'),
-        backgroundColor: Colors.blue,
+    final hasText = widget.controller.text.isNotEmpty;
+
+    return TextField(
+      controller: widget.controller,
+      decoration: InputDecoration(
+        labelText: widget.hintText,
+        border: const OutlineInputBorder(),
+        prefixIcon: const Icon(Icons.search),
+        suffixIcon: hasText
+            ? IconButton(
+                icon: const Icon(Icons.clear),
+                onPressed: () {
+                  widget.controller.clear();
+                  widget.onClear?.call();
+                  widget.onChanged?.call('');
+                },
+              )
+            : null,
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          children: [
-            // Barra di ricerca
-            TextField(
-              controller: _searchController,
-              decoration: InputDecoration(
-                labelText: 'Cerca un bot',
-                border: OutlineInputBorder(),
-                suffixIcon: IconButton(
-                  icon: Icon(Icons.search),
-                  onPressed: () {
-                    // Qui andrà il codice per eseguire la ricerca una volta integrato il backend
-                    print('Cercando: ${_searchController.text}');
-                  },
-                ),
-              ),
-              onChanged: (value) {
-                // Gestisci l'input dell'utente se necessario
-                print('Ricerca in corso per: $value');
-              },
-            ),
-            SizedBox(height: 20),
-            // Un semplice testo che mostra il termine cercato
-            Text(
-              'Risultati per: ${_searchController.text}',
-              style: TextStyle(fontSize: 18),
-            ),
-            // Altri widget che mostreranno i risultati della ricerca (da aggiungere più tardi)
-          ],
-        ),
-      ),
+      onChanged: widget.onChanged,
     );
   }
 }

--- a/lib/frontend/widgets/pages/bot_list_view.dart
+++ b/lib/frontend/widgets/pages/bot_list_view.dart
@@ -1,103 +1,350 @@
 import 'package:flutter/material.dart';
+
 import '../../models/bot.dart';
 import '../../services/bot_get_service.dart';
 import '../components/bot_card_component.dart';
+import '../components/search_component.dart';
 import 'bot_detail_view.dart';
 
 class BotList extends StatefulWidget {
   @override
-  _BotListState createState() => _BotListState();
+  State<BotList> createState() => _BotListState();
 }
 
 class _BotListState extends State<BotList> {
-  late Future<Map<String, List<Bot>>> _remoteBots;
-  late Future<List<Bot>> _localBots;
-
   final BotGetService _botGetService = BotGetService();
+  final TextEditingController _searchController = TextEditingController();
+
+  late Future<void> _loadFuture;
+
+  Map<String, List<Bot>> _remoteBots = {};
+  List<Bot> _localBots = [];
+
+  Map<String, List<Bot>> _filteredRemoteBots = {};
+  List<Bot> _filteredLocalBots = [];
+
+  List<String> _availableLanguages = [];
+  List<String> _availableTags = [];
+  List<String> _availableAuthors = [];
+  List<String> _availableVersions = [];
+
+  BotFilters _filters = const BotFilters();
 
   @override
   void initState() {
     super.initState();
-    _remoteBots = _botGetService.fetchBots();
-    _localBots = _botGetService.fetchLocalBotsFlat();
+    _loadFuture = _loadBots();
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadBots() async {
+    final remote = await _botGetService.fetchBots();
+    final local = await _botGetService.fetchLocalBotsFlat();
+
+    if (!mounted) return;
+
+    final allBots = [
+      ...remote.values.expand((bots) => bots),
+      ...local,
+    ];
+
+    final languages = _sortedUnique(allBots.map((bot) => bot.language));
+    final tags = _sortedUnique(allBots.expand((bot) => bot.tags));
+    final authors = _sortedUnique(
+        allBots.map((bot) => bot.author).where((author) => author.isNotEmpty));
+    final versions = _sortedUnique(allBots
+        .map((bot) => bot.version)
+        .where((version) => version.isNotEmpty));
+
+    final sanitizedFilters = _filters.copyWith(
+      language: _sanitizeSelection(_filters.language, languages),
+      tag: _sanitizeSelection(_filters.tag, tags),
+      author: _sanitizeSelection(_filters.author, authors),
+      version: _sanitizeSelection(_filters.version, versions),
+    );
+
+    setState(() {
+      _remoteBots = remote;
+      _localBots = local;
+      _availableLanguages = languages;
+      _availableTags = tags;
+      _availableAuthors = authors;
+      _availableVersions = versions;
+      _filters = sanitizedFilters;
+    });
+
+    _applyFilters();
+  }
+
+  List<String> _sortedUnique(Iterable<String> values) {
+    final Map<String, String> normalized = {};
+    for (final value in values) {
+      final trimmed = value.trim();
+      if (trimmed.isEmpty) continue;
+      final lower = trimmed.toLowerCase();
+      normalized.putIfAbsent(lower, () => trimmed);
+    }
+    final list = normalized.values.toList();
+    list.sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
+    return list;
+  }
+
+  String? _sanitizeSelection(String? current, List<String> options) {
+    if (current == null) return null;
+    for (final option in options) {
+      if (option.toLowerCase() == current.toLowerCase()) {
+        return option;
+      }
+    }
+    return null;
+  }
+
+  void _applyFilters() {
+    if (!mounted) return;
+    final updatedFilters =
+        _filters.copyWith(query: _searchController.text.trim());
+
+    setState(() {
+      _filters = updatedFilters;
+      _filteredRemoteBots =
+          _botGetService.filterGroupedBots(_remoteBots, updatedFilters);
+      _filteredLocalBots =
+          _botGetService.filterBots(_localBots, updatedFilters);
+    });
+  }
+
+  Future<void> _refreshBots() {
+    final future = _loadBots();
+    setState(() {
+      _loadFuture = future;
+    });
+    return future;
+  }
+
+  void _resetAllFilters() {
+    _searchController.clear();
+    _filters = const BotFilters();
+    _applyFilters();
+  }
+
+  void _onSearchCleared() {
+    _applyFilters();
+  }
+
+  void _updateLanguageFilter(String? language) {
+    _filters = _filters.copyWith(language: language);
+    _applyFilters();
+  }
+
+  void _updateTagFilter(String? tag) {
+    _filters = _filters.copyWith(tag: tag);
+    _applyFilters();
+  }
+
+  void _updateAuthorFilter(String? author) {
+    _filters = _filters.copyWith(author: author);
+    _applyFilters();
+  }
+
+  void _updateVersionFilter(String? version) {
+    _filters = _filters.copyWith(version: version);
+    _applyFilters();
+  }
+
+  int _countRemoteFilteredBots() {
+    return _filteredRemoteBots.values
+        .fold(0, (total, bots) => total + bots.length);
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('Lista dei Bot')),
-      body: FutureBuilder<Map<String, List<Bot>>>(
-        future: _remoteBots,
-        builder: (context, remoteSnapshot) {
-          return FutureBuilder<List<Bot>>(
-            future: _localBots,
-            builder: (context, localSnapshot) {
-              if (remoteSnapshot.connectionState == ConnectionState.waiting ||
-                  localSnapshot.connectionState == ConnectionState.waiting) {
-                return Center(child: CircularProgressIndicator());
-              }
+      appBar: AppBar(title: const Text('Lista dei Bot')),
+      body: FutureBuilder<void>(
+        future: _loadFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
 
-              if (remoteSnapshot.hasError) {
-                return Center(
-                    child: Text('Errore remoto: ${remoteSnapshot.error}'));
-              }
+          if (snapshot.hasError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Text('Errore durante il caricamento dei bot: '
+                    '${snapshot.error}'),
+              ),
+            );
+          }
 
-              if (localSnapshot.hasError) {
-                return Center(
-                    child: Text('Errore locale: ${localSnapshot.error}'));
-              }
-
-              final remoteData = remoteSnapshot.data ?? {};
-              final localData = localSnapshot.data ?? [];
-
-              return ListView(
-                children: [
-                  ExpansionTile(
-                    title: Text('Local Bots'),
-                    children: localData.map((bot) {
-                      return BotCard(
-                        bot: bot,
-                        onTap: () {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (_) => BotDetailView(bot: bot),
-                            ),
-                          );
-                        },
-                      );
-                    }).toList(),
+          return RefreshIndicator(
+            onRefresh: _refreshBots,
+            child: ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SearchView(
+                        controller: _searchController,
+                        onChanged: (_) => _applyFilters(),
+                        onClear: _onSearchCleared,
+                        hintText: 'Cerca per nome, descrizione, tag...',
+                      ),
+                      const SizedBox(height: 16),
+                      Wrap(
+                        spacing: 16,
+                        runSpacing: 12,
+                        children: [
+                          _buildFilterDropdown(
+                            label: 'Lingua',
+                            value: _filters.language,
+                            options: _availableLanguages,
+                            onChanged: _updateLanguageFilter,
+                          ),
+                          _buildFilterDropdown(
+                            label: 'Tag',
+                            value: _filters.tag,
+                            options: _availableTags,
+                            onChanged: _updateTagFilter,
+                          ),
+                          _buildFilterDropdown(
+                            label: 'Autore',
+                            value: _filters.author,
+                            options: _availableAuthors,
+                            onChanged: _updateAuthorFilter,
+                          ),
+                          _buildFilterDropdown(
+                            label: 'Versione',
+                            value: _filters.version,
+                            options: _availableVersions,
+                            onChanged: _updateVersionFilter,
+                          ),
+                        ],
+                      ),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: TextButton.icon(
+                          onPressed: _resetAllFilters,
+                          icon: const Icon(Icons.filter_alt_off),
+                          label: const Text('Reset filtri'),
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      _buildLocalSection(),
+                      const SizedBox(height: 24),
+                      _buildRemoteSection(),
+                    ],
                   ),
-                  ExpansionTile(
-                    title: Text('Remote Bots'),
-                    children: remoteData.entries.map((entry) {
-                      final language = entry.key;
-                      final bots = entry.value;
-
-                      return ExpansionTile(
-                        title: Text(language),
-                        children: bots.map((bot) {
-                          return BotCard(
-                            bot: bot,
-                            onTap: () {
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                  builder: (_) => BotDetailView(bot: bot),
-                                ),
-                              );
-                            },
-                          );
-                        }).toList(),
-                      );
-                    }).toList(),
-                  ),
-                ],
-              );
-            },
+                ),
+              ],
+            ),
           );
         },
       ),
+    );
+  }
+
+  Widget _buildFilterDropdown({
+    required String label,
+    required String? value,
+    required List<String> options,
+    required ValueChanged<String?> onChanged,
+  }) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minWidth: 200, maxWidth: 260),
+      child: DropdownButtonFormField<String?>(
+        value: value,
+        decoration: InputDecoration(labelText: label),
+        items: [
+          const DropdownMenuItem<String?>(value: null, child: Text('Tutte')),
+          ...options
+              .map((option) => DropdownMenuItem<String?>(
+                    value: option,
+                    child: Text(option),
+                  ))
+              .toList(),
+        ],
+        onChanged: onChanged,
+      ),
+    );
+  }
+
+  Widget _buildLocalSection() {
+    if (_filteredLocalBots.isEmpty) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Local Bots (0)',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          _buildEmptyTile(
+              'Nessun bot locale trovato con i filtri selezionati.'),
+        ],
+      );
+    }
+
+    return ExpansionTile(
+      title: Text('Local Bots (${_filteredLocalBots.length})'),
+      children: _filteredLocalBots.map(_buildBotTile).toList(),
+    );
+  }
+
+  Widget _buildRemoteSection() {
+    if (_filteredRemoteBots.isEmpty) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Remote Bots (0)',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          _buildEmptyTile(
+              'Nessun bot remoto trovato con i filtri selezionati.'),
+        ],
+      );
+    }
+
+    return ExpansionTile(
+      title: Text('Remote Bots (${_countRemoteFilteredBots()})'),
+      children: _filteredRemoteBots.entries.map((entry) {
+        final language = entry.key;
+        final bots = entry.value;
+
+        return ExpansionTile(
+          title: Text('$language (${bots.length})'),
+          children: bots.map(_buildBotTile).toList(),
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _buildBotTile(Bot bot) {
+    return BotCard(
+      bot: bot,
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => BotDetailView(bot: bot),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildEmptyTile(String message) {
+    return ListTile(
+      title: Text(message),
+      dense: true,
     );
   }
 }

--- a/test/frontend/services/bot_get_service_test.dart
+++ b/test/frontend/services/bot_get_service_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:scriptagher/frontend/models/bot.dart';
+import 'package:scriptagher/frontend/services/bot_get_service.dart';
+
+void main() {
+  group('BotGetService filtering', () {
+    final service = BotGetService();
+
+    final bots = [
+      const Bot(
+        botName: 'AlphaBot',
+        description: 'Risolve problemi matematici',
+        startCommand: 'python alpha.py',
+        sourcePath: '/alpha',
+        language: 'Python',
+        tags: ['math', 'education'],
+        author: 'Alice',
+        version: '1.0.0',
+      ),
+      const Bot(
+        botName: 'BetaHelper',
+        description: 'Assistente di traduzione',
+        startCommand: 'dart run beta',
+        sourcePath: '/beta',
+        language: 'Dart',
+        tags: ['translation', 'language'],
+        author: 'Bob',
+        version: '2.1.0',
+      ),
+      const Bot(
+        botName: 'GammaAI',
+        description: 'Analisi dati avanzata',
+        startCommand: 'node gamma.js',
+        sourcePath: '/gamma',
+        language: 'JavaScript',
+        tags: ['analytics'],
+        author: 'Alice',
+        version: '1.5.0',
+      ),
+    ];
+
+    final groupedBots = {
+      'Python': [bots[0]],
+      'Dart': [bots[1]],
+      'JavaScript': [bots[2]],
+    };
+
+    test('filters by search query across metadata', () {
+      final filters = const BotFilters(query: 'traduzione');
+      final filtered = service.filterGroupedBots(groupedBots, filters);
+
+      expect(filtered.length, 1);
+      expect(filtered.values.first.single.botName, 'BetaHelper');
+    });
+
+    test('filters by language and tag combination', () {
+      final filters = const BotFilters(language: 'python', tag: 'math');
+      final filtered = service.filterGroupedBots(groupedBots, filters);
+
+      expect(filtered.keys, contains('Python'));
+      expect(filtered['Python']!.length, 1);
+      expect(filtered['Python']!.first.botName, 'AlphaBot');
+
+      final flatFiltered = service.filterBots(bots, filters);
+      expect(flatFiltered.length, 1);
+      expect(flatFiltered.first.botName, 'AlphaBot');
+    });
+
+    test('filters by author and version ignoring case', () {
+      final filters = const BotFilters(author: 'alice', version: '1.5.0');
+      final flatFiltered = service.filterBots(bots, filters);
+
+      expect(flatFiltered.length, 1);
+      expect(flatFiltered.first.botName, 'GammaAI');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- enrich the backend bot model, database schema, and GitHub integration with metadata required for filtering
- extend the download/get services and REST controller to persist and expose language, tags, author, and version values
- refresh the Flutter client with metadata-aware filtering UI, updated search component, and coverage tests for filter logic

## Testing
- flutter test *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f2ac825948832b9a4b3f73d64c71cf