### PR TITLE
Add execution log management and history UI

### DIFF
--- a/lib/backend/server/server.dart
+++ b/lib/backend/server/server.dart
@@ -8,6 +8,7 @@ import 'controllers/bot_controller.dart';
 import 'services/bot_get_service.dart';
 import 'services/bot_download_service.dart';
 import 'services/execution_service.dart';
+import 'services/execution_log_service.dart';
 import 'db/bot_database.dart';
 import 'routes.dart';
 import 'package:scriptagher/backend/server/api_integration/github_api.dart';
@@ -21,7 +22,8 @@ Future<void> startServer() async {
   // Istanzia il BotService e BotController
   final botGetService = BotGetService(botDatabase, gitHubApi);
   final botDownloadService = BotDownloadService();
-  final executionService = ExecutionService(botDatabase);
+  final executionLogManager = ExecutionLogManager();
+  final executionService = ExecutionService(botDatabase, executionLogManager);
   final botController = BotController(botDownloadService, botGetService);
 
   // Ottieni il router con le rotte definite
@@ -31,6 +33,14 @@ Future<void> startServer() async {
   router.get('/bots/<language>/<botName>/stream',
       (Request request, String language, String botName) {
     return executionService.streamExecution(request, language, botName);
+  });
+  router.get('/bots/<language>/<botName>/logs',
+      (Request request, String language, String botName) {
+    return executionService.listLogs(request, language, botName);
+  });
+  router.get('/bots/<language>/<botName>/logs/<runId>',
+      (Request request, String language, String botName, String runId) {
+    return executionService.downloadLog(request, language, botName, runId);
   });
 
   // Usa il middleware di logging per tracciare le richieste

--- a/lib/backend/server/services/execution_log_service.dart
+++ b/lib/backend/server/services/execution_log_service.dart
@@ -1,0 +1,219 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../models/bot.dart';
+
+class ExecutionLogMetadata {
+  ExecutionLogMetadata({
+    required this.runId,
+    required this.language,
+    required this.botName,
+    required this.startedAt,
+    required this.logFileName,
+    this.botId,
+    this.finishedAt,
+    this.exitCode,
+    this.logFileSize,
+    this.errorMessage,
+  });
+
+  final String runId;
+  final String language;
+  final String botName;
+  final DateTime startedAt;
+  final int? botId;
+  DateTime? finishedAt;
+  int? exitCode;
+  final String logFileName;
+  int? logFileSize;
+  String? errorMessage;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'run_id': runId,
+      'language': language,
+      'bot_name': botName,
+      'bot_id': botId,
+      'started_at': startedAt.toIso8601String(),
+      'finished_at': finishedAt?.toIso8601String(),
+      'exit_code': exitCode,
+      'log_file': logFileName,
+      'log_file_size': logFileSize,
+      'error': errorMessage,
+    };
+  }
+
+  Map<String, dynamic> toLogMetadata({String? entryType}) {
+    return {
+      'runId': runId,
+      'botId': botId,
+      'language': language,
+      'botName': botName,
+      'startedAt': startedAt.toIso8601String(),
+      if (finishedAt != null) 'finishedAt': finishedAt!.toIso8601String(),
+      if (exitCode != null) 'exitCode': exitCode,
+      if (entryType != null) 'entryType': entryType,
+    };
+  }
+
+  static ExecutionLogMetadata fromJson(Map<String, dynamic> json) {
+    return ExecutionLogMetadata(
+      runId: json['run_id'] as String,
+      language: json['language'] as String,
+      botName: json['bot_name'] as String,
+      startedAt: DateTime.parse(json['started_at'] as String),
+      logFileName: json['log_file'] as String,
+      botId: json['bot_id'] as int?,
+      finishedAt: json['finished_at'] != null
+          ? DateTime.parse(json['finished_at'] as String)
+          : null,
+      exitCode: json['exit_code'] as int?,
+      logFileSize: json['log_file_size'] as int?,
+      errorMessage: json['error'] as String?,
+    );
+  }
+}
+
+class ExecutionLogSession {
+  ExecutionLogSession({
+    required this.metadata,
+    required this.logFile,
+    required this.metadataFile,
+    required this.logSink,
+  });
+
+  final ExecutionLogMetadata metadata;
+  final File logFile;
+  final File metadataFile;
+  final IOSink logSink;
+
+  Future<void> dispose() async {
+    await logSink.flush();
+    await logSink.close();
+  }
+}
+
+class ExecutionLogManager {
+  ExecutionLogManager({Directory? baseDirectory})
+      : _baseDirectory = baseDirectory ?? Directory('logs/executions');
+
+  final Directory _baseDirectory;
+
+  Future<ExecutionLogSession> startSession(Bot bot) async {
+    final runId = _generateRunId();
+    final directory = await _prepareDirectory(bot.language, bot.botName);
+    final logFile = File('${directory.path}/run_$runId.log');
+    final metadataFile = File('${directory.path}/run_$runId.json');
+
+    final metadata = ExecutionLogMetadata(
+      runId: runId,
+      language: bot.language,
+      botName: bot.botName,
+      botId: bot.id,
+      startedAt: DateTime.now().toUtc(),
+      logFileName: logFile.uri.pathSegments.last,
+    );
+
+    await metadataFile.writeAsString(jsonEncode(metadata.toJson()));
+    final sink = logFile.openWrite(mode: FileMode.append);
+
+    return ExecutionLogSession(
+      metadata: metadata,
+      logFile: logFile,
+      metadataFile: metadataFile,
+      logSink: sink,
+    );
+  }
+
+  Future<void> finalizeSession(
+    ExecutionLogSession session, {
+    required int exitCode,
+    String? errorMessage,
+  }) async {
+    await session.logSink.flush();
+    session.metadata
+      ..exitCode = exitCode
+      ..finishedAt = DateTime.now().toUtc()
+      ..errorMessage = errorMessage
+      ..logFileSize = await session.logFile.length();
+
+    await session.metadataFile
+        .writeAsString(jsonEncode(session.metadata.toJson()));
+  }
+
+  Future<List<ExecutionLogMetadata>> listLogs(
+      String language, String botName) async {
+    final directory = Directory('${_baseDirectory.path}/$language/$botName');
+    if (!await directory.exists()) {
+      return [];
+    }
+
+    final files = await directory
+        .list()
+        .where((entity) => entity is File && entity.path.endsWith('.json'))
+        .cast<File>()
+        .toList();
+
+    final logs = <ExecutionLogMetadata>[];
+    for (final file in files) {
+      try {
+        final contents = await file.readAsString();
+        final jsonData = jsonDecode(contents) as Map<String, dynamic>;
+        logs.add(ExecutionLogMetadata.fromJson(jsonData));
+      } catch (_) {
+        continue;
+      }
+    }
+
+    logs.sort((a, b) => b.startedAt.compareTo(a.startedAt));
+    return logs;
+  }
+
+  Future<ExecutionLogMetadata?> loadMetadata(
+      String language, String botName, String runId) async {
+    final file = await _metadataFile(language, botName, runId);
+    if (file == null || !await file.exists()) {
+      return null;
+    }
+    try {
+      final contents = await file.readAsString();
+      final jsonData = jsonDecode(contents) as Map<String, dynamic>;
+      return ExecutionLogMetadata.fromJson(jsonData);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<File?> openLogFile(
+      String language, String botName, String logFileName) async {
+    final directory = Directory('${_baseDirectory.path}/$language/$botName');
+    final file = File('${directory.path}/$logFileName');
+    if (await file.exists()) {
+      return file;
+    }
+    return null;
+  }
+
+  Future<Directory> _prepareDirectory(String language, String botName) async {
+    final directory = Directory('${_baseDirectory.path}/$language/$botName');
+    if (!await directory.exists()) {
+      await directory.create(recursive: true);
+    }
+    return directory;
+  }
+
+  Future<File?> _metadataFile(
+      String language, String botName, String runId) async {
+    final directory = Directory('${_baseDirectory.path}/$language/$botName');
+    if (!await directory.exists()) {
+      return null;
+    }
+    final file = File('${directory.path}/run_$runId.json');
+    return file;
+  }
+
+  String _generateRunId() {
+    final now = DateTime.now().toUtc();
+    return now.toIso8601String().replaceAll(':', '-');
+  }
+}

--- a/lib/frontend/models/execution_log.dart
+++ b/lib/frontend/models/execution_log.dart
@@ -1,0 +1,71 @@
+import 'package:intl/intl.dart';
+
+class ExecutionLog {
+  ExecutionLog({
+    required this.runId,
+    required this.startedAt,
+    required this.logFileName,
+    this.botId,
+    this.language,
+    this.botName,
+    this.finishedAt,
+    this.exitCode,
+    this.logFileSize,
+    this.errorMessage,
+  });
+
+  final String runId;
+  final DateTime startedAt;
+  final String logFileName;
+  final int? botId;
+  final String? language;
+  final String? botName;
+  final DateTime? finishedAt;
+  final int? exitCode;
+  final int? logFileSize;
+  final String? errorMessage;
+
+  factory ExecutionLog.fromJson(Map<String, dynamic> json) {
+    return ExecutionLog(
+      runId: json['run_id'] as String,
+      startedAt: DateTime.parse(json['started_at'] as String),
+      logFileName: json['log_file'] as String,
+      botId: json['bot_id'] as int?,
+      language: json['language'] as String?,
+      botName: json['bot_name'] as String?,
+      finishedAt: json['finished_at'] != null
+          ? DateTime.parse(json['finished_at'] as String)
+          : null,
+      exitCode: json['exit_code'] as int?,
+      logFileSize: json['log_file_size'] as int?,
+      errorMessage: json['error'] as String?,
+    );
+  }
+
+  String get formattedStartedAt =>
+      DateFormat('yyyy-MM-dd HH:mm:ss').format(startedAt.toLocal());
+
+  String get formattedFinishedAt => finishedAt == null
+      ? '—'
+      : DateFormat('yyyy-MM-dd HH:mm:ss').format(finishedAt!.toLocal());
+
+  String get status {
+    if (exitCode == null) {
+      return 'In corso';
+    }
+    return exitCode == 0 ? 'Completato' : 'Terminato con errori';
+  }
+
+  String get formattedSize {
+    if (logFileSize == null) {
+      return 'N/D';
+    }
+    if (logFileSize! < 1024) {
+      return '${logFileSize!} B';
+    }
+    if (logFileSize! < 1024 * 1024) {
+      return '${(logFileSize! / 1024).toStringAsFixed(1)} KB';
+    }
+    return '${(logFileSize! / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+}

--- a/lib/frontend/widgets/pages/bot_detail_view.dart
+++ b/lib/frontend/widgets/pages/bot_detail_view.dart
@@ -1,13 +1,17 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
 
 import '../../models/bot.dart';
+import '../../models/execution_log.dart';
 
 class BotDetailView extends StatefulWidget {
-  const BotDetailView({super.key, required this.bot, this.baseUrl = 'http://localhost:8080'});
+  const BotDetailView(
+      {super.key, required this.bot, this.baseUrl = 'http://localhost:8080'});
 
   final Bot bot;
   final String baseUrl;
@@ -19,19 +23,63 @@ class BotDetailView extends StatefulWidget {
 class _BotDetailViewState extends State<BotDetailView> {
   final ScrollController _scrollController = ScrollController();
   final List<_ConsoleEntry> _entries = [];
+  final List<ExecutionLog> _logHistory = [];
 
   http.Client? _client;
   StreamSubscription<String>? _subscription;
   bool _autoScroll = true;
   bool _isRunning = false;
+  bool _isLoadingLogs = false;
   String _buffer = '';
   String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadLogs();
+  }
 
   @override
   void dispose() {
     _stopExecution();
     _scrollController.dispose();
     super.dispose();
+  }
+
+  Future<void> _loadLogs() async {
+    setState(() {
+      _isLoadingLogs = true;
+    });
+
+    final uri = Uri.parse(
+        '${widget.baseUrl}/bots/${Uri.encodeComponent(widget.bot.language)}/${Uri.encodeComponent(widget.bot.botName)}/logs');
+
+    try {
+      final response = await http.get(uri);
+      if (response.statusCode == 200) {
+        final List<dynamic> data = jsonDecode(response.body) as List<dynamic>;
+        final logs = data
+            .whereType<Map<String, dynamic>>()
+            .map(ExecutionLog.fromJson)
+            .toList();
+        setState(() {
+          _logHistory
+            ..clear()
+            ..addAll(logs);
+        });
+      } else {
+        _showSnackBar(
+            'Impossibile recuperare i log (codice ${response.statusCode}).');
+      }
+    } catch (e) {
+      _showSnackBar('Errore durante il caricamento dei log: $e');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoadingLogs = false;
+        });
+      }
+    }
   }
 
   void _startExecution() async {
@@ -78,6 +126,7 @@ class _BotDetailViewState extends State<BotDetailView> {
           _isRunning = false;
         });
         _stopExecution();
+        _loadLogs();
       });
     } catch (e) {
       if (!mounted) return;
@@ -139,6 +188,7 @@ class _BotDetailViewState extends State<BotDetailView> {
           setState(() {
             _isRunning = false;
           });
+          _loadLogs();
         }
         return;
       }
