### PR TITLE
Add bot upload flow for local imports

### DIFF
--- a/lib/backend/server/controllers/bot_controller.dart
+++ b/lib/backend/server/controllers/bot_controller.dart
@@ -2,16 +2,21 @@ import 'dart:convert';
 import 'package:shelf/shelf.dart';
 import 'package:scriptagher/shared/custom_logger.dart';
 import 'package:scriptagher/shared/constants/LOGS.dart';
+import 'dart:io';
+import 'package:mime/mime.dart';
 import '../services/bot_get_service.dart';
 import '../services/bot_download_service.dart';
+import '../services/bot_upload_service.dart';
 import '../models/bot.dart';
 
 class BotController {
   final CustomLogger logger = CustomLogger();
   final BotDownloadService botDownloadService;
   final BotGetService botGetService;
+  final BotUploadService botUploadService;
 
-  BotController(this.botDownloadService, this.botGetService);
+  BotController(
+      this.botDownloadService, this.botGetService, this.botUploadService);
 
   // Endpoint per ottenere la lista dei bot disponibili remoti
   Future<Response> fetchAvailableBots(Request request) async {
@@ -114,5 +119,107 @@ class BotController {
         headers: {'Content-Type': 'application/json'},
       );
     }
+  }
+
+  Future<Response> uploadBot(Request request) async {
+    try {
+      final contentType = request.headers['content-type'];
+      if (contentType == null || !contentType.contains('multipart/form-data')) {
+        return Response(400,
+            body: json.encode({
+              'error': 'Invalid request',
+              'message': 'Content-Type must be multipart/form-data.',
+            }),
+            headers: {'Content-Type': 'application/json'});
+      }
+
+      final boundary = _extractBoundary(contentType);
+      if (boundary == null) {
+        return Response(400,
+            body: json.encode({
+              'error': 'Invalid request',
+              'message': 'Multipart boundary missing.',
+            }),
+            headers: {'Content-Type': 'application/json'});
+      }
+
+      final transformer = MimeMultipartTransformer(boundary);
+      final parts = transformer.bind(request.read());
+
+      File? uploadedFile;
+      Directory? uploadTempDir;
+      await for (final part in parts) {
+        final disposition = part.headers['content-disposition'];
+        if (disposition == null || !disposition.contains('filename=')) {
+          continue;
+        }
+
+        final filenameMatch =
+            RegExp(r'filename="?([^";]*)"?').firstMatch(disposition);
+        final filename = filenameMatch?.group(1) ?? 'upload.zip';
+        uploadTempDir ??=
+            await Directory.systemTemp.createTemp('bot_upload_');
+        final file = File('${uploadTempDir.path}/$filename');
+        final sink = file.openWrite();
+        await part.pipe(sink);
+        await sink.close();
+        uploadedFile = file;
+        break;
+      }
+
+      if (uploadedFile == null) {
+        if (uploadTempDir != null && await uploadTempDir.exists()) {
+          await uploadTempDir.delete(recursive: true);
+        }
+        return Response(400,
+            body: json.encode({
+              'error': 'Invalid request',
+              'message': 'No file part found in upload.',
+            }),
+            headers: {'Content-Type': 'application/json'});
+      }
+
+      try {
+        final bot = await botUploadService.importBotArchive(uploadedFile);
+
+        return Response.ok(
+          json.encode(bot.toResponseMap()),
+          headers: {'Content-Type': 'application/json'},
+        );
+      } finally {
+        if (uploadTempDir != null && await uploadTempDir.exists()) {
+          await uploadTempDir.delete(recursive: true);
+        }
+      }
+    } on FormatException catch (e) {
+      logger.warn(LOGS.BOT_SERVICE, 'Invalid bot archive: ${e.message}');
+      return Response(400,
+          body: json.encode({
+            'error': 'Invalid bot archive',
+            'message': e.message,
+          }),
+          headers: {'Content-Type': 'application/json'});
+    } catch (e) {
+      logger.error(LOGS.BOT_SERVICE, 'Error uploading bot: $e');
+      return Response.internalServerError(
+        body: json.encode({
+          'error': 'Error uploading bot',
+          'message': e.toString(),
+        }),
+        headers: {'Content-Type': 'application/json'},
+      );
+    }
+  }
+
+  String? _extractBoundary(String contentType) {
+    final boundaryIndex = contentType.indexOf('boundary=');
+    if (boundaryIndex == -1) {
+      return null;
+    }
+    var boundary = contentType.substring(boundaryIndex + 9);
+    if (boundary.endsWith(';')) {
+      boundary = boundary.substring(0, boundary.length - 1);
+    }
+    return boundary.replaceAll('"', '');
   }
 }

