### PR TITLE
Add process start endpoint and desktop integration

### DIFF
--- a/lib/backend/server/controllers/bot_controller.dart
+++ b/lib/backend/server/controllers/bot_controller.dart
@@ -4,14 +4,17 @@ import 'package:scriptagher/shared/custom_logger.dart';
 import 'package:scriptagher/shared/constants/LOGS.dart';
 import '../services/bot_get_service.dart';
 import '../services/bot_download_service.dart';
+import '../services/execution_service.dart';
 import '../models/bot.dart';
 
 class BotController {
   final CustomLogger logger = CustomLogger();
   final BotDownloadService botDownloadService;
   final BotGetService botGetService;
+  final ExecutionService executionService;
 
-  BotController(this.botDownloadService, this.botGetService);
+  BotController(
+      this.botDownloadService, this.botGetService, this.executionService);
 
   // Endpoint per ottenere la lista dei bot disponibili remoti
   Future<Response> fetchAvailableBots(Request request) async {
@@ -114,5 +117,10 @@ class BotController {
         headers: {'Content-Type': 'application/json'},
       );
     }
+  }
+
+  Future<Response> startBot(
+      Request request, String language, String botName) async {
+    return executionService.startBot(request, language, botName);
   }
 }

--- a/lib/backend/server/routes.dart
+++ b/lib/backend/server/routes.dart
@@ -22,6 +22,11 @@ class BotRoutes {
 
     router.get('/bots/downloaded', botController.fetchDownloadedBots);
 
+    router.post(
+        '/bots/<language>/<botName>/start',
+        (Request request, String language, String botName) =>
+            botController.startBot(request, language, botName));
+
     return router;
   }
 }

--- a/lib/backend/server/server.dart
+++ b/lib/backend/server/server.dart
@@ -27,7 +27,8 @@ Future<void> startServer() async {
   final botDownloadService = BotDownloadService();
   final executionLogManager = ExecutionLogManager();
   final executionService = ExecutionService(botDatabase, executionLogManager);
-  final botController = BotController(botDownloadService, botGetService);
+  final botController =
+      BotController(botDownloadService, botGetService, executionService);
 
   // Ottieni il router con le rotte definite
   final botRoutes = BotRoutes(botController);


### PR DESCRIPTION
## Summary
- add a backend start service that launches bots with language-specific runners and tracks pending processes
- expose a POST /bots/<language>/<botName>/start endpoint and wire controllers/routes to the new execution flow
- update the desktop BotDetailView to call the start endpoint, connect the stream with the returned PID, and surface launch status feedback

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f2b8f90744832ba6d1d51fd898e188