@@ -173,6 +223,70 @@ class _BotDetailViewState extends State<BotDetailView> {
       _entries.clear();
       _error = null;
     });
+  }
+
+  Future<void> _openLog(ExecutionLog log) async {
+    final uri = Uri.parse(
+        '${widget.baseUrl}/bots/${Uri.encodeComponent(widget.bot.language)}/${Uri.encodeComponent(widget.bot.botName)}/logs/${Uri.encodeComponent(log.runId)}');
+    try {
+      final response = await http.get(uri);
+      if (response.statusCode == 200) {
+        final content = utf8.decode(response.bodyBytes);
+        if (!mounted) return;
+        await showDialog<void>(
+          context: context,
+          builder: (context) {
+            return AlertDialog(
+              title: Text('Log ${log.runId}'),
+              content: SizedBox(
+                width: 600,
+                child: SingleChildScrollView(
+                  child: SelectableText(content),
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Chiudi'),
+                ),
+              ],
+            );
+          },
+        );
+      } else {
+        _showSnackBar(
+            'Impossibile aprire il log (codice ${response.statusCode}).');
+      }
+    } catch (e) {
+      _showSnackBar('Errore durante l\'apertura del log: $e');
+    }
+  }
+
+  Future<void> _exportLog(ExecutionLog log) async {
+    final uri = Uri.parse(
+        '${widget.baseUrl}/bots/${Uri.encodeComponent(widget.bot.language)}/${Uri.encodeComponent(widget.bot.botName)}/logs/${Uri.encodeComponent(log.runId)}');
+    try {
+      final response = await http.get(uri);
+      if (response.statusCode != 200) {
+        _showSnackBar(
+            'Impossibile esportare il log (codice ${response.statusCode}).');
+        return;
+      }
+
+      final directory = await getApplicationDocumentsDirectory();
+      final file = File('${directory.path}/${log.logFileName}');
+      await file.writeAsBytes(response.bodyBytes);
+      _showSnackBar('Log salvato in ${file.path}');
+    } catch (e) {
+      _showSnackBar('Errore durante l\'esportazione del log: $e');
+    }
+  }
+
+  void _showSnackBar(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
   }
 
   @override
