### PR TITLE
Adjust command token buffer flushing

### DIFF
--- a/lib/backend/server/services/execution_service.dart
+++ b/lib/backend/server/services/execution_service.dart
@@ -590,11 +590,13 @@ class ExecutionService {
     var inDoubleQuote = false;
     var escaping = false;
 
-    void flush() {
+    String? flush() {
       if (buffer.isNotEmpty) {
-        yield buffer.toString();
+        final token = buffer.toString();
         buffer.clear();
+        return token;
       }
+      return null;
     }
 
     for (final rune in command.runes) {
@@ -621,14 +623,20 @@ class ExecutionService {
       }
 
       if (char.trim().isEmpty && !inSingleQuote && !inDoubleQuote) {
-        flush();
+        final token = flush();
+        if (token != null) {
+          yield token;
+        }
         continue;
       }
 
       buffer.write(char);
     }
 
-    flush();
+    final token = flush();
+    if (token != null) {
+      yield token;
+    }
   }
 
   bool _looksLikePythonInterpreter(String value) {


### PR DESCRIPTION
## Summary
- return the buffered token from `_splitCommand`'s helper so the generator can yield directly
- ensure whitespace splitting and the final flush both emit tokens only when the buffer contains data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f2cf3789a8832bacdc3c6d433fb365