### PR TITLE
Add process control endpoints and UI updates for bot executions

### DIFF
--- a/lib/backend/server/controllers/bot_controller.dart
+++ b/lib/backend/server/controllers/bot_controller.dart
@@ -56,6 +56,16 @@ class BotController {
     return executionService.startBot(request, language, botName);
   }
 
+  Future<Response> stopBot(
+      Request request, String language, String botName) {
+    return executionService.stopBot(request, language, botName);
+  }
+
+  Future<Response> killBot(
+      Request request, String language, String botName) {
+    return executionService.killBot(request, language, botName);
+  }
+
   // Endpoint per scaricare un bot specifico
   Future<Response> downloadBot(
       Request request, String language, String botName) async {

--- a/lib/backend/server/routes.dart
+++ b/lib/backend/server/routes.dart
@@ -29,6 +29,16 @@ class BotRoutes {
         (Request request, String language, String botName) =>
             botController.startBot(request, language, botName));
 
+    router.post(
+        '/bots/<language>/<botName>/stop',
+        (Request request, String language, String botName) =>
+            botController.stopBot(request, language, botName));
+
+    router.post(
+        '/bots/<language>/<botName>/kill',
+        (Request request, String language, String botName) =>
+            botController.killBot(request, language, botName));
+
     return router;
   }
 }


### PR DESCRIPTION
## Summary
- store managed process metadata in the execution service and expose stop/kill helpers with exit-code responses
- wire new stop/kill endpoints through the bot controller and router
- enhance the bot detail view with stop/kill actions, active process tracking, and exit-code display

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f2c37fff48832bb2e4197d798bb87e