### PR TITLE
Add backend process control APIs and frontend stop/kill UI

### DIFF
--- a/lib/backend/server/routes.dart
+++ b/lib/backend/server/routes.dart
@@ -22,6 +22,14 @@ class BotRoutes {
 
     router.get('/bots/downloaded', botController.fetchDownloadedBots);
 
+    router.post('/bots/<language>/<botName>/stop',
+        (Request request, String language, String botName) =>
+            botController.stopBot(request, language, botName));
+
+    router.post('/bots/<language>/<botName>/kill',
+        (Request request, String language, String botName) =>
+            botController.killBot(request, language, botName));
+
     return router;
   }
 }

--- a/lib/backend/server/server.dart
+++ b/lib/backend/server/server.dart
@@ -27,7 +27,8 @@ Future<void> startServer() async {
   final botDownloadService = BotDownloadService();
   final executionLogManager = ExecutionLogManager();
   final executionService = ExecutionService(botDatabase, executionLogManager);
-  final botController = BotController(botDownloadService, botGetService);
+  final botController =
+      BotController(botDownloadService, botGetService, executionService);
 
   // Ottieni il router con le rotte definite
   final botRoutes = BotRoutes(botController);


### PR DESCRIPTION
## Summary
- track spawned processes in the execution service, exposing helpers to stop, kill and inspect exit codes
- add REST endpoints and controller wiring so stop/kill commands can be issued server-side
- update the bot detail view to surface the latest exit code and provide Stop/Kill controls that call the new APIs

## Testing
- not run (environment lacks `dart`/`flutter` tooling)


------
https://chatgpt.com/codex/tasks/task_e_68f2b8e797e8832b845a2721979be711