### PR TITLE
Update widget test to cover home page categories

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,26 +5,23 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:scriptagher/main.dart';
+import 'package:scriptagher/shared/services/telemetry_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+  testWidgets('Home page shows navigation categories', (WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final telemetryService = TelemetryService();
+    await telemetryService.initialize();
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    await tester.pumpWidget(MyApp(telemetryService: telemetryService));
+    await tester.pumpAndSettle();
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Scaricati'), findsOneWidget);
+    expect(find.text('Online'), findsOneWidget);
+    expect(find.text('Locali'), findsOneWidget);
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -20,8 +20,8 @@ void main() {
     await tester.pumpWidget(MyApp(telemetryService: telemetryService));
     await tester.pumpAndSettle();
 
-    expect(find.text('Scaricati'), findsOneWidget);
-    expect(find.text('Online'), findsOneWidget);
-    expect(find.text('Locali'), findsOneWidget);
+    expect(find.text('Scaricati'), findsWidgets);
+    expect(find.text('Online'), findsWidgets);
+    expect(find.text('Locali'), findsWidgets);
   });
 }


### PR DESCRIPTION
## Summary
- update the widget test to initialize the telemetry service and mock shared preferences
- ensure the home page categories are rendered by checking for the Scaricati/Online/Locali cards

## Testing
- flutter test *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f2da3cda74832b888886bd0a67f585