### PR TITLE
Add bot tutorial documentation and surface guidance in the UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,35 @@
 ## Descrizione
 Questo progetto è una semplice applicazione mobile/desktop/web sviluppata con Flutter. Flutter è un framework open-source che permette di creare app per dispositivi mobili, desktop e web da una singola base di codice. Questo README include informazioni su come eseguire, configurare, testare e distribuire l'app su diverse piattaforme (Android, iOS, Linux, Windows e altre).
 
+## Bot per Scriptagher
+
+Scriptagher consente di scaricare, installare ed eseguire bot provenienti da marketplace, repository locali o filesystem.
+
+- Consulta la guida completa su come strutturare e distribuire un bot in [`docs/create-your-bot.md`](docs/create-your-bot.md).
+- Troverai un esempio completo di `Bot.json`, il flusso di download/esecuzione e una checklist di sicurezza e best practice.
+
+### Struttura rapida di un bot
+
+```
+my-awesome-bot/
+├── Bot.json
+├── main.py
+├── requirements.txt
+└── resources/
+```
+
+Il file `Bot.json` contiene i metadati (nome, descrizione, versione), l'entrypoint da eseguire, variabili d'ambiente, comandi post installazione e le permission richieste. Consulta la guida per un esempio dettagliato e per comprendere come il backend esegue i comandi dichiarati in sicurezza.
+
+### Flusso di download ed esecuzione
+
+1. **Scoperta** – i bot online vengono caricati dall'API e presentati nella UI.
+2. **Download** – il pacchetto viene salvato nel database locale e nel filesystem.
+3. **Installazione** – eventuali comandi `postInstall` vengono eseguiti in un ambiente controllato.
+4. **Esecuzione** – l'entrypoint dichiarato in `Bot.json` viene avviato con argomenti e variabili configurate.
+5. **Monitoraggio** – l'interfaccia mostra i log in tempo reale nella pagina di dettaglio del bot.
+
+> **Sicurezza:** sviluppa bot in ambienti isolati, dichiara solo le permission indispensabili e controlla l'origine dei pacchetti. Altri suggerimenti sono disponibili nella guida dedicata.
+
 ## Struttura del Progetto
 La struttura di base di un'app Flutter è la seguente:
 

