### PR TITLE
feat: enhance bot detail metadata and actions

### DIFF
--- a/lib/backend/server/models/bot.dart
+++ b/lib/backend/server/models/bot.dart
@@ -151,8 +151,16 @@ class Bot {
       tags = (map['tags'] as List).whereType<String>().toList();
     }
 
+    int? id;
+    final idValue = map['id'];
+    if (idValue is int) {
+      id = idValue;
+    } else if (idValue is String) {
+      id = int.tryParse(idValue);
+    }
+
     return Bot(
-      id: map['id'],
+      id: id,
       botName: map['bot_name'],
       description: map['description'] ?? '',
       startCommand: map['start_command'] ?? '',
@@ -166,6 +174,27 @@ class Bot {
       tags: tags,
     );
   }
+
+  Map<String, dynamic> toJson() => {
+        if (id != null) 'id': id,
+        'bot_name': botName,
+        'description': description,
+        'start_command': startCommand,
+        'source_path': sourcePath,
+        'language': language,
+        'compat': compat.toJson(),
+        'permissions': permissions,
+        if (archiveSha256 != null) 'archive_sha256': archiveSha256,
+        'version': version,
+        if (author != null) 'author': author,
+        'tags': tags,
+      };
+
+  bool get isDownloaded =>
+      sourcePath.contains('data/remote') || sourcePath.contains('data\\remote');
+
+  bool get isLocal =>
+      sourcePath.contains('data/local') || sourcePath.contains('data\\local');
 }
 
 class BotCompat {

--- a/lib/frontend/models/bot.dart
+++ b/lib/frontend/models/bot.dart
@@ -93,7 +93,16 @@ class Bot {
   }
 
   factory Bot.fromJson(Map<String, dynamic> json) {
+    final dynamic idValue = json['id'];
+    int? parsedId;
+    if (idValue is int) {
+      parsedId = idValue;
+    } else if (idValue is String) {
+      parsedId = int.tryParse(idValue);
+    }
+
     return Bot(
+      id: parsedId,
       botName: json['bot_name'] ?? '',
       description: json['description'] ?? '',
       startCommand: json['start_command'] ?? '',
@@ -108,6 +117,27 @@ class Bot {
       tags: (json['tags'] as List?)?.whereType<String>().toList() ?? const [],
     );
   }
+
+  Map<String, dynamic> toJson() => {
+        if (id != null) 'id': id,
+        'bot_name': botName,
+        'description': description,
+        'start_command': startCommand,
+        'source_path': sourcePath,
+        'language': language,
+        'compat': compat.toJson(),
+        'permissions': permissions,
+        if (archiveSha256 != null) 'archive_sha256': archiveSha256,
+        'version': version,
+        if (author != null) 'author': author,
+        'tags': tags,
+      };
+
+  bool get isDownloaded =>
+      sourcePath.contains('data/remote') || sourcePath.contains('data\\remote');
+
+  bool get isLocal =>
+      sourcePath.contains('data/local') || sourcePath.contains('data\\local');
 }
 
 class BotCompat {

--- a/lib/frontend/services/bot_download_service.dart
+++ b/lib/frontend/services/bot_download_service.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../models/bot.dart';
+
+class BotDownloadService {
+  BotDownloadService({this.baseUrl = 'http://localhost:8080'});
+
+  final String baseUrl;
+
+  Future<Bot> downloadBot(String language, String botName) async {
+    final uri = Uri.parse(
+        '$baseUrl/bots/${Uri.encodeComponent(language)}/${Uri.encodeComponent(botName)}');
+
+    final response = await http.get(uri);
+    if (response.statusCode == 200) {
+      final Map<String, dynamic> data =
+          jsonDecode(response.body) as Map<String, dynamic>;
+      return Bot.fromJson(data);
+    }
+
+    try {
+      final Map<String, dynamic> error =
+          jsonDecode(response.body) as Map<String, dynamic>;
+      final message = error['message']?.toString();
+      if (message != null && message.isNotEmpty) {
+        throw Exception(message);
+      }
+    } catch (_) {
+      // ignore decoding errors and throw generic one below
+    }
+
+    throw Exception('Download fallito (codice ${response.statusCode}).');
+  }
+}

--- a/lib/frontend/services/bot_get_service.dart
+++ b/lib/frontend/services/bot_get_service.dart
@@ -23,6 +23,13 @@ class BotGetService {
     return applyFilter(grouped, filter);
   }
 
+  Future<List<Bot>> fetchOnlineBotsFlat(
+      {bool forceRefresh = false, BotFilter? filter}) async {
+    final grouped = await fetchOnlineBots(
+        forceRefresh: forceRefresh, filter: filter);
+    return grouped.values.expand((bots) => bots).toList();
+  }
+
   Future<Map<String, List<Bot>>> refreshOnlineBots() async =>
       fetchOnlineBots(forceRefresh: true);
 


### PR DESCRIPTION
## Summary
- parse and expose bot metadata consistently in the frontend/back-end models
- add a download service plus a flat online fetch helper for status lookups
- refresh the bot detail view to show metadata and manage download/update/open/run actions with state handling

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f2c73d28c0832bb2dc354324b780de