### PR TITLE
Add compatibility metadata and runtime checks

### DIFF
--- a/docs/create-your-bot.md
+++ b/docs/create-your-bot.md
@@ -43,7 +43,16 @@ my-awesome-bot/
   "permissions": [
     "network",
     "filesystem:read"
-  ]
+  ],
+  "compat": {
+    "desktop": {
+      "runtimes": ["python"]
+    },
+    "browser": {
+      "supported": false,
+      "reason": "Richiede un interprete Python locale"
+    }
+  }
 }
 ```
 
@@ -58,6 +67,10 @@ Campi principali:
 * **environment** – variabili d'ambiente aggiuntive.
 * **postInstall** – comandi eseguiti dopo il download per preparare il bot.
 * **permissions** – elenco dichiarativo delle risorse richieste.
+* **compat** – compatibilità dichiarativa: elenca i runtime desktop necessari
+  (`runtimes`) e indica se il bot è eseguibile nel browser (`browser.supported`).
+  Specifica un motivo opzionale (`browser.reason`) quando il supporto non è
+  disponibile.
 
 ## Flusso di download ed esecuzione
 

--- a/lib/backend/server/controllers/bot_controller.dart
+++ b/lib/backend/server/controllers/bot_controller.dart
@@ -26,7 +26,7 @@ class BotController {
       // Rispondi con la lista di bot in formato JSON
       return Response.ok(
           json.encode(availableBots
-              .map((bot) => bot.toMap())
+              .map((bot) => bot.toResponseMap())
               .toList()), // Converte ogni bot in una mappa JSON
           headers: {'Content-Type': 'application/json'});
     } catch (e) {
@@ -54,7 +54,7 @@ class BotController {
           LOGS.BOT_SERVICE, 'Downloaded bot ${bot.botName} successfully.');
 
       // Rispondi con i dettagli del bot come JSON
-      return Response.ok(json.encode(bot.toMap()),
+      return Response.ok(json.encode(bot.toResponseMap()),
           headers: {'Content-Type': 'application/json'});
     } catch (e) {
       logger.error(LOGS.BOT_SERVICE, 'Error downloading bot: $e');
@@ -76,7 +76,7 @@ class BotController {
 
       logger.info(LOGS.BOT_SERVICE, 'Fetched ${localBots.length} local bots.');
       return Response.ok(
-        json.encode(localBots.map((bot) => bot.toMap()).toList()),
+        json.encode(localBots.map((bot) => bot.toResponseMap()).toList()),
         headers: {'Content-Type': 'application/json'},
       );
     } catch (e) {
@@ -101,7 +101,7 @@ class BotController {
       logger.info(
           LOGS.BOT_SERVICE, 'Fetched ${downloadedBots.length} downloaded bots.');
       return Response.ok(
-        json.encode(downloadedBots.map((bot) => bot.toMap()).toList()),
+        json.encode(downloadedBots.map((bot) => bot.toResponseMap()).toList()),
         headers: {'Content-Type': 'application/json'},
       );
     } catch (e) {

--- a/lib/backend/server/models/bot.dart
+++ b/lib/backend/server/models/bot.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 class Bot {
   final int? id;
   final String botName;
@@ -5,6 +7,7 @@ class Bot {
   final String startCommand;
   final String sourcePath;
   final String language;
+  final BotCompat compat;
 
   Bot({
     this.id,
@@ -13,12 +16,14 @@ class Bot {
     required this.startCommand,
     required this.sourcePath,
     required this.language,
+    this.compat = const BotCompat(),
   });
 
   // Metodo factory per creare una nuova versione di Bot con dettagli aggiornati
   Bot copyWith({
     String? description,
     String? startCommand,
+    BotCompat? compat,
   }) {
     return Bot(
       id: id,
@@ -27,6 +32,7 @@ class Bot {
       startCommand: startCommand ?? this.startCommand,
       sourcePath: sourcePath,
       language: language,
+      compat: compat ?? this.compat,
     );
   }
 
@@ -38,10 +44,35 @@ class Bot {
       'start_command': startCommand,
       'source_path': sourcePath,
       'language': language,
+      'compat_json': jsonEncode(compat.toJson()),
+    };
+  }
+
+  Map<String, dynamic> toResponseMap() {
+    return {
+      'id': id,
+      'bot_name': botName,
+      'description': description,
+      'start_command': startCommand,
+      'source_path': sourcePath,
+      'language': language,
+      'compat': compat.toJson(),
     };
   }
 
   factory Bot.fromMap(Map<String, dynamic> map) {
+    BotCompat compat = const BotCompat();
+    final compatJson = map['compat_json'];
+    if (compatJson is String && compatJson.isNotEmpty) {
+      try {
+        compat = BotCompat.fromJson(jsonDecode(compatJson));
+      } catch (_) {
+        compat = const BotCompat();
+      }
+    } else if (map['compat'] != null) {
+      compat = BotCompat.fromJson(map['compat'] as Map<String, dynamic>);
+    }
+
     return Bot(
       id: map['id'],
       botName: map['bot_name'],
@@ -49,6 +80,152 @@ class Bot {
       startCommand: map['start_command'] ?? '',
       sourcePath: map['source_path'],
       language: map['language'],
+      compat: compat,
+    );
+  }
+}
+
+class BotCompat {
+  final List<String> desktopRuntimes;
+  final List<String> missingDesktopRuntimes;
+  final bool? browserSupported;
+  final String? browserReason;
+
+  const BotCompat({
+    this.desktopRuntimes = const [],
+    this.missingDesktopRuntimes = const [],
+    this.browserSupported,
+    this.browserReason,
+  });
+
+  BotCompat copyWith({
+    List<String>? desktopRuntimes,
+    List<String>? missingDesktopRuntimes,
+    bool? browserSupported,
+    bool setBrowserSupportedNull = false,
+    String? browserReason,
+    bool setBrowserReasonNull = false,
+  }) {
+    return BotCompat(
+      desktopRuntimes: desktopRuntimes ?? this.desktopRuntimes,
+      missingDesktopRuntimes:
+          missingDesktopRuntimes ?? this.missingDesktopRuntimes,
+      browserSupported: setBrowserSupportedNull
+          ? null
+          : (browserSupported ?? this.browserSupported),
+      browserReason: setBrowserReasonNull
+          ? null
+          : (browserReason ?? this.browserReason),
+    );
+  }
+
+  String get desktopStatus {
+    if (desktopRuntimes.isEmpty) {
+      return 'unknown';
+    }
+    return missingDesktopRuntimes.isEmpty ? 'compatible' : 'missing-runner';
+  }
+
+  String get browserStatus {
+    if (browserSupported == null) {
+      return 'unknown';
+    }
+    return browserSupported! ? 'supported' : 'unsupported';
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'desktop': {
+        'runtimes': desktopRuntimes,
+        'missingRuntimes': missingDesktopRuntimes,
+        'status': desktopStatus,
+      },
+      'browser': {
+        'supported': browserSupported,
+        'status': browserStatus,
+        if (browserReason != null) 'reason': browserReason,
+      },
+    };
+  }
+
+  factory BotCompat.fromJson(dynamic json) {
+    if (json is! Map<String, dynamic>) {
+      return const BotCompat();
+    }
+
+    final desktop = json['desktop'];
+    final browser = json['browser'];
+
+    List<String> runtimes = const [];
+    List<String> missing = const [];
+    bool? browserSupported;
+    String? browserReason;
+
+    if (desktop is Map<String, dynamic>) {
+      final runtimeList = desktop['runtimes'] ?? desktop['requires'];
+      if (runtimeList is List) {
+        runtimes = runtimeList.whereType<String>().toList();
+      }
+      final missingList = desktop['missingRuntimes'];
+      if (missingList is List) {
+        missing = missingList.whereType<String>().toList();
+      }
+    }
+
+    if (browser is Map<String, dynamic>) {
+      final supported = browser['supported'];
+      if (supported is bool) {
+        browserSupported = supported;
+      }
+      final reason = browser['reason'];
+      if (reason is String) {
+        browserReason = reason;
+      }
+    }
+
+    return BotCompat(
+      desktopRuntimes: runtimes,
+      missingDesktopRuntimes: missing,
+      browserSupported: browserSupported,
+      browserReason: browserReason,
+    );
+  }
+
+  factory BotCompat.fromManifest(dynamic json) {
+    if (json is! Map<String, dynamic>) {
+      return const BotCompat();
+    }
+    final desktop = json['desktop'];
+    final browser = json['browser'];
+
+    List<String> runtimes = const [];
+    bool? browserSupported;
+    String? browserReason;
+
+    if (desktop is Map<String, dynamic>) {
+      final runtimeList = desktop['runtimes'] ?? desktop['requires'];
+      if (runtimeList is List) {
+        runtimes = runtimeList.whereType<String>().toList();
+      }
+    }
+
+    if (browser is Map<String, dynamic>) {
+      final supported = browser['supported'];
+      if (supported is bool) {
+        browserSupported = supported;
+      }
+      final reason = browser['reason'] ?? browser['note'];
+      if (reason is String) {
+        browserReason = reason;
+      }
+    } else if (browser is bool) {
+      browserSupported = browser;
+    }
+
+    return BotCompat(
+      desktopRuntimes: runtimes,
+      browserSupported: browserSupported,
+      browserReason: browserReason,
     );
   }
 }

--- a/lib/backend/server/server.dart
+++ b/lib/backend/server/server.dart
@@ -12,6 +12,7 @@ import 'services/execution_log_service.dart';
 import 'db/bot_database.dart';
 import 'routes.dart';
 import 'package:scriptagher/backend/server/api_integration/github_api.dart';
+import 'services/system_runtime_service.dart';
 
 Future<void> startServer() async {
   // Crea un'istanza del CustomLogger
@@ -19,8 +20,10 @@ Future<void> startServer() async {
 
   final botDatabase = BotDatabase();
   final GitHubApi gitHubApi = GitHubApi();
+  final systemRuntimeService = SystemRuntimeService();
   // Istanzia il BotService e BotController
-  final botGetService = BotGetService(botDatabase, gitHubApi);
+  final botGetService =
+      BotGetService(botDatabase, gitHubApi, systemRuntimeService);
   final botDownloadService = BotDownloadService();
   final executionLogManager = ExecutionLogManager();
   final executionService = ExecutionService(botDatabase, executionLogManager);

--- a/lib/backend/server/services/bot_download_service.dart
+++ b/lib/backend/server/services/bot_download_service.dart
@@ -43,12 +43,17 @@ class BotDownloadService {
       final botJsonPath = '${botDir.path}/${APIS.BOT_FILE_CONFIG}';
       final botDetails = await BotUtils.fetchBotDetails(botJsonPath);
 
+      final compat = BotCompat.fromManifest(botDetails['compat']);
+      final startCommand = botDetails['startCommand'] ??
+          botDetails['entrypoint'] ??
+          '';
       final bot = Bot(
         botName: botDetails['botName'],
         description: botDetails['description'],
-        startCommand: botDetails['startCommand'],
+        startCommand: startCommand,
         sourcePath: botJsonPath,
         language: language,
+        compat: compat,
       );
       await botDatabase.insertBot(bot);
       await botZip.delete();

--- a/lib/backend/server/services/system_runtime_service.dart
+++ b/lib/backend/server/services/system_runtime_service.dart
@@ -1,0 +1,59 @@
+import 'dart:async';
+import 'dart:io';
+
+import '../models/bot.dart';
+
+class SystemRuntimeService {
+  final Map<String, bool> _runtimeAvailability = {};
+
+  Future<Map<String, bool>> ensureRuntimes(List<String> runtimes) async {
+    final Map<String, bool> results = {};
+    for (final runtime in runtimes) {
+      if (_runtimeAvailability.containsKey(runtime)) {
+        results[runtime] = _runtimeAvailability[runtime]!;
+        continue;
+      }
+      final isAvailable = await _checkRuntime(runtime);
+      _runtimeAvailability[runtime] = isAvailable;
+      results[runtime] = isAvailable;
+    }
+    return results;
+  }
+
+  Map<String, bool> get cachedAvailability =>
+      Map<String, bool>.unmodifiable(_runtimeAvailability);
+
+  Future<bool> _checkRuntime(String runtime) async {
+    final sanitized = runtime.trim();
+    if (sanitized.isEmpty) {
+      return false;
+    }
+
+    try {
+      final result = await Process.run(sanitized, const ['--version']);
+      return result.exitCode == 0;
+    } on ProcessException {
+      return false;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  BotCompat applyRuntimeResults(BotCompat compat) {
+    if (compat.desktopRuntimes.isEmpty) {
+      return compat;
+    }
+    final missing = <String>[];
+    for (final runtime in compat.desktopRuntimes) {
+      final available = _runtimeAvailability[runtime];
+      if (available == false || available == null) {
+        if (available == null) {
+          // trigger a check lazily to keep cache updated for future calls
+          unawaited(ensureRuntimes([runtime]));
+        }
+        missing.add(runtime);
+      }
+    }
+    return compat.copyWith(missingDesktopRuntimes: missing);
+  }
+}

--- a/lib/frontend/widgets/components/bot_card_component.dart
+++ b/lib/frontend/widgets/components/bot_card_component.dart
@@ -5,15 +5,82 @@ class BotCard extends StatelessWidget {
   final Bot bot;
   final VoidCallback onTap;
 
-  BotCard({required this.bot, required this.onTap});
+  const BotCard({super.key, required this.bot, required this.onTap});
+
+  List<Widget> _buildStatusChips(BuildContext context) {
+    final compat = bot.compat;
+    final List<Widget> chips = [];
+
+    if (compat.desktopStatus == 'compatible') {
+      chips.add(_statusChip(
+        context,
+        label: 'Compatibile',
+        color: Colors.green.shade600,
+        icon: Icons.check_circle_outline,
+      ));
+    } else if (compat.desktopStatus == 'missing-runner') {
+      final missing = compat.missingDesktopRuntimes.join(', ');
+      final label = missing.isEmpty
+          ? 'Runner mancante'
+          : 'Runner mancante: $missing';
+      chips.add(_statusChip(
+        context,
+        label: label,
+        color: Colors.orange.shade700,
+        icon: Icons.warning_amber_rounded,
+      ));
+    }
+
+    if (compat.browserStatus == 'unsupported') {
+      chips.add(_statusChip(
+        context,
+        label: 'Non supportato nel browser',
+        color: Colors.blueGrey.shade600,
+        icon: Icons.block,
+      ));
+    }
+
+    return chips;
+  }
+
+  Widget _statusChip(BuildContext context,
+      {required String label, required Color color, required IconData icon}) {
+    return Chip(
+      avatar: Icon(icon, size: 18, color: color),
+      label: Text(label),
+      backgroundColor: color.withOpacity(0.12),
+      labelStyle: Theme.of(context)
+          .textTheme
+          .labelMedium
+          ?.copyWith(color: color, fontWeight: FontWeight.w600),
+      side: BorderSide(color: color.withOpacity(0.4)),
+      visualDensity: VisualDensity.compact,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
+    final chips = _buildStatusChips(context);
+
     return Card(
-      margin: EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+      margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
       child: ListTile(
         title: Text(bot.botName),
-        subtitle: Text(bot.description),
+        subtitle: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(bot.description),
+            if (chips.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 4,
+                children: chips,
+              ),
+            ],
+          ],
+        ),
         onTap: onTap,
       ),
     );

--- a/lib/frontend/widgets/pages/bot_detail_view.dart
+++ b/lib/frontend/widgets/pages/bot_detail_view.dart
@@ -320,6 +320,8 @@ class _BotDetailViewState extends State<BotDetailView> {
               'Descrizione: ${widget.bot.description}',
               style: Theme.of(context).textTheme.bodyLarge,
             ),
+            const SizedBox(height: 12),
+            _buildCompatBadges(context),
             const SizedBox(height: 20),
             Row(
               children: [
@@ -430,6 +432,67 @@ class _BotDetailViewState extends State<BotDetailView> {
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildCompatBadges(BuildContext context) {
+    final compat = widget.bot.compat;
+    final List<Widget> chips = [];
+
+    if (compat.desktopStatus == 'compatible') {
+      chips.add(_compatChip(
+        context,
+        label: 'Compatibile',
+        icon: Icons.check_circle_outline,
+        color: Colors.green.shade600,
+      ));
+    } else if (compat.desktopStatus == 'missing-runner') {
+      final missing = compat.missingDesktopRuntimes.join(', ');
+      final label = missing.isEmpty
+          ? 'Runner mancante'
+          : 'Runner mancante: $missing';
+      chips.add(_compatChip(
+        context,
+        label: label,
+        icon: Icons.warning_amber_rounded,
+        color: Colors.orange.shade700,
+      ));
+    }
+
+    if (compat.browserStatus == 'unsupported') {
+      chips.add(_compatChip(
+        context,
+        label: compat.browserReason ?? 'Non supportato nel browser',
+        icon: Icons.block,
+        color: Colors.blueGrey.shade600,
+      ));
+    }
+
+    if (chips.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 4,
+      children: chips,
+    );
+  }
+
+  Widget _compatChip(BuildContext context,
+      {required String label,
+      required IconData icon,
+      required Color color}) {
+    return Chip(
+      avatar: Icon(icon, size: 18, color: color),
+      label: Text(label),
+      backgroundColor: color.withOpacity(0.12),
+      labelStyle: Theme.of(context)
+          .textTheme
+          .labelMedium
+          ?.copyWith(color: color, fontWeight: FontWeight.w600),
+      side: BorderSide(color: color.withOpacity(0.4)),
+      visualDensity: VisualDensity.compact,
     );
   }
 


### PR DESCRIPTION
## Summary
- extend bot manifest documentation and model schema with a compat section
- add desktop runtime availability checks and persist compat data through the backend API
- surface compatibility badges in the Flutter UI for list and detail views

## Testing
- flutter test *(fails: flutter not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68f2b58c0c30832b8e6f3ad0a1683fea