--- a/lib/backend/server/db/bot_database.dart
+++ b/lib/backend/server/db/bot_database.dart
@@ -288,6 +288,16 @@ class BotDatabase {
     await batch.commit(noResult: true);
   }
 
+  Future<void> insertOrUpdateLocalBot(Bot bot) async {
+    final db = await database;
+    await db.insert(
+      'local_bots',
+      bot.toMap(),
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+    logger.info('BotDatabase', 'Local bot ${bot.botName} saved.');
+  }
+
   // Cancella tutti i bot locali (se serve)
   Future<void> clearLocalBots() async {
     final db = await database;

--- a/lib/backend/server/routes.dart
+++ b/lib/backend/server/routes.dart
@@ -22,6 +22,8 @@ class BotRoutes {
 
     router.get('/bots/downloaded', botController.fetchDownloadedBots);
 
+    router.post('/bots/upload', botController.uploadBot);
+
     return router;
   }
 }

--- a/lib/backend/server/server.dart
+++ b/lib/backend/server/server.dart
@@ -7,6 +7,7 @@ import 'package:shelf_router/shelf_router.dart';
 import 'controllers/bot_controller.dart';
 import 'services/bot_get_service.dart';
 import 'services/bot_download_service.dart';
+import 'services/bot_upload_service.dart';
 import 'services/execution_service.dart';
 import 'services/execution_log_service.dart';
 import 'db/bot_database.dart';
@@ -25,9 +26,11 @@ Future<void> startServer() async {
   final botGetService =
       BotGetService(botDatabase, gitHubApi, systemRuntimeService);
   final botDownloadService = BotDownloadService();
+  final botUploadService = BotUploadService(botDatabase);
   final executionLogManager = ExecutionLogManager();
   final executionService = ExecutionService(botDatabase, executionLogManager);
-  final botController = BotController(botDownloadService, botGetService);
+  final botController =
+      BotController(botDownloadService, botGetService, botUploadService);
 
   // Ottieni il router con le rotte definite
   final botRoutes = BotRoutes(botController);

--- a/lib/backend/server/services/bot_upload_service.dart
+++ b/lib/backend/server/services/bot_upload_service.dart
@@ -1,0 +1,163 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import 'package:scriptagher/shared/constants/APIS.dart';
+import 'package:scriptagher/shared/custom_logger.dart';
+import 'package:scriptagher/shared/utils/BotUtils.dart';
+import 'package:scriptagher/shared/utils/ZipUtils.dart';
+import '../db/bot_database.dart';
+import '../models/bot.dart';
+
+class BotUploadService {
+  BotUploadService(this.botDatabase);
+
+  final BotDatabase botDatabase;
+  final CustomLogger logger = CustomLogger();
+
+  /// Processes an uploaded bot archive and stores it locally.
+  Future<Bot> importBotArchive(File uploadedFile) async {
+    Directory? tempDir;
+    try {
+      tempDir = await Directory.systemTemp.createTemp('bot_upload_');
+      final normalizedFile =
+          await _normalizeUploadedFile(uploadedFile, tempDir: tempDir);
+      final isZip = await _isZipArchive(normalizedFile);
+      if (!isZip) {
+        throw const FormatException('Unsupported file type. Please upload a ZIP archive.');
+      }
+
+      final extractionDir = Directory(p.join(tempDir.path, 'extracted'));
+      await extractionDir.create(recursive: true);
+      await ZipUtils.unzipFile(normalizedFile.path, extractionDir.path);
+
+      final manifestFile = await _findManifestFile(extractionDir);
+      if (manifestFile == null) {
+        throw const FormatException('Bot.json manifest not found in the uploaded archive.');
+      }
+
+      final manifest = await BotUtils.fetchBotDetails(manifestFile.path);
+      final bot = _mapManifestToBot(manifest, manifestFile);
+
+      await _persistBotFiles(manifestFile.parent, bot);
+      await botDatabase.insertOrUpdateLocalBot(bot);
+
+      logger.info('BotUploadService',
+          'Imported bot ${bot.botName} (${bot.language}) successfully.');
+      return bot;
+    } finally {
+      if (tempDir != null && await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+      if (await uploadedFile.exists()) {
+        await uploadedFile.delete();
+      }
+    }
+  }
+
+  Future<File> _normalizeUploadedFile(File uploadedFile,
+      {required Directory tempDir}) async {
+    if (!await uploadedFile.exists()) {
+      throw FileSystemException('Uploaded file not found', uploadedFile.path);
+    }
+
+    if (uploadedFile.parent.path == tempDir.path) {
+      return uploadedFile;
+    }
+
+    final destination =
+        File(p.join(tempDir.path, p.basename(uploadedFile.path)));
+    await uploadedFile.copy(destination.path);
+    return destination;
+  }
+
+  Future<bool> _isZipArchive(File file) async {
+    if (!await file.exists()) {
+      return false;
+    }
+
+    final raf = await file.open();
+    try {
+      final header = await raf.read(4);
+      if (header.length < 4) return false;
+      return header[0] == 0x50 &&
+          header[1] == 0x4b &&
+          (header[2] == 0x03 || header[2] == 0x05 || header[2] == 0x07) &&
+          (header[3] == 0x04 || header[3] == 0x06 || header[3] == 0x08);
+    } finally {
+      await raf.close();
+    }
+  }
+
+  Future<File?> _findManifestFile(Directory extractionDir) async {
+    final expectedName = APIS.BOT_FILE_CONFIG.toLowerCase();
+    await for (final entity in extractionDir.list(recursive: true)) {
+      if (entity is File &&
+          p.basename(entity.path).toLowerCase() == expectedName) {
+        return entity;
+      }
+    }
+    return null;
+  }
+
+  Bot _mapManifestToBot(Map<String, dynamic> manifest, File manifestFile) {
+    final botName = _requireString(manifest, 'botName');
+    final language = _requireString(manifest, 'language');
+
+    final description = (manifest['description'] as String?)?.trim() ?? '';
+    final startCommand =
+        (manifest['startCommand'] ?? manifest['entrypoint']) as String? ?? '';
+    final compat = BotCompat.fromManifest(manifest['compat']);
+
+    final destinationManifestPath = p.join(
+      APIS.BOT_DIR_DATA_LOCAL,
+      language,
+      botName,
+      APIS.BOT_FILE_CONFIG,
+    );
+
+    return Bot(
+      botName: botName,
+      description: description,
+      startCommand: startCommand,
+      sourcePath: destinationManifestPath,
+      language: language,
+      compat: compat,
+    );
+  }
+
+  Future<void> _persistBotFiles(Directory sourceDir, Bot bot) async {
+    final destinationDir = Directory(p.join(
+      APIS.BOT_DIR_DATA_LOCAL,
+      bot.language,
+      bot.botName,
+    ));
+
+    if (await destinationDir.exists()) {
+      await destinationDir.delete(recursive: true);
+    }
+    await destinationDir.create(recursive: true);
+
+    await _copyDirectory(sourceDir, destinationDir);
+  }
+
+  Future<void> _copyDirectory(Directory source, Directory destination) async {
+    await for (final entity in source.list(followLinks: false)) {
+      final newPath = p.join(destination.path, p.basename(entity.path));
+      if (entity is File) {
+        await File(newPath).create(recursive: true);
+        await entity.copy(newPath);
+      } else if (entity is Directory) {
+        final newDir = Directory(newPath);
+        await newDir.create(recursive: true);
+        await _copyDirectory(entity, newDir);
+      }
+    }
+  }
+
+  String _requireString(Map<String, dynamic> manifest, String key) {
+    final value = manifest[key];
+    if (value is String && value.trim().isNotEmpty) {
+      return value;
+    }
+    throw FormatException('Manifest is missing required field "$key".');
+  }
+}

--- a/lib/frontend/services/bot_upload_service.dart
+++ b/lib/frontend/services/bot_upload_service.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+import '../models/bot.dart';
+
+class BotUploadService {
+  BotUploadService({this.baseUrl = 'http://localhost:8080'});
+
+  final String baseUrl;
+
+  Future<Bot> uploadBotFile({
+    required Stream<List<int>> stream,
+    required int length,
+    required String filename,
+  }) async {
+    final uri = Uri.parse('$baseUrl/bots/upload');
+    final request = http.MultipartRequest('POST', uri);
+    request.files.add(http.MultipartFile('file', stream, length,
+        filename: p.basename(filename)));
+
+    final response = await http.Response.fromStream(await request.send());
+
+    if (response.statusCode != 200) {
+      final errorBody = response.body.isNotEmpty ? response.body : null;
+      throw Exception(
+          'Impossibile caricare il bot (${response.statusCode}): ${errorBody ?? 'nessun dettaglio fornito'}');
+    }
+
+    final Map<String, dynamic> data = jsonDecode(response.body);
+    return Bot.fromJson(data);
+  }
+}

--- a/lib/frontend/widgets/pages/bot_list_view.dart
+++ b/lib/frontend/widgets/pages/bot_list_view.dart
@@ -1,7 +1,15 @@
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
 import '../../models/bot.dart';
 import '../../models/bot_navigation.dart';
 import '../../services/bot_get_service.dart';
+import '../../services/bot_upload_service.dart';
 import '../components/bot_card_component.dart';
 import 'bot_detail_view.dart';
 
@@ -15,12 +23,14 @@ class BotList extends StatefulWidget {
 class _BotListState extends State<BotList>
     with SingleTickerProviderStateMixin {
   final BotGetService _botGetService = BotGetService();
+  final BotUploadService _botUploadService = BotUploadService();
 
-  late final Map<BotCategory, Future<Map<String, List<Bot>>>> _categoryFutures;
+  late Map<BotCategory, Future<Map<String, List<Bot>>>> _categoryFutures;
   late final TabController _tabController;
 
   BotCategory _selectedCategory = BotCategory.online;
   bool _argumentsHandled = false;
+  bool _isUploading = false;
 
   @override
   void initState() {
@@ -154,6 +164,200 @@ class _BotListState extends State<BotList>
         controller: _tabController,
         children:
             BotCategory.values.map(_buildCategoryView).toList(growable: false),
+      ),
+      floatingActionButton: _selectedCategory == BotCategory.local
+          ? FloatingActionButton.extended(
+              onPressed: _isUploading ? null : _showUploadOptions,
+              icon: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 200),
+                child: _isUploading
+                    ? const SizedBox(
+                        key: ValueKey('progress'),
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.upload_file, key: ValueKey('icon')),
+              ),
+              label: Text(_isUploading ? 'Caricamento...' : 'Importa bot'),
+            )
+          : null,
+    );
+  }
+
+  Future<void> _showUploadOptions() async {
+    await showModalBottomSheet<void>(
+      context: context,
+      builder: (context) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.archive_outlined),
+              title: const Text('Seleziona archivio ZIP'),
+              onTap: () {
+                Navigator.of(context).pop();
+                _pickZipFile();
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.folder),
+              title: const Text('Seleziona cartella'),
+              onTap: () {
+                Navigator.of(context).pop();
+                _pickDirectory();
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _pickZipFile() async {
+    try {
+      final result = await FilePicker.platform.pickFiles(
+        allowMultiple: false,
+        type: FileType.custom,
+        allowedExtensions: const ['zip'],
+        withReadStream: true,
+      );
+
+      if (result == null || result.files.isEmpty) {
+        return;
+      }
+
+      final file = result.files.single;
+      final stream = _streamFromPlatformFile(file);
+      await _performUpload(
+        stream,
+        file.size,
+        file.name,
+      );
+    } catch (e) {
+      _showSnackBar('Errore durante la selezione del file: $e', isError: true);
+    }
+  }
+
+  Future<void> _pickDirectory() async {
+    try {
+      final directoryPath = await FilePicker.platform.getDirectoryPath();
+      if (directoryPath == null) {
+        return;
+      }
+
+      final zipFile = await _zipDirectory(directoryPath);
+      try {
+        final stream = zipFile.openRead();
+        final length = await zipFile.length();
+        await _performUpload(
+          stream,
+          length,
+          p.basename(zipFile.path),
+        );
+      } finally {
+        if (await zipFile.exists()) {
+          await zipFile.delete();
+        }
+      }
+    } catch (e) {
+      _showSnackBar('Errore durante la selezione della cartella: $e',
+          isError: true);
+    }
+  }
+
+  Future<File> _zipDirectory(String directoryPath) async {
+    final directory = Directory(directoryPath);
+    if (!await directory.exists()) {
+      throw Exception('La cartella selezionata non esiste più.');
+    }
+
+    final archive = Archive();
+    await for (final entity
+        in directory.list(recursive: true, followLinks: false)) {
+      if (entity is File) {
+        final relativePath = p.relative(entity.path, from: directory.path);
+        final bytes = await entity.readAsBytes();
+        archive.addFile(ArchiveFile(relativePath, bytes.length, bytes));
+      }
+    }
+
+    final encoded = ZipEncoder().encode(archive);
+    if (encoded == null) {
+      throw Exception('La cartella selezionata è vuota.');
+    }
+
+    final tempDir = await getTemporaryDirectory();
+    final zipPath =
+        p.join(tempDir.path, '${p.basename(directory.path)}.zip');
+    final zipFile = File(zipPath);
+    await zipFile.writeAsBytes(encoded, flush: true);
+    return zipFile;
+  }
+
+  Stream<List<int>> _streamFromPlatformFile(PlatformFile file) {
+    if (file.readStream != null) {
+      return file.readStream!;
+    }
+    if (file.bytes != null) {
+      return Stream<List<int>>.value(file.bytes!);
+    }
+    if (file.path != null) {
+      return File(file.path!).openRead();
+    }
+    throw Exception('Impossibile leggere il file selezionato.');
+  }
+
+  Future<void> _performUpload(
+      Stream<List<int>> stream, int length, String filename) async {
+    setState(() {
+      _isUploading = true;
+    });
+
+    try {
+      final bot = await _botUploadService.uploadBotFile(
+        stream: stream,
+        length: length,
+        filename: filename,
+      );
+
+      if (!mounted) return;
+
+      _showSnackBar('Bot "${bot.botName}" importato con successo.');
+      _refreshCategory(BotCategory.local);
+    } catch (e) {
+      _showSnackBar('Errore durante il caricamento: $e', isError: true);
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isUploading = false;
+        });
+      }
+    }
+  }
+
+  void _refreshCategory(BotCategory category) {
+    setState(() {
+      switch (category) {
+        case BotCategory.downloaded:
+          _categoryFutures[category] = _botGetService.fetchDownloadedBots();
+          break;
+        case BotCategory.online:
+          _categoryFutures[category] = _botGetService.fetchOnlineBots();
+          break;
+        case BotCategory.local:
+          _categoryFutures[category] = _botGetService.fetchLocalBots();
+          break;
+      }
+    });
+  }
+
+  void _showSnackBar(String message, {bool isError = false}) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: isError ? Theme.of(context).colorScheme.error : null,
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,8 @@ dependencies:
   sentry_flutter: ^7.18.0
   shared_preferences: ^2.3.2
   crypto: ^3.0.5
+  file_picker: ^8.0.3
+  mime: ^1.0.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a backend upload service and POST endpoint to unpack bot archives and validate manifests
- persist imported bots as local entries and improve local filesystem discovery
- wire a frontend file picker and upload workflow to import bots into the local tab

## Testing
- `flutter pub get` *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2badc74a0832b997bd83581c479f4