### PR TITLE
Add manifest validation and tests for bot imports

### DIFF
--- a/lib/shared/exceptions/bot_manifest_validation_exception.dart
+++ b/lib/shared/exceptions/bot_manifest_validation_exception.dart
@@ -1,0 +1,8 @@
+class BotManifestValidationException implements Exception {
+  final String message;
+
+  BotManifestValidationException(this.message);
+
+  @override
+  String toString() => 'BotManifestValidationException: $message';
+}

--- a/lib/shared/utils/BotUtils.dart
+++ b/lib/shared/utils/BotUtils.dart
@@ -1,9 +1,19 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:scriptagher/shared/custom_logger.dart';
+import 'package:scriptagher/shared/exceptions/bot_manifest_validation_exception.dart';
 
 class BotUtils {
   static final logger = CustomLogger();
+
+  static const Map<String, Type> _manifestSchema = {
+    'name': String,
+    'version': String,
+    'permissions': List,
+    'hash': String,
+  };
+
+  static final RegExp _hashRegExp = RegExp(r'^[a-fA-F0-9]{64}$');
 
   // Fetches bot details from a JSON file (bot.json)
   static Future<Map<String, dynamic>> fetchBotDetails(String botJsonPath) async {
@@ -14,10 +24,81 @@ class BotUtils {
       }
 
       String content = await botJsonFile.readAsString();
-      return json.decode(content);
+      final dynamic decoded = json.decode(content);
+      if (decoded is! Map<String, dynamic>) {
+        throw BotManifestValidationException(
+            'bot.json must contain a JSON object at the root.');
+      }
+
+      final manifest = Map<String, dynamic>.from(decoded);
+      validateBotManifest(manifest);
+      return manifest;
+    } on BotManifestValidationException catch (e) {
+      logger.error('BotUtils', 'Invalid bot manifest: ${e.message}');
+      rethrow;
     } catch (e) {
       logger.error('BotUtils', 'Error reading bot.json: $e');
       rethrow;
+    }
+  }
+
+  static void validateBotManifest(Map<String, dynamic> manifest) {
+    for (final entry in _manifestSchema.entries) {
+      final key = entry.key;
+      final expectedType = entry.value;
+      if (!manifest.containsKey(key)) {
+        throw BotManifestValidationException(
+            "Missing required field '$key' in bot.json manifest.");
+      }
+
+      final value = manifest[key];
+      if (expectedType == String && value is! String) {
+        throw BotManifestValidationException(
+            "Field '$key' must be a string in bot.json manifest.");
+      }
+      if (expectedType == List && value is! List) {
+        throw BotManifestValidationException(
+            "Field '$key' must be a list in bot.json manifest.");
+      }
+    }
+
+    final name = manifest['name'];
+    if (name is String && name.trim().isEmpty) {
+      throw BotManifestValidationException(
+          "Field 'name' cannot be empty in bot.json manifest.");
+    }
+
+    final version = manifest['version'];
+    if (version is String && version.trim().isEmpty) {
+      throw BotManifestValidationException(
+          "Field 'version' cannot be empty in bot.json manifest.");
+    }
+
+    final permissions = manifest['permissions'];
+    if (permissions is List) {
+      if (permissions.isEmpty) {
+        throw BotManifestValidationException(
+            "Field 'permissions' must contain at least one entry in bot.json manifest.");
+      }
+      final hasInvalidPermission = permissions.any(
+        (permission) => permission is! String || permission.trim().isEmpty,
+      );
+      if (hasInvalidPermission) {
+        throw BotManifestValidationException(
+            "Field 'permissions' must contain only non-empty strings in bot.json manifest.");
+      }
+    }
+
+    final hash = manifest['hash'];
+    if (hash is String) {
+      if (hash.trim().isEmpty) {
+        throw BotManifestValidationException(
+            "Field 'hash' cannot be empty in bot.json manifest.");
+      }
+      if (!_hashRegExp.hasMatch(hash)) {
+        throw BotManifestValidationException(
+            "Field 'hash' must be a 64-character hexadecimal string in bot.json manifest.");
+      }
     }
   }
 

--- a/test/shared/utils/bot_utils_test.dart
+++ b/test/shared/utils/bot_utils_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scriptagher/shared/exceptions/bot_manifest_validation_exception.dart';
+import 'package:scriptagher/shared/utils/BotUtils.dart';
+
+void main() {
+  group('BotUtils.validateBotManifest', () {
+    test('accepts a valid manifest', () {
+      final manifest = {
+        'name': 'Example Bot',
+        'version': '1.0.0',
+        'permissions': ['filesystem', 'network'],
+        'hash': 'a' * 64,
+      };
+
+      expect(() => BotUtils.validateBotManifest(manifest), returnsNormally);
+    });
+
+    test('throws when required fields are missing', () {
+      final manifest = {
+        'name': 'Example Bot',
+        'version': '1.0.0',
+        'permissions': ['filesystem'],
+      };
+
+      expect(
+        () => BotUtils.validateBotManifest(manifest),
+        throwsA(isA<BotManifestValidationException>()
+            .having((e) => e.message, 'message', contains("'hash'"))),
+      );
+    });
+
+    test('throws when permissions contain invalid entries', () {
+      final manifest = {
+        'name': 'Example Bot',
+        'version': '1.0.0',
+        'permissions': ['filesystem', ''],
+        'hash': 'b' * 64,
+      };
+
+      expect(
+        () => BotUtils.validateBotManifest(manifest),
+        throwsA(isA<BotManifestValidationException>()
+            .having((e) => e.message, 'message', contains('permissions'))),
+      );
+    });
+
+    test('throws when hash is not 64 hexadecimal characters', () {
+      final manifest = {
+        'name': 'Example Bot',
+        'version': '1.0.0',
+        'permissions': ['filesystem'],
+        'hash': 'invalid-hash',
+      };
+
+      expect(
+        () => BotUtils.validateBotManifest(manifest),
+        throwsA(isA<BotManifestValidationException>()
+            .having((e) => e.message, 'message', contains('64-character'))),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- define and apply a validation schema for bot manifests, covering name, version, permissions and hash
- introduce a dedicated validation exception and handle it during remote bot downloads
- add unit tests to verify valid and invalid manifest scenarios

## Testing
- not run (flutter command is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f2babec604832b852744d28030d51e