### PR TITLE
Enforce bot manifest validation and surface clear errors

### DIFF
--- a/lib/backend/server/controllers/bot_controller.dart
+++ b/lib/backend/server/controllers/bot_controller.dart
@@ -8,6 +8,7 @@ import '../services/bot_get_service.dart';
 import '../services/bot_download_service.dart';
 import '../services/bot_upload_service.dart';
 import '../models/bot.dart';
+import '../exceptions/download_exceptions.dart';
 
 class BotController {
   final CustomLogger logger = CustomLogger();
@@ -60,6 +61,14 @@ class BotController {
 
       // Rispondi con i dettagli del bot come JSON
       return Response.ok(json.encode(bot.toResponseMap()),
+          headers: {'Content-Type': 'application/json'});
+    } on DownloadException catch (e) {
+      logger.warn(LOGS.BOT_SERVICE, 'Download failed: ${e.message}');
+      return Response(400,
+          body: json.encode({
+            'error': 'Download failed',
+            'message': e.message,
+          }),
           headers: {'Content-Type': 'application/json'});
     } catch (e) {
       logger.error(LOGS.BOT_SERVICE, 'Error downloading bot: $e');

--- a/lib/shared/utils/BotUtils.dart
+++ b/lib/shared/utils/BotUtils.dart
@@ -36,6 +36,14 @@ class BotUtils {
       {String? expectedSha256}) {
     final normalized = Map<String, dynamic>.from(manifest);
 
+    final botName = _requireNonEmptyStringField(normalized,
+        const ['botName', 'name'], 'Manifest must include a non-empty botName');
+    normalized['botName'] = botName;
+
+    final version = _requireNonEmptyStringField(normalized, const ['version'],
+        'Manifest must include a non-empty version');
+    normalized['version'] = version;
+
     final dynamic shaCandidate =
         normalized['archiveSha256'] ?? normalized['sha256'];
     if (shaCandidate is! String || shaCandidate.trim().isEmpty) {
@@ -60,7 +68,7 @@ class BotUtils {
 
     final dynamic permissionsValue = normalized['permissions'];
     if (permissionsValue == null) {
-      throw const FormatException('permissions field is required');
+      throw const FormatException('Manifest must include a permissions field');
     }
     if (permissionsValue is! List) {
       throw const FormatException('permissions must be an array of strings');
@@ -78,6 +86,18 @@ class BotUtils {
     normalized['permissions'] = permissions;
 
     return normalized;
+  }
+
+  static String _requireNonEmptyStringField(Map<String, dynamic> manifest,
+      List<String> candidateKeys, String errorMessage) {
+    for (final key in candidateKeys) {
+      final value = manifest[key];
+      if (value is String && value.trim().isNotEmpty) {
+        return value.trim();
+      }
+    }
+
+    throw FormatException(errorMessage);
   }
 
   // Checks if a bot is available locally by looking for required files

--- a/test/bot_utils_test.dart
+++ b/test/bot_utils_test.dart
@@ -1,0 +1,75 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scriptagher/shared/utils/BotUtils.dart';
+
+void main() {
+  const archiveHash =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+  const validManifest = {
+    'botName': 'SampleBot',
+    'version': '1.2.3',
+    'archiveSha256': archiveHash,
+    'permissions': ['network', 'filesystem:read']
+  };
+
+  group('BotUtils.parseManifestContent', () {
+    test('returns normalized manifest for valid content', () {
+      final manifestJson = json.encode(validManifest);
+
+      final result = BotUtils.parseManifestContent(manifestJson);
+
+      expect(result['botName'], equals('SampleBot'));
+      expect(result['version'], equals('1.2.3'));
+      expect(result['archiveSha256'], equals(archiveHash.toLowerCase()));
+      expect(result['permissions'], equals(validManifest['permissions']));
+    });
+
+    test('accepts name alias for botName', () {
+      final manifestWithAlias = Map<String, dynamic>.from(validManifest)
+        ..remove('botName')
+        ..['name'] = 'AliasBot';
+      final manifestJson = json.encode(manifestWithAlias);
+
+      final result = BotUtils.parseManifestContent(manifestJson);
+
+      expect(result['botName'], equals('AliasBot'));
+    });
+
+    test('throws when botName is missing', () {
+      final manifest = Map<String, dynamic>.from(validManifest)
+        ..remove('botName');
+      final manifestJson = json.encode(manifest);
+
+      expect(
+        () => BotUtils.parseManifestContent(manifestJson),
+        throwsA(isA<FormatException>().having(
+            (e) => e.message, 'message', contains('botName'))),
+      );
+    });
+
+    test('throws when version is empty', () {
+      final manifest = Map<String, dynamic>.from(validManifest)
+        ..['version'] = '  ';
+      final manifestJson = json.encode(manifest);
+
+      expect(
+        () => BotUtils.parseManifestContent(manifestJson),
+        throwsA(isA<FormatException>().having(
+            (e) => e.message, 'message', contains('version'))),
+      );
+    });
+
+    test('throws when permissions contain invalid values', () {
+      final manifest = Map<String, dynamic>.from(validManifest)
+        ..['permissions'] = ['network', ''];
+      final manifestJson = json.encode(manifest);
+
+      expect(
+        () => BotUtils.parseManifestContent(manifestJson),
+        throwsA(isA<FormatException>().having(
+            (e) => e.message, 'message', contains('permissions'))),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- enforce required bot manifest fields for name, version, hash, and permissions
- convert manifest validation failures into download errors with HTTP 400 responses
- add unit tests covering valid and invalid manifest scenarios

## Testing
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f2bd5df978832b8e8a194c385d01f5