### PR TITLE
Add caching refresh controls for bot listings

### DIFF
--- a/lib/backend/server/routes.dart
+++ b/lib/backend/server/routes.dart
@@ -18,6 +18,9 @@ class BotRoutes {
     router.get('/bots',
         (Request request) => botController.fetchAvailableBots(request));
 
+    router.get('/bots/refresh',
+        (Request request) => botController.refreshAvailableBots(request));
+
     router.get('/localbots', botController.fetchLocalBots);
 
     router.get('/bots/downloaded', botController.fetchDownloadedBots);

--- a/lib/frontend/services/bot_get_service.dart
+++ b/lib/frontend/services/bot_get_service.dart
@@ -9,8 +9,25 @@ class BotGetService {
 
   Future<Map<String, List<Bot>>> fetchBots() => fetchOnlineBots();
 
-  Future<Map<String, List<Bot>>> fetchOnlineBots() async {
-    return _fetchGrouped(Uri.parse('$baseUrl/bots'));
+  Future<Map<String, List<Bot>>> fetchOnlineBots(
+      {bool forceRefresh = false, Duration? maxCacheAge}) async {
+    final queryParameters = <String, String>{};
+    if (forceRefresh) {
+      queryParameters['forceRefresh'] = 'true';
+    }
+    if (maxCacheAge != null) {
+      queryParameters['maxCacheAge'] = maxCacheAge.inSeconds.toString();
+    }
+
+    final uri = Uri.parse('$baseUrl/bots').replace(
+      queryParameters: queryParameters.isEmpty ? null : queryParameters,
+    );
+
+    return _fetchGrouped(uri);
+  }
+
+  Future<Map<String, List<Bot>>> refreshOnlineBots() async {
+    return _fetchGrouped(Uri.parse('$baseUrl/bots/refresh'));
   }
 
   Future<Map<String, List<Bot>>> fetchDownloadedBots() async {


### PR DESCRIPTION
## Summary
- track last remote bot list fetch in the database metadata table for cache validation
- serve cached bots when the data is still fresh while exposing force-refresh capabilities via query and dedicated endpoint
- add a frontend refresh button that triggers the forced refresh endpoint and surfaces loading feedback

## Testing
- Not run (tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68f2bae9f544832ba07f4d2b0b1f9c3b