### PR TITLE
Add browser sandbox runner for compatible bots

### DIFF
--- a/lib/frontend/models/bot.dart
+++ b/lib/frontend/models/bot.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 class Bot {
   final int? id;
   final String botName;
@@ -75,12 +78,16 @@ class BotCompat {
   final List<String> missingDesktopRuntimes;
   final bool? browserSupported;
   final String? browserReason;
+  final String? browserRunner;
+  final BrowserPayloads browserPayloads;
 
   const BotCompat({
     this.desktopRuntimes = const [],
     this.missingDesktopRuntimes = const [],
     this.browserSupported,
     this.browserReason,
+    this.browserRunner,
+    this.browserPayloads = const BrowserPayloads(),
   });
 
   String get desktopStatus {
@@ -100,12 +107,16 @@ class BotCompat {
   bool get isDesktopCompatible => desktopStatus == 'compatible';
   bool get isDesktopRunnerMissing => desktopStatus == 'missing-runner';
   bool get isBrowserUnsupported => browserStatus == 'unsupported';
+  bool get canRunInBrowser =>
+      browserSupported == true && browserPayloads.hasJavaScript;
 
   BotCompat copyWith({
     List<String>? desktopRuntimes,
     List<String>? missingDesktopRuntimes,
     bool? browserSupported,
     String? browserReason,
+    String? browserRunner,
+    BrowserPayloads? browserPayloads,
   }) {
     return BotCompat(
       desktopRuntimes: desktopRuntimes ?? this.desktopRuntimes,
@@ -113,6 +124,8 @@ class BotCompat {
           missingDesktopRuntimes ?? this.missingDesktopRuntimes,
       browserSupported: browserSupported ?? this.browserSupported,
       browserReason: browserReason ?? this.browserReason,
+      browserRunner: browserRunner ?? this.browserRunner,
+      browserPayloads: browserPayloads ?? this.browserPayloads,
     );
   }
 
@@ -127,6 +140,8 @@ class BotCompat {
         'supported': browserSupported,
         'status': browserStatus,
         if (browserReason != null) 'reason': browserReason,
+        if (browserRunner != null) 'runner': browserRunner,
+        if (!browserPayloads.isEmpty) 'payloads': browserPayloads.toJson(),
       },
     };
   }
@@ -143,6 +158,8 @@ class BotCompat {
     List<String> missing = const [];
     bool? browserSupported;
     String? browserReason;
+    String? browserRunner;
+    BrowserPayloads payloads = const BrowserPayloads();
 
     if (desktop is Map<String, dynamic>) {
       final runtimeList = desktop['runtimes'] ?? desktop['requires'];
@@ -164,6 +181,14 @@ class BotCompat {
       if (reason is String) {
         browserReason = reason;
       }
+      final runner = browser['runner'];
+      if (runner is String && runner.isNotEmpty) {
+        browserRunner = runner;
+      }
+      final payloadJson = browser['payloads'] ?? browser['artifacts'];
+      if (payloadJson != null) {
+        payloads = BrowserPayloads.fromJson(payloadJson);
+      }
     } else if (browser is bool) {
       browserSupported = browser;
     }
@@ -173,6 +198,160 @@ class BotCompat {
       missingDesktopRuntimes: missing,
       browserSupported: browserSupported,
       browserReason: browserReason,
+      browserRunner: browserRunner,
+      browserPayloads: payloads,
     );
+  }
+}
+
+class BrowserPayloads {
+  const BrowserPayloads({
+    this.javascript,
+    this.wasm,
+    Map<String, dynamic>? metadata,
+  }) : metadata = metadata ?? const {};
+
+  final BrowserPayload? javascript;
+  final BrowserPayload? wasm;
+  final Map<String, dynamic> metadata;
+
+  bool get hasJavaScript => javascript?.hasData ?? false;
+  bool get hasWasm => wasm?.hasData ?? false;
+  bool get isEmpty => !hasJavaScript && !hasWasm && metadata.isEmpty;
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+    if (javascript != null && javascript!.hasData) {
+      map['javascript'] = javascript!.toJson();
+    }
+    if (wasm != null && wasm!.hasData) {
+      map['wasm'] = wasm!.toJson();
+    }
+    if (metadata.isNotEmpty) {
+      map['metadata'] = metadata;
+    }
+    return map;
+  }
+
+  BrowserPayloads copyWith({
+    BrowserPayload? javascript,
+    BrowserPayload? wasm,
+    Map<String, dynamic>? metadata,
+  }) {
+    return BrowserPayloads(
+      javascript: javascript ?? this.javascript,
+      wasm: wasm ?? this.wasm,
+      metadata: metadata ?? this.metadata,
+    );
+  }
+
+  static BrowserPayloads fromJson(dynamic json) {
+    if (json is! Map<String, dynamic>) {
+      return const BrowserPayloads();
+    }
+
+    BrowserPayload? jsPayload;
+    BrowserPayload? wasmPayload;
+    final jsJson = json['javascript'] ?? json['js'];
+    if (jsJson != null) {
+      jsPayload = BrowserPayload.fromJson(jsJson);
+    }
+    final wasmJson = json['wasm'];
+    if (wasmJson != null) {
+      wasmPayload = BrowserPayload.fromJson(wasmJson);
+    }
+    final metadataJson = json['metadata'];
+    Map<String, dynamic>? metadata;
+    if (metadataJson is Map<String, dynamic>) {
+      metadata = metadataJson;
+    }
+
+    return BrowserPayloads(
+      javascript: jsPayload,
+      wasm: wasmPayload,
+      metadata: metadata ?? const {},
+    );
+  }
+}
+
+class BrowserPayload {
+  const BrowserPayload({
+    this.inline,
+    this.url,
+    this.base64,
+  });
+
+  final String? inline;
+  final String? url;
+  final String? base64;
+
+  bool get hasData =>
+      (inline != null && inline!.isNotEmpty) ||
+      (url != null && url!.isNotEmpty) ||
+      (base64 != null && base64!.isNotEmpty);
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{};
+    if (inline != null && inline!.isNotEmpty) {
+      map['inline'] = inline;
+    }
+    if (url != null && url!.isNotEmpty) {
+      map['url'] = url;
+    }
+    if (base64 != null && base64!.isNotEmpty) {
+      map['base64'] = base64;
+    }
+    return map;
+  }
+
+  static BrowserPayload fromJson(dynamic json) {
+    if (json is String) {
+      if (json.trim().startsWith('http')) {
+        return BrowserPayload(url: json.trim());
+      }
+      return BrowserPayload(inline: json);
+    }
+
+    if (json is! Map<String, dynamic>) {
+      return const BrowserPayload();
+    }
+
+    final inline = json['inline'] ?? json['code'] ?? json['script'];
+    final url = json['url'] ?? json['href'];
+    final base64 = json['base64'] ?? json['b64'];
+
+    return BrowserPayload(
+      inline: inline is String ? inline : null,
+      url: url is String ? url : null,
+      base64: base64 is String ? base64 : null,
+    );
+  }
+
+  String? decodeUtf8() {
+    if (inline != null) {
+      return inline;
+    }
+    if (base64 != null) {
+      try {
+        return utf8.decode(base64Decode(base64!));
+      } catch (_) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  Uint8List? decodeBytes() {
+    if (base64 != null) {
+      try {
+        return Uint8List.fromList(base64Decode(base64!));
+      } catch (_) {
+        return null;
+      }
+    }
+    if (inline != null) {
+      return Uint8List.fromList(utf8.encode(inline!));
+    }
+    return null;
   }
 }

--- a/lib/frontend/services/browser_runner/browser_bot_runner.dart
+++ b/lib/frontend/services/browser_runner/browser_bot_runner.dart
@@ -1,0 +1,26 @@
+import 'package:http/http.dart' as http;
+
+import '../../models/bot.dart';
+import 'browser_runner_models.dart';
+import 'browser_bot_runner_stub.dart'
+    if (dart.library.html) 'browser_bot_runner_web.dart' as platform;
+
+class BrowserBotRunner {
+  BrowserBotRunner({http.Client? httpClient})
+      : _delegate = platform.createBrowserRunner(httpClient: httpClient);
+
+  final platform.BrowserBotRunnerDelegate _delegate;
+
+  static bool get isSupported => platform.browserRunnerSupported;
+
+  bool get isAvailable => _delegate.isSupported;
+
+  Future<BrowserRunnerSession> start(
+    Bot bot, {
+    required String baseUrl,
+  }) {
+    return _delegate.start(bot, baseUrl: baseUrl);
+  }
+
+  void dispose() => _delegate.dispose();
+}

--- a/lib/frontend/services/browser_runner/browser_bot_runner_stub.dart
+++ b/lib/frontend/services/browser_runner/browser_bot_runner_stub.dart
@@ -1,0 +1,36 @@
+import 'package:http/http.dart' as http;
+
+import '../../models/bot.dart';
+import 'browser_runner_models.dart';
+
+abstract class BrowserBotRunnerDelegate {
+  bool get isSupported;
+
+  Future<BrowserRunnerSession> start(
+    Bot bot, {
+    required String baseUrl,
+  });
+
+  void dispose();
+}
+
+BrowserBotRunnerDelegate createBrowserRunner({http.Client? httpClient}) =>
+    _UnsupportedBrowserBotRunner();
+
+bool get browserRunnerSupported => false;
+
+class _UnsupportedBrowserBotRunner implements BrowserBotRunnerDelegate {
+  @override
+  bool get isSupported => false;
+
+  @override
+  Future<BrowserRunnerSession> start(
+    Bot bot, {
+    required String baseUrl,
+  }) {
+    throw UnsupportedError('Browser runner not available on this platform');
+  }
+
+  @override
+  void dispose() {}
+}

--- a/lib/frontend/services/browser_runner/browser_bot_runner_web.dart
+++ b/lib/frontend/services/browser_runner/browser_bot_runner_web.dart
@@ -1,0 +1,305 @@
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html';
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
+
+import '../../models/bot.dart';
+import 'browser_bot_runner_stub.dart';
+import 'browser_runner_models.dart';
+
+class BrowserBotRunnerWeb implements BrowserBotRunnerDelegate {
+  BrowserBotRunnerWeb({http.Client? httpClient})
+      : _httpClient = httpClient ?? http.Client(),
+        _ownsClient = httpClient == null;
+
+  final http.Client _httpClient;
+  final bool _ownsClient;
+
+  @override
+  bool get isSupported => true;
+
+  @override
+  Future<BrowserRunnerSession> start(
+    Bot bot, {
+    required String baseUrl,
+  }) async {
+    if (bot.compat.browserSupported != true ||
+        !bot.compat.browserPayloads.hasJavaScript) {
+      throw StateError('Bot non compatibile con l\'esecuzione nel browser');
+    }
+
+    final resolvedScript = await _resolveScript(bot, baseUrl);
+    if (resolvedScript == null) {
+      throw StateError('Payload JavaScript mancante per ${bot.botName}.');
+    }
+
+    final wasmBytes = await _resolveWasm(bot, baseUrl);
+    final worker = _createWorker();
+    final controller = StreamController<BrowserRunnerEvent>.broadcast();
+    StreamSubscription<MessageEvent>? messageSub;
+    StreamSubscription<Event>? errorSub;
+
+    void handleError(Object error) {
+      if (!controller.isClosed) {
+        controller.add(
+          BrowserRunnerEvent(
+            type: 'stderr',
+            message: error.toString(),
+          ),
+        );
+        controller.add(
+          BrowserRunnerEvent(type: 'status', message: 'failed'),
+        );
+      }
+    }
+
+    try {
+      messageSub = worker.onMessage.listen((event) {
+        _handleWorkerMessage(controller, event.data);
+      });
+
+      errorSub = worker.onError.listen((event) {
+        final message = event is ErrorEvent
+            ? (event.message?.toString() ?? 'Worker error')
+            : 'Worker error';
+        handleError(message);
+      });
+
+      final buffer = wasmBytes?.buffer;
+      final payloadMessage = <String, Object?>{
+        'type': 'start',
+        if (resolvedScript.source != null) 'source': resolvedScript.source,
+        if (resolvedScript.url != null) 'scriptUrl': resolvedScript.url,
+        if (buffer != null) 'wasmBytes': buffer,
+        'baseUrl': baseUrl,
+        'bot': {
+          'name': bot.botName,
+          'language': bot.language,
+        },
+        if (bot.compat.browserRunner != null)
+          'runner': bot.compat.browserRunner,
+        if (bot.compat.browserPayloads.metadata.isNotEmpty)
+          'metadata': bot.compat.browserPayloads.metadata,
+        if (!bot.compat.browserPayloads.isEmpty)
+          'payloads': bot.compat.browserPayloads.toJson(),
+      };
+
+      if (buffer != null) {
+        worker.postMessage(payloadMessage, [buffer]);
+      } else {
+        worker.postMessage(payloadMessage);
+      }
+    } catch (error, stackTrace) {
+      messageSub?.cancel();
+      errorSub?.cancel();
+      worker.terminate();
+      await _closeController(controller);
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+
+    return BrowserRunnerSession(
+      stream: controller.stream,
+      onStop: () async {
+        try {
+          worker.postMessage({'type': 'terminate'});
+        } catch (_) {}
+        worker.terminate();
+        await messageSub?.cancel();
+        await errorSub?.cancel();
+        await _closeController(controller);
+      },
+    );
+  }
+
+  Future<void> _closeController(
+      StreamController<BrowserRunnerEvent> controller) async {
+    if (!controller.isClosed) {
+      await controller.close();
+    }
+  }
+
+  Worker _createWorker() {
+    final blob = Blob(<String>[_workerBootstrap], 'application/javascript');
+    final url = Url.createObjectUrlFromBlob(blob);
+    final worker = Worker(url);
+    Url.revokeObjectUrl(url);
+    return worker;
+  }
+
+  Future<_ResolvedScript?> _resolveScript(Bot bot, String baseUrl) async {
+    final payload = bot.compat.browserPayloads.javascript;
+    if (payload == null || !payload.hasData) {
+      return null;
+    }
+
+    final source = payload.decodeUtf8();
+    if (source != null && source.trim().isNotEmpty) {
+      return _ResolvedScript(source: source);
+    }
+
+    final url = payload.url;
+    if (url != null && url.isNotEmpty) {
+      return _ResolvedScript(url: _resolveUrl(baseUrl, url));
+    }
+
+    return null;
+  }
+
+  Future<Uint8List?> _resolveWasm(Bot bot, String baseUrl) async {
+    final payload = bot.compat.browserPayloads.wasm;
+    if (payload == null || !payload.hasData) {
+      return null;
+    }
+
+    final inlineBytes = payload.decodeBytes();
+    if (inlineBytes != null && inlineBytes.isNotEmpty) {
+      return inlineBytes;
+    }
+
+    final url = payload.url;
+    if (url != null && url.isNotEmpty) {
+      final resolved = _resolveUrl(baseUrl, url);
+      final response = await _httpClient.get(Uri.parse(resolved));
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        return Uint8List.fromList(response.bodyBytes);
+      }
+      throw StateError(
+          'Impossibile scaricare il payload WASM (${response.statusCode}).');
+    }
+
+    return null;
+  }
+
+  void _handleWorkerMessage(
+    StreamController<BrowserRunnerEvent> controller,
+    dynamic data,
+  ) {
+    if (controller.isClosed) {
+      return;
+    }
+
+    if (data is Map) {
+      final type = data['type']?.toString() ?? 'stdout';
+      final message = data['message']?.toString() ?? '';
+      final rawCode = data['code'];
+      int? code;
+      if (rawCode is num) {
+        code = rawCode.toInt();
+      } else if (rawCode is String) {
+        code = int.tryParse(rawCode);
+      }
+      controller.add(
+        BrowserRunnerEvent(
+          type: type,
+          message: message,
+          code: code,
+        ),
+      );
+    } else if (data != null) {
+      controller.add(
+        BrowserRunnerEvent(
+          type: 'stdout',
+          message: data.toString(),
+        ),
+      );
+    }
+  }
+
+  String _resolveUrl(String baseUrl, String value) {
+    final base = Uri.parse(baseUrl);
+    final target = Uri.parse(value);
+    return (target.hasScheme ? target : base.resolveUri(target)).toString();
+  }
+
+  @override
+  void dispose() {
+    if (_ownsClient) {
+      _httpClient.close();
+    }
+  }
+}
+
+class _ResolvedScript {
+  const _ResolvedScript({this.source, this.url});
+
+  final String? source;
+  final String? url;
+}
+
+const String _workerBootstrap = r'''
+self.console = {
+  log: (...args) => self.postMessage({ type: 'stdout', message: args.join(' ') }),
+  error: (...args) => self.postMessage({ type: 'stderr', message: args.join(' ') }),
+};
+
+function send(type, message, extra) {
+  const payload = Object.assign({ type, message: String(message ?? '') }, extra || {});
+  self.postMessage(payload);
+}
+
+self.onmessage = async (event) => {
+  const data = event.data || {};
+  if (data.type === 'start') {
+    try {
+      let entrypoint = null;
+      if (typeof data.source === 'string' && data.source.length > 0) {
+        entrypoint = new Function('sandbox', 'context', data.source);
+      }
+      if (typeof data.scriptUrl === 'string' && data.scriptUrl.length > 0) {
+        importScripts(data.scriptUrl);
+        if (typeof self.scriptagherMain === 'function') {
+          entrypoint = self.scriptagherMain;
+        }
+      }
+      const sandbox = {
+        print: (value) => send('stdout', value),
+        error: (value) => send('stderr', value),
+        status: (value, code) => send('status', value, code != null ? { code } : {}),
+        emit: (type, value, extra) => send(type, value, extra),
+        wasmBytes: data.wasmBytes || null,
+        baseUrl: data.baseUrl || null,
+        bot: data.bot || {},
+        metadata: data.metadata || {},
+        payloads: data.payloads || {},
+      };
+      if (!entrypoint) {
+        throw new Error('Nessun entrypoint disponibile per il bot.');
+      }
+      const context = {
+        wasmBytes: data.wasmBytes || null,
+        baseUrl: data.baseUrl || null,
+        bot: data.bot || {},
+        metadata: data.metadata || {},
+        payloads: data.payloads || {},
+      };
+      const result = await entrypoint(sandbox, context);
+      if (typeof result === 'string' && result.length > 0) {
+        sandbox.print(result);
+      }
+      sandbox.status('finished', 0);
+    } catch (error) {
+      const message = error && error.stack ? String(error.stack) : String(error);
+      send('stderr', message);
+      send('status', 'failed', { code: 1 });
+    }
+  } else if (data.type === 'stdin') {
+    if (typeof self.scriptagherOnInput === 'function') {
+      try {
+        await self.scriptagherOnInput(data.message);
+      } catch (error) {
+        const message = error && error.stack ? String(error.stack) : String(error);
+        send('stderr', message);
+      }
+    }
+  } else if (data.type === 'terminate') {
+    close();
+  }
+};
+''';
+
+BrowserBotRunnerDelegate createBrowserRunner({http.Client? httpClient}) =>
+    BrowserBotRunnerWeb(httpClient: httpClient);
+
+bool get browserRunnerSupported => true;

--- a/lib/frontend/services/browser_runner/browser_runner_models.dart
+++ b/lib/frontend/services/browser_runner/browser_runner_models.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+class BrowserRunnerEvent {
+  BrowserRunnerEvent({
+    required this.type,
+    required this.message,
+    this.code,
+  });
+
+  final String type;
+  final String message;
+  final int? code;
+
+  bool get isStatus => type == 'status';
+}
+
+class BrowserRunnerSession {
+  BrowserRunnerSession({
+    required Stream<BrowserRunnerEvent> stream,
+    Future<void> Function()? onStop,
+  })  : _stream = stream,
+        _onStop = onStop;
+
+  final Stream<BrowserRunnerEvent> _stream;
+  final Future<void> Function()? _onStop;
+  bool _stopped = false;
+
+  Stream<BrowserRunnerEvent> get stream => _stream;
+
+  Future<void> stop() async {
+    if (_stopped) return;
+    _stopped = true;
+    if (_onStop != null) {
+      await _onStop!();
+    }
+  }
+}

--- a/lib/frontend/widgets/pages/bot_detail_view.dart
+++ b/lib/frontend/widgets/pages/bot_detail_view.dart
@@ -2,12 +2,15 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
 
 import '../../models/bot.dart';
 import '../../models/execution_log.dart';
+import '../../services/browser_runner/browser_bot_runner.dart';
+import '../../services/browser_runner/browser_runner_models.dart';
 
 class BotDetailView extends StatefulWidget {
   const BotDetailView(
@@ -27,6 +30,9 @@ class _BotDetailViewState extends State<BotDetailView> {
 
   http.Client? _client;
   StreamSubscription<String>? _subscription;
+  BrowserBotRunner? _browserRunner;
+  BrowserRunnerSession? _browserSession;
+  StreamSubscription<BrowserRunnerEvent>? _browserSubscription;
   bool _autoScroll = true;
   bool _isRunning = false;
   bool _isLoadingLogs = false;
@@ -47,6 +53,7 @@ class _BotDetailViewState extends State<BotDetailView> {
   void dispose() {
     _stopExecution();
     _scrollController.dispose();
+    _browserRunner?.dispose();
     super.dispose();
   }
 
@@ -87,6 +94,11 @@ class _BotDetailViewState extends State<BotDetailView> {
   }
 
   void _startExecution() async {
+    if (_shouldUseBrowserRunner) {
+      await _startBrowserExecution();
+      return;
+    }
+
     _stopExecution();
     setState(() {
       _entries.clear();
@@ -148,6 +160,95 @@ class _BotDetailViewState extends State<BotDetailView> {
     if (closeClient) {
       _client?.close();
       _client = null;
+    }
+    _browserSubscription?.cancel();
+    _browserSubscription = null;
+    _browserSession?.stop();
+    _browserSession = null;
+  }
+
+  bool get _shouldUseBrowserRunner =>
+      kIsWeb && BrowserBotRunner.isSupported && widget.bot.compat.canRunInBrowser;
+
+  bool get _canExecuteBot {
+    if (kIsWeb) {
+      return _shouldUseBrowserRunner;
+    }
+    return true;
+  }
+
+  Future<void> _startBrowserExecution() async {
+    _stopExecution();
+    setState(() {
+      _entries.clear();
+      _error = null;
+      _isRunning = true;
+    });
+
+    _appendEntry(
+      _ConsoleEntry(
+        message: 'Avvio sandbox browser...',
+        type: 'status',
+      ),
+    );
+
+    _browserRunner ??= BrowserBotRunner();
+
+    try {
+      final session = await _browserRunner!.start(
+        widget.bot,
+        baseUrl: widget.baseUrl,
+      );
+      _browserSession = session;
+      _browserSubscription = session.stream.listen((event) {
+        if (!mounted) return;
+        if (event.type == 'status') {
+          final display = event.code != null
+              ? '${event.message} (code: ${event.code})'
+              : event.message;
+          _appendEntry(
+            _ConsoleEntry(
+              message: display,
+              type: event.type,
+            ),
+          );
+          if (event.message == 'finished' || event.message == 'failed') {
+            setState(() {
+              _isRunning = false;
+              if (event.message == 'failed' && _error == null) {
+                _error = 'Esecuzione fallita nella sandbox browser.';
+              }
+            });
+          }
+          return;
+        }
+
+        _appendEntry(
+          _ConsoleEntry(
+            message: event.message,
+            type: event.type,
+          ),
+        );
+      }, onError: (Object error, StackTrace _) {
+        if (!mounted) return;
+        setState(() {
+          _error = 'Errore sandbox: $error';
+          _isRunning = false;
+        });
+      }, onDone: () {
+        if (!mounted) return;
+        setState(() {
+          _isRunning = false;
+        });
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _error = 'Impossibile avviare nel browser: $error';
+        _isRunning = false;
+      });
+      _browserSession?.stop();
+      _browserSession = null;
     }
   }
 
@@ -326,7 +427,7 @@ class _BotDetailViewState extends State<BotDetailView> {
             Row(
               children: [
                 ElevatedButton(
-                  onPressed: _isRunning ? null : _startExecution,
+                  onPressed: _isRunning || !_canExecuteBot ? null : _startExecution,
                   child: Text(_isRunning ? 'Esecuzione in corso...' : 'Esegui Bot'),
                 ),
                 const SizedBox(width: 16),
@@ -355,6 +456,17 @@ class _BotDetailViewState extends State<BotDetailView> {
               Text(
                 _error!,
                 style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ],
+            if (kIsWeb && !_shouldUseBrowserRunner) ...[
+              const SizedBox(height: 12),
+              Text(
+                widget.bot.compat.browserReason ??
+                    'Questo bot non è compatibile con il runner browser.',
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.error,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
             ],
             const SizedBox(height: 20),


### PR DESCRIPTION
## Summary
- extend bot compatibility metadata with browser runner configuration and payload descriptors
- add a browser sandbox runner based on Web Workers for executing JS/WASM bots and streaming console events
- update the bot detail page to route compatible bots through the browser runner and surface sandbox output/errors

## Testing
- Not run (flutter and dart tooling unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68f2b8c55e10832b8951af3d2ff880ec