### PR TITLE
Add backend CORS middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Il file `Bot.json` contiene i metadati (nome, descrizione, versione), l'entrypoi
 
 > **Sicurezza:** sviluppa bot in ambienti isolati, dichiara solo le permission indispensabili e controlla l'origine dei pacchetti. Altri suggerimenti sono disponibili nella guida dedicata.
 
+### Backend API e CORS
+
+Il server backend Shelf esposto su `http://localhost:8080` gestisce automaticamente le richieste `OPTIONS` e applica gli header CORS `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods` e `Access-Control-Allow-Headers` a tutte le risposte, inclusi gli stream SSE. Assicurati che qualsiasi client personalizzato invii le richieste con gli header previsti (ad esempio `Content-Type` o `Authorization`) per sfruttare correttamente il supporto CORS fornito dal backend.
+
 ## Struttura del Progetto
 La struttura di base di un'app Flutter è la seguente:
 

--- a/lib/backend/server/services/execution_service.dart
+++ b/lib/backend/server/services/execution_service.dart
@@ -327,11 +327,10 @@ class ExecutionService {
 
     return Response.ok(
       controller.stream,
-      headers: {
+      headers: const <String, String>{
         'Content-Type': 'text/event-stream',
         'Cache-Control': 'no-cache',
         'Connection': 'keep-alive',
-        'Access-Control-Allow-Origin': '*',
       },
     );
   }

--- a/test/backend/server/server_test.dart
+++ b/test/backend/server/server_test.dart
@@ -1,0 +1,54 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shelf/shelf.dart';
+
+import 'package:scriptagher/backend/server/server.dart';
+
+void main() {
+  group('CORS middleware', () {
+    test('responds to OPTIONS requests with default CORS headers', () async {
+      final Handler handler = const Pipeline()
+          .addMiddleware(createMiddleware())
+          .addHandler((Request _) => Response.ok('OK'));
+
+      final Response response =
+          await handler(Request('OPTIONS', Uri.parse('http://localhost/test')));
+
+      expect(response.statusCode, equals(200));
+      expect(response.headers['Access-Control-Allow-Origin'], equals('*'));
+      expect(response.headers['Access-Control-Allow-Methods'], contains('OPTIONS'));
+      expect(response.headers['Access-Control-Allow-Headers'], contains('Content-Type'));
+      expect(await response.readAsString(), isEmpty);
+    });
+
+    test('adds CORS headers to streaming responses without removing existing ones',
+        () async {
+      final Handler handler = const Pipeline()
+          .addMiddleware(createMiddleware())
+          .addHandler((Request _) {
+        final Stream<List<int>> stream = Stream<List<int>>.fromIterable(
+          <List<int>>[utf8.encode('data: test\\n\\n')],
+        );
+        return Response.ok(
+          stream,
+          headers: const <String, String>{
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache',
+            'Connection': 'keep-alive',
+          },
+        );
+      });
+
+      final Response response =
+          await handler(Request('GET', Uri.parse('http://localhost/stream')));
+
+      expect(response.headers['Access-Control-Allow-Origin'], equals('*'));
+      expect(response.headers['Access-Control-Allow-Methods'], isNotEmpty);
+      expect(response.headers['Access-Control-Allow-Headers'], isNotEmpty);
+      expect(response.headers['Content-Type'], 'text/event-stream');
+      expect(response.headers['Cache-Control'], 'no-cache');
+      expect(response.headers['Connection'], 'keep-alive');
+    });
+  });
+}

--- a/test/backend/server/server_test.dart
+++ b/test/backend/server/server_test.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf.dart' hide createMiddleware;
 
 import 'package:scriptagher/backend/server/server.dart';
 


### PR DESCRIPTION
## Summary
- add a reusable CORS middleware that answers OPTIONS requests and augments all responses
- ensure the streaming execution endpoint relies on the middleware for cross-origin headers
- document the new API behaviour and cover it with automated tests

## Testing
- flutter test *(fails: Flutter SDK not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f3770bae08832b873571b453a79a3d