### PR TITLE
Update home page navigation to handle settings section

### DIFF
--- a/lib/frontend/widgets/pages/home_page_view.dart
+++ b/lib/frontend/widgets/pages/home_page_view.dart
@@ -30,20 +30,27 @@ class _HomePageState extends State<HomePage>
       icon: Icons.folder_outlined,
       category: BotCategory.local,
     ),
-    _Section(
+  ];
+
+  final List<_SectionItem> _sections = const [
+    _SectionItem(
       title: 'Impostazioni',
       description: 'Gestisci preferenze, privacy e telemetria',
+      icon: Icons.settings_outlined,
       routeName: '/settings',
     ),
   ];
 
   late final TabController _tabController;
   int _selectedIndex = 0;
+  bool _isTabControllerUpdateFromNavigation = false;
+
+  int get _totalDestinations => _categories.length + _sections.length;
 
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: _categories.length, vsync: this);
+    _tabController = TabController(length: _totalDestinations, vsync: this);
     _tabController.addListener(_handleTabSelection);
   }
 
@@ -55,21 +62,34 @@ class _HomePageState extends State<HomePage>
   }
 
   void _handleTabSelection() {
-    if (!_tabController.indexIsChanging) {
-      setState(() {
-        _selectedIndex = _tabController.index;
-      });
+    if (_tabController.indexIsChanging) return;
+
+    setState(() {
+      _selectedIndex = _tabController.index;
+    });
+
+    if (_isTabControllerUpdateFromNavigation) {
+      _isTabControllerUpdateFromNavigation = false;
+      return;
     }
+
+    _handleSelection(_tabController.index);
   }
 
   void _onDestinationSelected(int index) {
-    if (_selectedIndex == index) return;
+    if (_selectedIndex == index) {
+      _handleSelection(index);
+      return;
+    }
     setState(() {
       _selectedIndex = index;
       if (_tabController.index != index) {
+        _isTabControllerUpdateFromNavigation = true;
         _tabController.index = index;
       }
     });
+
+    _handleSelection(index);
   }
 
   void _openBots(BotCategory category) {
@@ -80,13 +100,71 @@ class _HomePageState extends State<HomePage>
     );
   }
 
+  void _openSection(_SectionItem section) {
+    Navigator.pushNamed(context, section.routeName);
+  }
+
+  void _handleSelection(int index) {
+    if (index < _categories.length) {
+      return;
+    }
+
+    final section = _sections[index - _categories.length];
+    _openSection(section);
+  }
+
   void _openTutorial() {
     Navigator.pushNamed(context, '/tutorial');
   }
 