@@ -263,9 +377,89 @@ class _BotDetailViewState extends State<BotDetailView> {
                       ),
               ),
             ),
+            const SizedBox(height: 20),
+            SizedBox(
+              height: 220,
+              child: Card(
+                elevation: 2,
+                child: Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Text(
+                            'Storico esecuzioni',
+                            style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                          const Spacer(),
+                          IconButton(
+                            tooltip: 'Aggiorna',
+                            onPressed: _isLoadingLogs ? null : _loadLogs,
+                            icon: _isLoadingLogs
+                                ? const SizedBox(
+                                    width: 16,
+                                    height: 16,
+                                    child: CircularProgressIndicator(strokeWidth: 2),
+                                  )
+                                : const Icon(Icons.refresh),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 12),
+                      Expanded(
+                        child: _buildLogList(),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildLogList() {
+    if (_isLoadingLogs && _logHistory.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_logHistory.isEmpty) {
+      return const Center(
+        child: Text('Nessun log disponibile per questo bot.'),
+      );
+    }
+
+    return ListView.separated(
+      itemCount: _logHistory.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, index) {
+        final log = _logHistory[index];
+        return ListTile(
+          title: Text('${log.formattedStartedAt} • ${log.status}'),
+          subtitle: Text(
+            'Fine: ${log.formattedFinishedAt} • Exit code: ${log.exitCode ?? 'n/d'} • Dimensione: ${log.formattedSize}',
+          ),
+          trailing: Wrap(
+            spacing: 8,
+            children: [
+              IconButton(
+                tooltip: 'Apri log',
+                icon: const Icon(Icons.visibility),
+                onPressed: () => _openLog(log),
+              ),
+              IconButton(
+                tooltip: 'Esporta log',
+                icon: const Icon(Icons.download),
+                onPressed: () => _exportLog(log),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- add an execution log manager that stores per-run metadata and files for bots
- update the execution service to stream stdout/stderr to dedicated run logs, expose history/download endpoints, and enrich logger metadata
- surface historical logs in the bot detail view with open/export actions and update the custom logger to accept metadata

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f2b232fd18832bb6a192dd4ba0ef18