### PR TITLE
Enhance bot metadata and detail view actions

### DIFF
--- a/lib/backend/server/models/bot.dart
+++ b/lib/backend/server/models/bot.dart
@@ -7,7 +7,11 @@ class Bot {
   final String startCommand;
   final String sourcePath;
   final String language;
+  final String? author;
+  final String? version;
+  final List<String> permissions;
   final BotCompat compat;
+  final BotPlatformCompatibility platformCompatibility;
 
   Bot({
     this.id,
@@ -16,7 +20,11 @@ class Bot {
     required this.startCommand,
     required this.sourcePath,
     required this.language,
+    this.author,
+    this.version,
+    this.permissions = const [],
     this.compat = const BotCompat(),
+    this.platformCompatibility = const BotPlatformCompatibility(),
   });
 
   // Metodo factory per creare una nuova versione di Bot con dettagli aggiornati
@@ -24,15 +32,25 @@ class Bot {
     String? description,
     String? startCommand,
     BotCompat? compat,
+    String? sourcePath,
+    String? author,
+    String? version,
+    List<String>? permissions,
+    BotPlatformCompatibility? platformCompatibility,
   }) {
     return Bot(
       id: id,
       botName: botName,
       description: description ?? this.description,
       startCommand: startCommand ?? this.startCommand,
-      sourcePath: sourcePath,
+      sourcePath: sourcePath ?? this.sourcePath,
       language: language,
+      author: author ?? this.author,
+      version: version ?? this.version,
+      permissions: permissions ?? this.permissions,
       compat: compat ?? this.compat,
+      platformCompatibility:
+          platformCompatibility ?? this.platformCompatibility,
     );
   }
 
@@ -44,7 +62,11 @@ class Bot {
       'start_command': startCommand,
       'source_path': sourcePath,
       'language': language,
+      'author': author,
+      'version': version,
+      'permissions_json': jsonEncode(permissions),
       'compat_json': jsonEncode(compat.toJson()),
+      'platforms_json': jsonEncode(platformCompatibility.toJson()),
     };
   }
 
@@ -56,7 +78,11 @@ class Bot {
       'start_command': startCommand,
       'source_path': sourcePath,
       'language': language,
+      'author': author,
+      'version': version,
+      'permissions': permissions,
       'compat': compat.toJson(),
+      'platform_compat': platformCompatibility.toJson(),
     };
   }
 
@@ -70,7 +96,38 @@ class Bot {
         compat = const BotCompat();
       }
     } else if (map['compat'] != null) {
-      compat = BotCompat.fromJson(map['compat'] as Map<String, dynamic>);
+      final value = map['compat'];
+      if (value is Map<String, dynamic>) {
+        compat = BotCompat.fromJson(value);
+      }
+    }
+
+    List<String> permissions = const [];
+    final permissionsJson = map['permissions_json'];
+    if (permissionsJson is String && permissionsJson.isNotEmpty) {
+      try {
+        final decoded = jsonDecode(permissionsJson);
+        if (decoded is List) {
+          permissions = decoded.whereType<String>().toList();
+        }
+      } catch (_) {}
+    } else if (map['permissions'] is List) {
+      permissions = (map['permissions'] as List).whereType<String>().toList();
+    }
+
+    BotPlatformCompatibility platformCompatibility =
+        const BotPlatformCompatibility();
+    final platformsJson = map['platforms_json'];
+    if (platformsJson is String && platformsJson.isNotEmpty) {
+      try {
+        platformCompatibility = BotPlatformCompatibility.fromJson(
+            jsonDecode(platformsJson));
+      } catch (_) {
+        platformCompatibility = const BotPlatformCompatibility();
+      }
+    } else if (map['platform_compat'] != null) {
+      platformCompatibility =
+          BotPlatformCompatibility.fromJson(map['platform_compat']);
     }
 
     return Bot(
@@ -78,9 +135,13 @@ class Bot {
       botName: map['bot_name'],
       description: map['description'] ?? '',
       startCommand: map['start_command'] ?? '',
-      sourcePath: map['source_path'],
-      language: map['language'],
+      sourcePath: map['source_path'] ?? '',
+      language: map['language'] ?? '',
+      author: map['author'],
+      version: map['version'],
+      permissions: permissions,
       compat: compat,
+      platformCompatibility: platformCompatibility,
     );
   }
 }
@@ -227,5 +288,169 @@ class BotCompat {
       browserSupported: browserSupported,
       browserReason: browserReason,
     );