-  Widget _buildCategoryContent(_Category category) {
+  Widget _buildCategoryContent(int index) {
+    if (index < _categories.length) {
+      final category = _categories[index];
+      return Padding(
+        key: ValueKey(category.category),
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(category.icon, size: 32, color: Colors.blueAccent),
+                const SizedBox(width: 12),
+                Text(
+                  category.title,
+                  style: const TextStyle(
+                    fontSize: 28,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Text(
+              category.description,
+              style: const TextStyle(
+                fontSize: 16,
+                color: Colors.black54,
+              ),
+            ),
+            const Spacer(),
+            Align(
+              alignment: Alignment.bottomRight,
+              child: ElevatedButton.icon(
+                onPressed: () => _openBots(category.category),
+                icon: const Icon(Icons.arrow_forward),
+                label: const Text('Apri elenco'),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final section = _sections[index - _categories.length];
     return Padding(
-      key: ValueKey(category.category),
+      key: ValueKey(section.routeName),
       padding: const EdgeInsets.all(16.0),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -94,10 +172,10 @@ class _HomePageState extends State<HomePage>
           Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(category.icon, size: 32, color: Colors.blueAccent),
+              Icon(section.icon, size: 32, color: Colors.blueAccent),
               const SizedBox(width: 12),
               Text(
-                category.title,
+                section.title,
                 style: const TextStyle(
                   fontSize: 28,
                   fontWeight: FontWeight.bold,
@@ -107,7 +185,7 @@ class _HomePageState extends State<HomePage>
           ),
           const SizedBox(height: 16),
           Text(
-            category.description,
+            section.description,
             style: const TextStyle(
               fontSize: 16,
               color: Colors.black54,
@@ -117,9 +195,9 @@ class _HomePageState extends State<HomePage>
           Align(
             alignment: Alignment.bottomRight,
             child: ElevatedButton.icon(
-              onPressed: () => _openBots(category.category),
+              onPressed: () => _openSection(section),
               icon: const Icon(Icons.arrow_forward),
-              label: const Text('Apri elenco'),
+              label: Text('Apri ${section.title}'),
             ),
           ),
         ],
@@ -213,26 +291,34 @@ class _HomePageState extends State<HomePage>
                           selectedIndex: _selectedIndex,
                           onDestinationSelected: _onDestinationSelected,
                           labelType: NavigationRailLabelType.all,
-                          destinations: _categories
-                              .map(
-                                (category) => NavigationRailDestination(
-                                  icon: Icon(category.icon),
-                                  selectedIcon: Icon(
-                                    category.icon,
-                                    color: Colors.blueAccent,
-                                  ),
-                                  label: Text(category.title),
+                          destinations: [
+                            ..._categories.map(
+                              (category) => NavigationRailDestination(
+                                icon: Icon(category.icon),
+                                selectedIcon: Icon(
+                                  category.icon,
+                                  color: Colors.blueAccent,
                                 ),
-                              )
-                              .toList(),
+                                label: Text(category.title),
+                              ),
+                            ),
+                            ..._sections.map(
+                              (section) => NavigationRailDestination(
+                                icon: Icon(section.icon),
+                                selectedIcon: Icon(
+                                  section.icon,
+                                  color: Colors.blueAccent,
+                                ),
+                                label: Text(section.title),
+                              ),
+                            ),
+                          ],
                         ),
                         const VerticalDivider(width: 1),
                         Expanded(
                           child: AnimatedSwitcher(
                             duration: const Duration(milliseconds: 200),
-                            child: _buildCategoryContent(
-                              _categories[_selectedIndex],
-                            ),
+                            child: _buildCategoryContent(_selectedIndex),
                           ),
                         ),
                       ],
@@ -246,17 +332,19 @@ class _HomePageState extends State<HomePage>
                         controller: _tabController,
                         labelColor: Colors.blueAccent,
                         unselectedLabelColor: Colors.grey,
-                        tabs: _categories
-                            .map((category) => Tab(text: category.title))
-                            .toList(),
+                        tabs: [
+                          ..._categories.map((category) => Tab(text: category.title)),
+                          ..._sections.map((section) => Tab(text: section.title)),
+                        ],
                       ),
                       const SizedBox(height: 16),
                       Expanded(
                         child: TabBarView(
                           controller: _tabController,
-                          children: _categories
-                              .map(_buildCategoryContent)
-                              .toList(),
+                          children: List.generate(
+                            _totalDestinations,
+                            _buildCategoryContent,
+                          ),
                         ),
                       ),
                     ],
@@ -282,5 +370,19 @@ class _Category {
     required this.description,
     required this.icon,
     required this.category,
+  });
+}
+
+class _SectionItem {
+  final String title;
+  final String description;
+  final IconData icon;
+  final String routeName;
+
+  const _SectionItem({
+    required this.title,
+    required this.description,
+    required this.icon,
+    required this.routeName,
   });
 }


### PR DESCRIPTION
## Summary
- separate home page navigation categories from additional sections
- add a dedicated settings section that opens the /settings route when selected
- update navigation rail, tabs, and content panes to handle both categories and sections consistently

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f2cf411110832b9e0e8562d808dc3d