### PR TITLE
Add remote bot caching and refresh control

### DIFF
--- a/lib/backend/server/controllers/bot_controller.dart
+++ b/lib/backend/server/controllers/bot_controller.dart
@@ -22,8 +22,11 @@ class BotController {
   Future<Response> fetchAvailableBots(Request request) async {
     try {
       logger.info(LOGS.BOT_SERVICE, 'Fetching list of available bots...');
+      final query = request.requestedUri.queryParameters;
+      final forceRefresh =
+          query['forceRefresh'] == 'true' || query['force_refresh'] == 'true';
       final List<Bot> availableBots = await botGetService
-          .fetchAvailableBots(); // Restituisce una lista di bot con tutti i dettagli
+          .fetchAvailableBots(forceRefresh: forceRefresh);
 
       // Logga i dettagli della risposta
       logger.info(LOGS.BOT_SERVICE, 'Fetched ${availableBots.length} bots.');

--- a/lib/backend/server/services/bot_get_service.dart
+++ b/lib/backend/server/services/bot_get_service.dart
@@ -14,13 +14,31 @@ class BotGetService {
   final GitHubApi gitHubApi;
   final SystemRuntimeService systemRuntimeService;
 
+  static const Duration _cacheDuration = Duration(minutes: 15);
+
   BotGetService(
       this.botDatabase, this.gitHubApi, this.systemRuntimeService);
 
   /// Fetches the list of all available bots from the remote API.
-  Future<List<Bot>> fetchAvailableBots() async {
+  Future<List<Bot>> fetchAvailableBots({bool forceRefresh = false}) async {
     try {
       logger.info('BotService', 'Fetching available bots list.');
+
+      if (!forceRefresh) {
+        final lastFetch = await botDatabase.getLastRemoteFetch();
+        if (lastFetch != null) {
+          final isFresh = DateTime.now().toUtc().difference(lastFetch) <=
+              _cacheDuration;
+          if (isFresh) {
+            final cachedBots = await botDatabase.getAllBots();
+            if (cachedBots.isNotEmpty) {
+              logger.info('BotService',
+                  'Serving ${cachedBots.length} bots from cache (last fetch at $lastFetch).');
+              return cachedBots;
+            }
+          }
+        }
+      }
 
       // Fetch the list of bots from GitHub API
       final rawData = await gitHubApi.fetchBotsList();
@@ -51,6 +69,7 @@ class BotGetService {
 
       // Salva la lista dei bot nel database
       await botDatabase.insertBots(allBots);
+      await botDatabase.setLastRemoteFetch(DateTime.now());
 
       logger.info('BotService',
           'Successfully saved ${allBots.length} bots to the database.');
@@ -58,6 +77,14 @@ class BotGetService {
       return allBots;
     } catch (e) {
       logger.error('BotService', 'Error fetching bots: $e');
+      if (!forceRefresh) {
+        final cachedBots = await botDatabase.getAllBots();
+        if (cachedBots.isNotEmpty) {
+          logger.warn('BotService',
+              'Returning cached bots after fetch failure (${cachedBots.length} bots).');
+          return cachedBots;
+        }
+      }
       rethrow;
     }
   }

--- a/lib/frontend/services/bot_get_service.dart
+++ b/lib/frontend/services/bot_get_service.dart
@@ -7,11 +7,20 @@ class BotGetService {
 
   BotGetService({this.baseUrl = 'http://localhost:8080'});
 
-  Future<Map<String, List<Bot>>> fetchBots() => fetchOnlineBots();
+  Future<Map<String, List<Bot>>> fetchBots({bool forceRefresh = false}) =>
+      fetchOnlineBots(forceRefresh: forceRefresh);
 
-  Future<Map<String, List<Bot>>> fetchOnlineBots() async {
-    return _fetchGrouped(Uri.parse('$baseUrl/bots'));
+  Future<Map<String, List<Bot>>> fetchOnlineBots({bool forceRefresh = false}) async {
+    final uri = forceRefresh
+        ? Uri.parse('$baseUrl/bots').replace(queryParameters: {
+            'forceRefresh': 'true',
+          })
+        : Uri.parse('$baseUrl/bots');
+    return _fetchGrouped(uri);
   }
+
+  Future<Map<String, List<Bot>>> refreshOnlineBots() async =>
+      fetchOnlineBots(forceRefresh: true);
 
   Future<Map<String, List<Bot>>> fetchDownloadedBots() async {
     return _fetchGrouped(Uri.parse('$baseUrl/bots/downloaded'));


### PR DESCRIPTION
## Summary
- add a metadata table in the bot database to persist the timestamp of the last remote fetch
- reuse cached bots when the timestamp is fresh and allow forcing a refresh through the backend and frontend services
- expose an "Aggiorna" button in the bot list view that triggers the forced refresh and shows progress feedback

## Testing
- Not run (Flutter/Dart tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68f2bd688bd4832bb3b0906dc523925f