+  }
+}
+
+enum BotPlatformSupportStatus {
+  supported,
+  unsupported,
+  partial,
+  unknown,
+}
+
+class BotPlatformCompatibility {
+  final Map<String, BotPlatformSupportStatus> platforms;
+  final List<String> notes;
+
+  const BotPlatformCompatibility({
+    this.platforms = const {},
+    this.notes = const [],
+  });
+
+  bool get isEmpty => platforms.isEmpty && notes.isEmpty;
+
+  List<String> get supported => platforms.entries
+      .where((entry) => entry.value == BotPlatformSupportStatus.supported)
+      .map((entry) => entry.key)
+      .toList();
+
+  List<String> get unsupported => platforms.entries
+      .where((entry) => entry.value == BotPlatformSupportStatus.unsupported)
+      .map((entry) => entry.key)
+      .toList();
+
+  List<String> get partial => platforms.entries
+      .where((entry) => entry.value == BotPlatformSupportStatus.partial)
+      .map((entry) => entry.key)
+      .toList();
+
+  List<String> get unknown => platforms.entries
+      .where((entry) => entry.value == BotPlatformSupportStatus.unknown)
+      .map((entry) => entry.key)
+      .toList();
+
+  Map<String, dynamic> toJson() {
+    return {
+      'platforms': platforms.map(
+        (key, value) => MapEntry(key, value.name),
+      ),
+      if (notes.isNotEmpty) 'notes': notes,
+    };
+  }
+
+  BotPlatformCompatibility copyWith({
+    Map<String, BotPlatformSupportStatus>? platforms,
+    List<String>? notes,
+  }) {
+    return BotPlatformCompatibility(
+      platforms: platforms ?? this.platforms,
+      notes: notes ?? this.notes,
+    );
+  }
+
+  factory BotPlatformCompatibility.fromJson(dynamic json) {
+    if (json == null) {
+      return const BotPlatformCompatibility();
+    }
+
+    Map<String, BotPlatformSupportStatus> platforms = {};
+    List<String> notes = const [];
+
+    if (json is Map<String, dynamic>) {
+      if (json['platforms'] is Map<String, dynamic>) {
+        platforms = _parsePlatformStatuses(json['platforms']);
+      } else {
+        platforms = _parsePlatformStatuses(json);
+      }
+
+      if (json['supported'] is List) {
+        platforms.addEntries(
+          (json['supported'] as List)
+              .whereType<String>()
+              .map((platform) => MapEntry(
+                  platform, BotPlatformSupportStatus.supported)),
+        );
+      }
+      if (json['unsupported'] is List) {
+        platforms.addEntries(
+          (json['unsupported'] as List)
+              .whereType<String>()
+              .map((platform) => MapEntry(
+                  platform, BotPlatformSupportStatus.unsupported)),
+        );
+      }
+      if (json['partial'] is List) {
+        platforms.addEntries(
+          (json['partial'] as List)
+              .whereType<String>()
+              .map((platform) =>
+                  MapEntry(platform, BotPlatformSupportStatus.partial)),
+        );
+      }
+      if (json['notes'] is List) {
+        notes = (json['notes'] as List).whereType<String>().toList();
+      }
+    } else if (json is List) {
+      platforms = {
+        for (final platform in json.whereType<String>())
+          platform: BotPlatformSupportStatus.supported,
+      };
+    } else if (json is String) {
+      platforms = {
+        for (final platform in json.split(',').map((e) => e.trim()).where(
+            (element) => element.isNotEmpty))
+          platform: BotPlatformSupportStatus.supported,
+      };
+    }
+
+    return BotPlatformCompatibility(
+      platforms: platforms,
+      notes: notes,
+    );
+  }
+
+  factory BotPlatformCompatibility.fromManifest(dynamic json) {
+    return BotPlatformCompatibility.fromJson(json);
+  }
+
+  static Map<String, BotPlatformSupportStatus> _parsePlatformStatuses(
+      Map<String, dynamic> json) {
+    final Map<String, BotPlatformSupportStatus> platforms = {};
+
+    json.forEach((key, value) {
+      final normalizedKey = key.toString();
+      platforms[normalizedKey] = _parseStatus(value);
+    });
+
+    return platforms;
+  }
+
+  static BotPlatformSupportStatus _parseStatus(dynamic value) {
+    if (value is bool) {
+      return value
+          ? BotPlatformSupportStatus.supported
+          : BotPlatformSupportStatus.unsupported;
+    }
+
+    if (value is String) {
+      switch (value.toLowerCase()) {
+        case 'yes':
+        case 'supported':
+        case 'true':
+          return BotPlatformSupportStatus.supported;
+        case 'no':
+        case 'unsupported':
+        case 'false':
+          return BotPlatformSupportStatus.unsupported;
+        case 'partial':
+        case 'experimental':
+        case 'preview':
+          return BotPlatformSupportStatus.partial;
+        default:
+          return BotPlatformSupportStatus.unknown;
+      }
+    }
+
+    return BotPlatformSupportStatus.unknown;
   }
 }

