### PR TITLE
Add backend start endpoint and desktop launch flow

### DIFF
--- a/lib/backend/server/controllers/bot_controller.dart
+++ b/lib/backend/server/controllers/bot_controller.dart
@@ -7,6 +7,7 @@ import 'package:mime/mime.dart';
 import '../services/bot_get_service.dart';
 import '../services/bot_download_service.dart';
 import '../services/bot_upload_service.dart';
+import '../services/execution_service.dart';
 import '../models/bot.dart';
 
 class BotController {
@@ -14,9 +15,10 @@ class BotController {
   final BotDownloadService botDownloadService;
   final BotGetService botGetService;
   final BotUploadService botUploadService;
+  final ExecutionService executionService;
 
   BotController(
-      this.botDownloadService, this.botGetService, this.botUploadService);
+      this.botDownloadService, this.botGetService, this.botUploadService, this.executionService);
 
   // Endpoint per ottenere la lista dei bot disponibili remoti
   Future<Response> fetchAvailableBots(Request request) async {
@@ -43,6 +45,11 @@ class BotController {
           }),
           headers: {'Content-Type': 'application/json'});
     }
+  }
+
+  Future<Response> startBot(
+      Request request, String language, String botName) {
+    return executionService.startBot(request, language, botName);
   }
 
   // Endpoint per scaricare un bot specifico

--- a/lib/backend/server/routes.dart
+++ b/lib/backend/server/routes.dart
@@ -24,6 +24,11 @@ class BotRoutes {
 
     router.post('/bots/upload', botController.uploadBot);
 
+    router.post(
+        '/bots/<language>/<botName>/start',
+        (Request request, String language, String botName) =>
+            botController.startBot(request, language, botName));
+
     return router;
   }
 }

--- a/lib/backend/server/server.dart
+++ b/lib/backend/server/server.dart
@@ -30,7 +30,8 @@ Future<void> startServer() async {
   final executionLogManager = ExecutionLogManager();
   final executionService = ExecutionService(botDatabase, executionLogManager);
   final botController =
-      BotController(botDownloadService, botGetService, botUploadService);
+      BotController(botDownloadService, botGetService, botUploadService,
+          executionService);
 
   // Ottieni il router con le rotte definite
   final botRoutes = BotRoutes(botController);


### PR DESCRIPTION
## Summary
- add an execution start endpoint that launches bots with language-specific runners and tracks running sessions
- expose the new start route through the controller and router wiring
- connect the desktop BotDetailView to the start endpoint and show launch status feedback

## Testing
- not run (dart/flutter tools unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f2bd49f190832bb9fcb43fb458f842