--- a/docs/create-your-bot.md
+++ b/docs/create-your-bot.md
@@ -1,0 +1,100 @@
+# Guida: crea il tuo bot Scriptagher
+
+Questa guida illustra la struttura prevista per un bot compatibile con Scriptagher,
+mostra un esempio completo di `Bot.json` e descrive il flusso con cui l'applicazione
+download e avvia i bot. Include inoltre suggerimenti di sicurezza e best practice
+per gli sviluppatori.
+
+## Struttura minima di un bot
+
+Ogni bot è distribuito come directory comprimibile (zip) con la seguente struttura
+minima:
+
+```
+my-awesome-bot/
+├── Bot.json
+├── main.py            # entrypoint principale (il nome può cambiare, vedi Bot.json)
+├── requirements.txt   # dipendenze opzionali
+└── resources/         # asset opzionali
+```
+
+* **Bot.json** descrive metadati, comandi e runtime richiesti.
+* **File sorgente**: lo script o binario che implementa la logica del bot.
+* **Dipendenze**: file opzionali (`requirements.txt`, `package.json`, ecc.) usati
+  durante la fase di installazione.
+
+## Esempio di `Bot.json`
+
+```json
+{
+  "botName": "MyAwesomeBot",
+  "version": "1.0.0",
+  "description": "Esempio di bot che stampa un messaggio",
+  "author": "Jane Doe",
+  "language": "python",
+  "entrypoint": "main.py",
+  "args": ["--verbose"],
+  "environment": {
+    "PYTHONPATH": "./"
+  },
+  "postInstall": [
+    "pip install -r requirements.txt"
+  ],
+  "permissions": [
+    "network",
+    "filesystem:read"
+  ]
+}
+```
+
+Campi principali:
+
+* **botName** – identificativo mostrato nell'interfaccia.
+* **version** – utile per aggiornamenti.
+* **description** – anteprima rapida della funzionalità.
+* **language** – usato dal backend per scegliere il runtime.
+* **entrypoint** – file o comando da eseguire.
+* **args** – argomenti opzionali.
+* **environment** – variabili d'ambiente aggiuntive.
+* **postInstall** – comandi eseguiti dopo il download per preparare il bot.
+* **permissions** – elenco dichiarativo delle risorse richieste.
+
+## Flusso di download ed esecuzione
+
+1. **Scoperta** – i bot pubblicati online vengono elencati nella sezione "Online".
+2. **Download** – l'utente avvia il download; il pacchetto zip viene salvato nel
+   database locale e sul filesystem.
+3. **Installazione** – se `postInstall` contiene comandi, il backend li esegue
+   nell'ambiente isolato del bot.
+4. **Esecuzione** – dall'interfaccia è possibile avviare il bot: il backend
+   esegue l'`entrypoint` impostando argomenti e variabili indicati.
+5. **Monitoraggio** – l'output viene mostrato in tempo reale nella pagina di
+   dettaglio del bot.
+
+## Crea il tuo bot
+
+1. Clona questo repository o scarica il template dal sito.
+2. Crea una nuova cartella per il bot e aggiungi `Bot.json` con i metadati.
+3. Implementa l'`entrypoint` e assicurati che sia eseguibile localmente.
+4. Se servono dipendenze, aggiungi i file necessari (`requirements.txt`,
+   `package.json`, ecc.) e riportale in `postInstall`.
+5. Comprimi la cartella e caricala nel marketplace Scriptagher oppure
+   posizionala nelle directory monitorate dall'applicazione.
+
+## Note di sicurezza e best practice
+
+* **Esegui sempre il bot in un ambiente isolato** (es. container, ambiente
+  virtuale) per evitare che processi malevoli compromettano il sistema.
+* **Valida l'input** proveniente da utenti o servizi esterni per prevenire
+  injection e escalation.
+* **Limita le dipendenze** a quelle strettamente necessarie e blocca le versioni
+  per ridurre l'esposizione a vulnerabilità note.
+* **Dichiara solo le permission indispensabili** in `Bot.json` e verifica che il
+  bot non acceda a risorse non necessarie.
+* **Gestisci in modo sicuro i segreti** (token, chiavi API) usando variabili
+  d'ambiente o servizi di secret management, evitando di inserirli nel codice.
+* **Firma digitalmente o verifica l'origine del pacchetto** prima di pubblicarlo.
+* **Monitora l'esecuzione** con log strutturati e gestisci gli errori in modo
+  esplicito per migliorare la diagnosi.
+
+Per ulteriori dettagli, consulta il README principale o contatta il team.

--- a/lib/frontend/widgets/pages/bot_detail_view.dart
+++ b/lib/frontend/widgets/pages/bot_detail_view.dart
@@ -27,6 +27,10 @@ class _BotDetailViewState extends State<BotDetailView> {
   String _buffer = '';
   String? _error;
 
+  void _openTutorial() {
+    Navigator.pushNamed(context, '/tutorial');
+  }
+
   @override
   void dispose() {
     _stopExecution();
@@ -180,6 +184,13 @@ class _BotDetailViewState extends State<BotDetailView> {
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.bot.botName),
+        actions: [
+          IconButton(
+            tooltip: 'Guida: crea il tuo bot',
+            onPressed: _openTutorial,
+            icon: const Icon(Icons.school_outlined),
+          ),
+        ],
       ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),

--- a/lib/frontend/widgets/pages/home_page_view.dart
+++ b/lib/frontend/widgets/pages/home_page_view.dart
@@ -80,6 +80,10 @@ class _HomePageState extends State<HomePage>
     );
   }
 