--- a/lib/frontend/models/bot.dart
+++ b/lib/frontend/models/bot.dart
@@ -5,7 +5,11 @@ class Bot {
   final String startCommand;
   final String sourcePath;
   final String language;
+  final String? author;
+  final String? version;
+  final List<String> permissions;
   final BotCompat compat;
+  final BotPlatformCompatibility platformCompatibility;
 
   Bot({
     this.id,
@@ -14,7 +18,11 @@ class Bot {
     required this.startCommand,
     required this.sourcePath,
     required this.language,
+    this.author,
+    this.version,
+    this.permissions = const [],
     this.compat = const BotCompat(),
+    this.platformCompatibility = const BotPlatformCompatibility(),
   });
 
   // Metodo factory per creare una nuova versione di Bot con dettagli aggiornati
@@ -22,15 +30,25 @@ class Bot {
     String? description,
     String? startCommand,
     BotCompat? compat,
+    String? sourcePath,
+    String? author,
+    String? version,
+    List<String>? permissions,
+    BotPlatformCompatibility? platformCompatibility,
   }) {
     return Bot(
       id: id,
       botName: botName,
       description: description ?? this.description,
       startCommand: startCommand ?? this.startCommand,
-      sourcePath: sourcePath,
+      sourcePath: sourcePath ?? this.sourcePath,
       language: language,
+      author: author ?? this.author,
+      version: version ?? this.version,
+      permissions: permissions ?? this.permissions,
       compat: compat ?? this.compat,
+      platformCompatibility:
+          platformCompatibility ?? this.platformCompatibility,
     );
   }
 
@@ -42,30 +60,47 @@ class Bot {
       'start_command': startCommand,
       'source_path': sourcePath,
       'language': language,
+      'author': author,
+      'version': version,
+      'permissions': permissions,
       'compat': compat.toJson(),
+      'platform_compat': platformCompatibility.toJson(),
     };
   }
 
   factory Bot.fromMap(Map<String, dynamic> map) {
     return Bot(
       id: map['id'],
-      botName: map['bot_name'],
+      botName: map['bot_name'] ?? '',
       description: map['description'] ?? '',
       startCommand: map['start_command'] ?? '',
-      sourcePath: map['source_path'],
-      language: map['language'],
+      sourcePath: map['source_path'] ?? '',
+      language: map['language'] ?? '',
+      author: map['author'],
+      version: map['version'],
+      permissions: (map['permissions'] as List?)?.whereType<String>().toList() ??
+          const [],
       compat: BotCompat.fromJson(map['compat']),
+      platformCompatibility:
+          BotPlatformCompatibility.fromJson(map['platform_compat']),
     );
   }
 
   factory Bot.fromJson(Map<String, dynamic> json) {
     return Bot(
+      id: json['id'],
       botName: json['bot_name'] ?? '',
       description: json['description'] ?? '',
       startCommand: json['start_command'] ?? '',
       sourcePath: json['source_path'] ?? '',
       language: json['language'] ?? '',
+      author: json['author'],
+      version: json['version'],
+      permissions:
+          (json['permissions'] as List?)?.whereType<String>().toList() ?? const [],
       compat: BotCompat.fromJson(json['compat']),
+      platformCompatibility:
+          BotPlatformCompatibility.fromJson(json['platform_compat']),
     );
   }
 }
@@ -174,5 +209,159 @@ class BotCompat {
       browserSupported: browserSupported,
       browserReason: browserReason,
     );
