### PR TITLE
Remove Sentry telemetry integration

### DIFF
--- a/lib/shared/constants/telemetry.dart
+++ b/lib/shared/constants/telemetry.dart
@@ -1,4 +1,4 @@
-const String telemetryDsn = String.fromEnvironment(
-  'SCRIPTAGHER_SENTRY_DSN',
-  defaultValue: '',
+const bool telemetryDefaultOptIn = bool.fromEnvironment(
+  'SCRIPTAGHER_TELEMETRY_OPT_IN',
+  defaultValue: false,
 );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,6 @@ dependencies:
   path_provider: ^2.1.3
   bitsdojo_window: ^0.1.6
   url_launcher: ^6.3.1
-  sentry_flutter: ^7.18.0
   shared_preferences: ^2.3.2
   crypto: ^3.0.5
   file_picker: ^8.0.3


### PR DESCRIPTION
## Summary
- remove the sentry_flutter dependency and simplify the telemetry configuration
- replace the Sentry-based telemetry service with a local CustomLogger backend

## Testing
- ⚠️ `flutter pub get` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f2cf38b034832b87b1bb54b412fb5f