### PR TITLE
Add process control endpoints and UI for bot executions

### DIFF
--- a/lib/backend/server/routes.dart
+++ b/lib/backend/server/routes.dart
@@ -24,6 +24,16 @@ class BotRoutes {
 
     router.post('/bots/upload', botController.uploadBot);
 
+    router.post(
+        '/bots/<language>/<botName>/stop',
+        (Request request, String language, String botName) =>
+            botController.stopBotExecution(request, language, botName));
+
+    router.post(
+        '/bots/<language>/<botName>/kill',
+        (Request request, String language, String botName) =>
+            botController.killBotExecution(request, language, botName));
+
     return router;
   }
 }

--- a/lib/backend/server/server.dart
+++ b/lib/backend/server/server.dart
@@ -29,8 +29,12 @@ Future<void> startServer() async {
   final botUploadService = BotUploadService(botDatabase);
   final executionLogManager = ExecutionLogManager();
   final executionService = ExecutionService(botDatabase, executionLogManager);
-  final botController =
-      BotController(botDownloadService, botGetService, botUploadService);
+  final botController = BotController(
+    botDownloadService,
+    botGetService,
+    botUploadService,
+    executionService,
+  );
 
   // Ottieni il router con le rotte definite
   final botRoutes = BotRoutes(botController);


### PR DESCRIPTION
## Summary
- track running process handles inside the execution service and expose helpers to stop, kill, and read exit codes
- add REST endpoints for stop/kill actions and wire them through the bot controller and routes
- update the bot detail view to display the latest exit code and provide Stop/Kill buttons that hit the new APIs

## Testing
- not run (dart tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f2bfc67c5c832b8dd2bbce12324704