+  }
+}
+
+enum BotPlatformSupportStatus {
+  supported,
+  unsupported,
+  partial,
+  unknown,
+}
+
+class BotPlatformCompatibility {
+  final Map<String, BotPlatformSupportStatus> platforms;
+  final List<String> notes;
+
+  const BotPlatformCompatibility({
+    this.platforms = const {},
+    this.notes = const [],
+  });
+
+  bool get isEmpty => platforms.isEmpty && notes.isEmpty;
+
+  List<String> get supported => platforms.entries
+      .where((entry) => entry.value == BotPlatformSupportStatus.supported)
+      .map((entry) => entry.key)
+      .toList();
+
+  List<String> get unsupported => platforms.entries
+      .where((entry) => entry.value == BotPlatformSupportStatus.unsupported)
+      .map((entry) => entry.key)
+      .toList();
+
+  List<String> get partial => platforms.entries
+      .where((entry) => entry.value == BotPlatformSupportStatus.partial)
+      .map((entry) => entry.key)
+      .toList();
+
+  List<String> get unknown => platforms.entries
+      .where((entry) => entry.value == BotPlatformSupportStatus.unknown)
+      .map((entry) => entry.key)
+      .toList();
+
+  Map<String, dynamic> toJson() {
+    return {
+      'platforms': platforms.map(
+        (key, value) => MapEntry(key, value.name),
+      ),
+      if (notes.isNotEmpty) 'notes': notes,
+    };
+  }
+
+  factory BotPlatformCompatibility.fromJson(dynamic json) {
+    if (json == null) {
+      return const BotPlatformCompatibility();
+    }
+
+    Map<String, BotPlatformSupportStatus> platforms = {};
+    List<String> notes = const [];
+
+    if (json is Map<String, dynamic>) {
+      if (json['platforms'] is Map<String, dynamic>) {
+        platforms = _parsePlatformStatuses(json['platforms']);
+      } else {
+        platforms = _parsePlatformStatuses(json);
+      }
+
+      if (json['supported'] is List) {
+        platforms.addEntries(
+          (json['supported'] as List)
+              .whereType<String>()
+              .map((platform) => MapEntry(
+                  platform, BotPlatformSupportStatus.supported)),
+        );
+      }
+      if (json['unsupported'] is List) {
+        platforms.addEntries(
+          (json['unsupported'] as List)
+              .whereType<String>()
+              .map((platform) => MapEntry(
+                  platform, BotPlatformSupportStatus.unsupported)),
+        );
+      }
+      if (json['partial'] is List) {
+        platforms.addEntries(
+          (json['partial'] as List)
+              .whereType<String>()
+              .map((platform) =>
+                  MapEntry(platform, BotPlatformSupportStatus.partial)),
+        );
+      }
+      if (json['notes'] is List) {
+        notes = (json['notes'] as List).whereType<String>().toList();
+      }
+    } else if (json is List) {
+      platforms = {
+        for (final platform in json.whereType<String>())
+          platform: BotPlatformSupportStatus.supported,
+      };
+    } else if (json is String) {
+      platforms = {
+        for (final platform in json.split(',').map((e) => e.trim()).where(
+            (element) => element.isNotEmpty))
+          platform: BotPlatformSupportStatus.supported,
+      };
+    }
+
+    return BotPlatformCompatibility(
+      platforms: platforms,
+      notes: notes,
+    );
+  }
+
+  factory BotPlatformCompatibility.fromManifest(dynamic json) {
+    return BotPlatformCompatibility.fromJson(json);
+  }
+
+  static Map<String, BotPlatformSupportStatus> _parsePlatformStatuses(
+      Map<String, dynamic> json) {
+    final Map<String, BotPlatformSupportStatus> platforms = {};
+
+    json.forEach((key, value) {
+      final normalizedKey = key.toString();
+      platforms[normalizedKey] = _parseStatus(value);
+    });
+
+    return platforms;
+  }
+
+  static BotPlatformSupportStatus _parseStatus(dynamic value) {
+    if (value is bool) {
+      return value
+          ? BotPlatformSupportStatus.supported
+          : BotPlatformSupportStatus.unsupported;
+    }
+
+    if (value is String) {
+      switch (value.toLowerCase()) {
+        case 'yes':
+        case 'supported':
+        case 'true':
+          return BotPlatformSupportStatus.supported;
+        case 'no':
+        case 'unsupported':
+        case 'false':
+          return BotPlatformSupportStatus.unsupported;
+        case 'partial':
+        case 'experimental':
+        case 'preview':
+          return BotPlatformSupportStatus.partial;
+        default:
+          return BotPlatformSupportStatus.unknown;
+      }
+    }
+
+    return BotPlatformSupportStatus.unknown;
   }
 }


### PR DESCRIPTION
## Summary
- extend bot models and API responses with author, version, permissions and platform compatibility metadata
- persist the additional metadata in the database and propagate it through download/local bot flows
- enrich the bot detail view with metadata sections and wired actions for download/update, folder access and execution

## Testing
- not run (environment lacks Flutter/Dart tooling)


------
https://chatgpt.com/codex/tasks/task_e_68f2b9088968832b83f4fd36e43c4a86