+  void _openTutorial() {
+    Navigator.pushNamed(context, '/tutorial');
+  }
+
   Widget _buildCategoryContent(_Category category) {
     return Padding(
       key: ValueKey(category.category),
@@ -137,6 +141,64 @@ class _HomePageState extends State<HomePage>
                 fontSize: 26,
                 fontWeight: FontWeight.bold,
                 color: Colors.black87,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Card(
+              elevation: 2,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: InkWell(
+                borderRadius: BorderRadius.circular(12),
+                onTap: _openTutorial,
+                child: Padding(
+                  padding: const EdgeInsets.all(20),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Icon(Icons.school_outlined,
+                          color: Colors.blueAccent, size: 32),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Text(
+                              'Crea il tuo bot',
+                              style: TextStyle(
+                                fontSize: 20,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            const SizedBox(height: 8),
+                            Text(
+                              'Segui il tutorial passo-passo per creare un bot sicuro compatibile con Scriptagher.',
+                              style: TextStyle(
+                                fontSize: 15,
+                                color: Colors.grey.shade700,
+                              ),
+                            ),
+                            const SizedBox(height: 12),
+                            Row(
+                              children: const [
+                                Text(
+                                  'Apri tutorial',
+                                  style: TextStyle(
+                                    fontSize: 15,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                                SizedBox(width: 4),
+                                Icon(Icons.arrow_forward, size: 18),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
               ),
             ),
             const SizedBox(height: 24),

--- a/lib/frontend/widgets/pages/tutorial_page.dart
+++ b/lib/frontend/widgets/pages/tutorial_page.dart
@@ -1,0 +1,236 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+const String _tutorialDocsUrl =
+    'https://github.com/scriptagher/scriptagher/blob/main/docs/create-your-bot.md';
+
+class TutorialPage extends StatelessWidget {
+  const TutorialPage({super.key});
+
+  Future<void> _openDocs(BuildContext context) async {
+    final uri = Uri.parse(_tutorialDocsUrl);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+      return;
+    }
+
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    messenger?.showSnackBar(
+      const SnackBar(
+        content:
+            Text('Impossibile aprire la documentazione, controlla la connessione.'),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Crea il tuo bot'),
+        actions: [
+          IconButton(
+            tooltip: 'Apri la guida completa',
+            icon: const Icon(Icons.open_in_new),
+            onPressed: () => _openDocs(context),
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Panoramica',
+              style: theme.textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Scriptagher esegue bot impacchettati come cartelle con un file Bot.json che descrive '
+              'metadati, runtime e permessi. Segui i passaggi sotto per crearne uno nuovo.',
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'Struttura del progetto',
+              style: theme.textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: Colors.grey.shade100,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: Colors.grey.shade300),
+              ),
+              child: const SelectableText(
+                'my-awesome-bot/\n'
+                '├── Bot.json\n'
+                '├── main.py\n'
+                '├── requirements.txt\n'
+                '└── resources/\n',
+                style: TextStyle(fontFamily: 'monospace'),
+              ),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'Il file Bot.json definisce nome, versione, linguaggio, entrypoint, argomenti opzionali e '
+              'comandi di installazione. I file sorgente contengono la logica del bot e possono includere '
+              'dipendenze dichiarate nei comandi di post installazione.',
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'Esempio di Bot.json',
+              style: theme.textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: Colors.grey.shade100,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: Colors.grey.shade300),
+              ),
+              child: const SelectableText(
+                '{\n'
+                '  "botName": "MyAwesomeBot",\n'
+                '  "version": "1.0.0",\n'
+                '  "description": "Esempio di bot che stampa un messaggio",\n'
+                '  "author": "Jane Doe",\n'
+                '  "language": "python",\n'
+                '  "entrypoint": "main.py",\n'
+                '  "args": ["--verbose"],\n'
+                '  "environment": {\n'
+                '    "PYTHONPATH": "./"\n'
+                '  },\n'
+                '  "postInstall": [\n'
+                '    "pip install -r requirements.txt"\n'
+                '  ],\n'
+                '  "permissions": [\n'
+                '    "network",\n'
+                '    "filesystem:read"\n'
+                '  ]\n'
+                '}\n',
+                style: TextStyle(fontFamily: 'monospace'),
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'Flusso di lavoro',
+              style: theme.textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            const _NumberedList(
+              items: [
+                'Scopri i bot nella libreria Online o prepara una nuova cartella locale.',
+                'Compila Bot.json con metadati, entrypoint, permessi e comandi di installazione.',
+                'Testa il bot localmente eseguendo l\'entrypoint con gli stessi argomenti.',
+                'Comprimi la cartella e caricala nel marketplace oppure copiala nelle directory monitorate.',
+                'Scarica o apri il bot da Scriptagher per installarlo ed eseguirlo dal dettaglio.',
+              ],
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'Best practice di sicurezza',
+              style: theme.textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            const _BulletList(
+              items: [
+                'Isola l\'esecuzione (container, ambienti virtuali) per ridurre l\'impatto di codice malevolo.',
+                'Limita dipendenze e versioni per diminuire vulnerabilità e assicurane l\'aggiornamento.',
+                'Gestisci segreti e token tramite variabili d\'ambiente sicure, mai in chiaro nel repository.',
+                'Richiedi solo le permission strettamente necessarie in Bot.json e verifica gli accessi.',
+                'Valida l\'input e registra log strutturati per facilitare monitoraggio e audit.',
+              ],
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'Risorse aggiuntive',
+              style: theme.textTheme.titleLarge,
+            ),
+            const SizedBox(height: 8),
+            Text.rich(
+              TextSpan(
+                text: 'Consulta la documentazione completa in ',
+                children: [
+                  WidgetSpan(
+                    alignment: PlaceholderAlignment.baseline,
+                    baseline: TextBaseline.alphabetic,
+                    child: GestureDetector(
+                      onTap: () => _openDocs(context),
+                      child: Text(
+                        'docs/create-your-bot.md',
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.primary,
+                          decoration: TextDecoration.underline,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const TextSpan(text: ' nel repository.'),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _NumberedList extends StatelessWidget {
+  const _NumberedList({required this.items});
+
+  final List<String> items;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (int index = 0; index < items.length; index++)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('${index + 1}. ', style: const TextStyle(fontWeight: FontWeight.bold)),
+                Expanded(child: Text(items[index])),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _BulletList extends StatelessWidget {
+  const _BulletList({required this.items});
+
+  final List<String> items;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final item in items)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('• '),
+                Expanded(child: Text(item)),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'package:scriptagher/frontend/widgets/pages/test1.dart';
 import 'package:scriptagher/frontend/widgets/pages/test2.dart';
 import 'package:scriptagher/frontend/widgets/pages/test3.dart';
 import 'package:scriptagher/frontend/widgets/pages/settings_page.dart';
+import 'package:scriptagher/frontend/widgets/pages/tutorial_page.dart';
 import 'package:scriptagher/shared/services/telemetry_service.dart';
 
 
@@ -100,6 +101,7 @@ class MyApp extends StatelessWidget {
         '/test2':     (_) => test2(),   // la pagina test1 List
         '/test3':     (_) => test3(),   // la pagina test1 List
         '/settings': (_) => SettingsPage(telemetryService: telemetryService),
+        '/tutorial': (_) => const TutorialPage(),
       },
 
       debugShowCheckedModeBanner: false,


### PR DESCRIPTION
## Summary
- add a dedicated create-your-bot guide covering structure, Bot.json example, lifecycle, and security notes
- update the README to highlight bot documentation and summarize the download/execution flow
- introduce an in-app tutorial page and surface links from the home screen and bot detail view

## Testing
- not run (Flutter/Dart tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f2b15152cc832ba7905d9ac310d14a