### PR TITLE
Add backend process control and update bot detail UI

### DIFF
--- a/lib/backend/server/controllers/bot_controller.dart
+++ b/lib/backend/server/controllers/bot_controller.dart
@@ -8,15 +8,17 @@ import '../services/bot_get_service.dart';
 import '../services/bot_download_service.dart';
 import '../services/bot_upload_service.dart';
 import '../models/bot.dart';
+import '../services/execution_service.dart';
 
 class BotController {
   final CustomLogger logger = CustomLogger();
   final BotDownloadService botDownloadService;
   final BotGetService botGetService;
   final BotUploadService botUploadService;
+  final ExecutionService executionService;
 
-  BotController(
-      this.botDownloadService, this.botGetService, this.botUploadService);
+  BotController(this.botDownloadService, this.botGetService, this.botUploadService,
+      this.executionService);
 
   // Endpoint per ottenere la lista dei bot disponibili remoti
   Future<Response> fetchAvailableBots(Request request) async {
@@ -221,5 +223,21 @@ class BotController {
       boundary = boundary.substring(0, boundary.length - 1);
     }
     return boundary.replaceAll('"', '');
+  }
+
+  Future<Response> stopBot(
+      Request request, String language, String botName) async {
+    final result = await executionService.stopExecution(language, botName);
+    return Response(result.statusCode,
+        body: json.encode(result.toJson(action: 'stop')),
+        headers: {'Content-Type': 'application/json'});
+  }
+
+  Future<Response> killBot(
+      Request request, String language, String botName) async {
+    final result = await executionService.killExecution(language, botName);
+    return Response(result.statusCode,
+        body: json.encode(result.toJson(action: 'kill')),
+        headers: {'Content-Type': 'application/json'});
   }
 }

--- a/lib/backend/server/routes.dart
+++ b/lib/backend/server/routes.dart
@@ -24,6 +24,14 @@ class BotRoutes {
 
     router.post('/bots/upload', botController.uploadBot);
 
+    router.post('/bots/<language>/<botName>/stop',
+        (Request request, String language, String botName) =>
+            botController.stopBot(request, language, botName));
+
+    router.post('/bots/<language>/<botName>/kill',
+        (Request request, String language, String botName) =>
+            botController.killBot(request, language, botName));
+
     return router;
   }
 }

--- a/lib/backend/server/server.dart
+++ b/lib/backend/server/server.dart
@@ -29,8 +29,8 @@ Future<void> startServer() async {
   final botUploadService = BotUploadService(botDatabase);
   final executionLogManager = ExecutionLogManager();
   final executionService = ExecutionService(botDatabase, executionLogManager);
-  final botController =
-      BotController(botDownloadService, botGetService, botUploadService);
+  final botController = BotController(
+      botDownloadService, botGetService, botUploadService, executionService);
 
   // Ottieni il router con le rotte definite
   final botRoutes = BotRoutes(botController);


### PR DESCRIPTION
## Summary
- keep track of running executions in the backend and expose stop/kill helpers with exit code reporting
- add REST endpoints for sending stop/kill commands through the existing controller
- update the bot detail UI to show exit codes and provide stop/kill controls

## Testing
- Not run (dart CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f2bd3ddb44832bba820498fef4a6d6