### PR TITLE
Add theme controller with persistent theme switching

### DIFF
--- a/lib/frontend/widgets/components/window_title_bar_desktop.dart
+++ b/lib/frontend/widgets/components/window_title_bar_desktop.dart
@@ -3,6 +3,7 @@ import 'dart:io' show Platform;
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:bitsdojo_window/bitsdojo_window.dart';
+import 'package:scriptagher/shared/theme/theme_controller.dart';
 
 bool get _isDesktop =>
     !kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS);
@@ -21,10 +22,13 @@ class WindowTitleBar extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
+    final colorScheme = Theme.of(context).colorScheme;
+    final themeController = ThemeController();
+
     return WindowTitleBarBox(
       child: MoveWindow(
         child: Container(
-          color: const Color.fromARGB(34, 34, 34, 221),
+          color: colorScheme.surface,
           height: 40,
           padding: const EdgeInsets.symmetric(horizontal: 12),
           child: Row(
@@ -32,46 +36,73 @@ class WindowTitleBar extends StatelessWidget {
             children: [
               GestureDetector(
                 onTap: () => Navigator.pushNamed(context, '/home'),
-                child: const Text(
+                child: Text(
                   'Scriptagher',
-                  style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 18,
-                    fontWeight: FontWeight.w600,
-                  ),
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        color: colorScheme.onSurface,
+                        fontWeight: FontWeight.w600,
+                      ),
                 ),
               ),
-              PopupMenuButton<_MenuOption>(
-                icon: const Icon(Icons.menu, color: Colors.white),
-                onSelected: (opt) {
-                  switch (opt) {
-                    case _MenuOption.portfolio:
-                      Navigator.pushNamed(context, '/portfolio');
-                      break;
-                    case _MenuOption.botsList:
-                      Navigator.pushNamed(context, '/bots');
-                      break;
-                  }
-                },
-                itemBuilder: (ctx) => const [
-                  const PopupMenuItem<_MenuOption>(
-                    enabled: false,
-                    child: const Text(
-                      'Prima Sezione',
-                      style: TextStyle(
-                        fontWeight: FontWeight.bold,
-                        color: Colors.white70,
+              Row(
+                children: [
+                  AnimatedBuilder(
+                    animation: themeController,
+                    builder: (context, _) {
+                      final currentTheme = themeController.currentTheme;
+                      return PopupMenuButton<AppTheme>(
+                        tooltip: 'Cambia tema',
+                        initialValue: currentTheme,
+                        icon: Icon(
+                          Icons.brightness_6,
+                          color: colorScheme.onSurface,
+                        ),
+                        onSelected: (theme) => themeController.setTheme(theme),
+                        itemBuilder: (ctx) => AppTheme.values
+                            .map(
+                              (theme) => CheckedPopupMenuItem<AppTheme>(
+                                value: theme,
+                                checked: theme == currentTheme,
+                                child: Text(_labelForTheme(theme)),
+                              ),
+                            )
+                            .toList(),
+                      );
+                    },
+                  ),
+                  const SizedBox(width: 8),
+                  PopupMenuButton<_MenuOption>(
+                    icon: Icon(Icons.menu, color: colorScheme.onSurface),
+                    onSelected: (opt) {
+                      switch (opt) {
+                        case _MenuOption.portfolio:
+                          Navigator.pushNamed(context, '/portfolio');
+                          break;
+                        case _MenuOption.botsList:
+                          Navigator.pushNamed(context, '/bots');
+                          break;
+                      }
+                    },
+                    itemBuilder: (ctx) => const [
+                      PopupMenuItem<_MenuOption>(
+                        enabled: false,
+                        child: Text(
+                          'Prima Sezione',
+                          style: TextStyle(
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
                       ),
-                    ),
-                  ),
-                  const PopupMenuDivider(),
-                  const PopupMenuItem<_MenuOption>(
-                    value: _MenuOption.portfolio,
-                    child: const Text('Portfolio'),
-                  ),
-                  const PopupMenuItem<_MenuOption>(
-                    value: _MenuOption.botsList,
-                    child: const Text('Bots List'),
+                      PopupMenuDivider(),
+                      PopupMenuItem<_MenuOption>(
+                        value: _MenuOption.portfolio,
+                        child: Text('Portfolio'),
+                      ),
+                      PopupMenuItem<_MenuOption>(
+                        value: _MenuOption.botsList,
+                        child: Text('Bots List'),
+                      ),
+                    ],
                   ),
                 ],
               ),
@@ -84,3 +115,14 @@ class WindowTitleBar extends StatelessWidget {
 }
 
 enum _MenuOption { portfolio, botsList }
+
+String _labelForTheme(AppTheme theme) {
+  switch (theme) {
+    case AppTheme.light:
+      return 'Tema chiaro';
+    case AppTheme.dark:
+      return 'Tema scuro';
+    case AppTheme.highContrast:
+      return 'Alto contrasto';
+  }
+}

--- a/lib/frontend/widgets/components/window_title_bar_web.dart
+++ b/lib/frontend/widgets/components/window_title_bar_web.dart
@@ -1,29 +1,54 @@
 import 'package:flutter/material.dart';
+import 'package:scriptagher/shared/theme/theme_controller.dart';
 
 class WindowTitleBar extends StatelessWidget {
   const WindowTitleBar({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final themeController = ThemeController();
+
     return Container(
-      color: Colors.blueGrey.shade900,
+      color: colorScheme.surface,
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       child: Row(
         children: [
           GestureDetector(
             onTap: () => Navigator.pushNamed(context, '/home'),
-            child: const Text(
+            child: Text(
               'Scriptagher',
-              style: TextStyle(
-                color: Colors.white,
-                fontSize: 18,
-                fontWeight: FontWeight.w600,
-              ),
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: colorScheme.onSurface,
+                    fontWeight: FontWeight.w600,
+                  ),
             ),
           ),
           const Spacer(),
+          AnimatedBuilder(
+            animation: themeController,
+            builder: (context, _) {
+              final currentTheme = themeController.currentTheme;
+              return PopupMenuButton<AppTheme>(
+                tooltip: 'Cambia tema',
+                initialValue: currentTheme,
+                icon: Icon(Icons.brightness_6, color: colorScheme.onSurface),
+                onSelected: (theme) => themeController.setTheme(theme),
+                itemBuilder: (ctx) => AppTheme.values
+                    .map(
+                      (theme) => CheckedPopupMenuItem<AppTheme>(
+                        value: theme,
+                        checked: theme == currentTheme,
+                        child: Text(_labelForTheme(theme)),
+                      ),
+                    )
+                    .toList(),
+              );
+            },
+          ),
+          const SizedBox(width: 8),
           PopupMenuButton<_MenuOption>(
-            icon: const Icon(Icons.menu, color: Colors.white),
+            icon: Icon(Icons.menu, color: colorScheme.onSurface),
             onSelected: (opt) {
               switch (opt) {
                 case _MenuOption.portfolio:
@@ -35,13 +60,13 @@ class WindowTitleBar extends StatelessWidget {
               }
             },
             itemBuilder: (ctx) => const [
-              const PopupMenuItem<_MenuOption>(
+              PopupMenuItem<_MenuOption>(
                 value: _MenuOption.portfolio,
-                child: const Text('Portfolio'),
+                child: Text('Portfolio'),
               ),
-              const PopupMenuItem<_MenuOption>(
+              PopupMenuItem<_MenuOption>(
                 value: _MenuOption.botsList,
-                child: const Text('Bots List'),
+                child: Text('Bots List'),
               ),
             ],
           ),
@@ -52,3 +77,14 @@ class WindowTitleBar extends StatelessWidget {
 }
 
 enum _MenuOption { portfolio, botsList }
+
+String _labelForTheme(AppTheme theme) {
+  switch (theme) {
+    case AppTheme.light:
+      return 'Tema chiaro';
+    case AppTheme.dark:
+      return 'Tema scuro';
+    case AppTheme.highContrast:
+      return 'Alto contrasto';
+  }
+}

--- a/lib/frontend/widgets/pages/settings_page.dart
+++ b/lib/frontend/widgets/pages/settings_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:scriptagher/shared/services/telemetry_service.dart';
+import 'package:scriptagher/shared/theme/theme_controller.dart';
 
 class SettingsPage extends StatelessWidget {
   final TelemetryService telemetryService;
@@ -16,16 +17,13 @@ class SettingsPage extends StatelessWidget {
         padding: const EdgeInsets.all(24.0),
         child: ListView(
           children: [
-            Text(
-              'Privacy e telemetria',
-              style: Theme.of(context)
-                  .textTheme
-                  .headlineMedium
-                  ?.copyWith(fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 24),
+            _SectionTitle(title: 'Aspetto e accessibilità'),
+            const SizedBox(height: 12),
+            const _ThemeSelector(),
+            const SizedBox(height: 32),
+            _SectionTitle(title: 'Privacy e telemetria'),
+            const SizedBox(height: 12),
             Card(
-              elevation: 2,
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
                 child: ValueListenableBuilder<bool>(
@@ -69,6 +67,132 @@ class SettingsPage extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class _ThemeSelector extends StatelessWidget {
+  const _ThemeSelector();
+
+  String _labelFor(AppTheme theme) {
+    switch (theme) {
+      case AppTheme.light:
+        return 'Chiaro';
+      case AppTheme.dark:
+        return 'Scuro';
+      case AppTheme.highContrast:
+        return 'Alto contrasto';
+    }
+  }
+
+  IconData _iconFor(AppTheme theme) {
+    switch (theme) {
+      case AppTheme.light:
+        return Icons.light_mode;
+      case AppTheme.dark:
+        return Icons.dark_mode;
+      case AppTheme.highContrast:
+        return Icons.invert_colors;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final themeController = ThemeController();
+
+    return AnimatedBuilder(
+      animation: themeController,
+      builder: (context, _) {
+        final currentTheme = themeController.currentTheme;
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Tema applicazione',
+                  style: Theme.of(context)
+                      .textTheme
+                      .titleMedium
+                      ?.copyWith(fontWeight: FontWeight.w600),
+                ),
+                const SizedBox(height: 12),
+                Wrap(
+                  spacing: 12,
+                  runSpacing: 12,
+                  children: themeController.availableThemes.map((theme) {
+                    final selected = theme == currentTheme;
+                    final labelStyle = Theme.of(context).textTheme.labelLarge;
+                    final colorScheme = Theme.of(context).colorScheme;
+                    return ChoiceChip(
+                      showCheckmark: false,
+                      label: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            _iconFor(theme),
+                            size: 18,
+                            color: selected
+                                ? colorScheme.onPrimary
+                                : colorScheme.onSurface,
+                          ),
+                          const SizedBox(width: 8),
+                          Text(
+                            _labelFor(theme),
+                            style: labelStyle?.copyWith(
+                              color: selected
+                                  ? colorScheme.onPrimary
+                                  : colorScheme.onSurface,
+                            ),
+                          ),
+                        ],
+                      ),
+                      selected: selected,
+                      onSelected: (isSelected) {
+                        if (!isSelected || theme == currentTheme) {
+                          return;
+                        }
+                        themeController.setTheme(theme);
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text(
+                              'Tema impostato su ${_labelFor(theme)}',
+                            ),
+                          ),
+                        );
+                      },
+                      selectedColor: colorScheme.primary,
+                      backgroundColor: colorScheme.surfaceVariant,
+                    );
+                  }).toList(),
+                ),
+                const SizedBox(height: 12),
+                const Text(
+                  'Scegli tra modalità chiara, scura o ad alto contrasto per migliorare la leggibilità.',
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _SectionTitle extends StatelessWidget {
+  final String title;
+
+  const _SectionTitle({required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      title,
+      style: Theme.of(context)
+          .textTheme
+          .headlineMedium
+          ?.copyWith(fontWeight: FontWeight.bold),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'frontend/widgets/pages/settings_page.dart';
 import 'frontend/widgets/pages/tutorial_page.dart';
 import 'shared/custom_logger.dart';
 import 'shared/services/telemetry_service.dart';
+import 'shared/theme/theme_controller.dart';
 import 'backend/setup/backend_initializer_desktop.dart'
     if (dart.library.html) 'backend/setup/backend_initializer_web.dart'
         as backend_initializer;
@@ -24,35 +25,52 @@ Future<void> main() async {
 
   final logger = CustomLogger();
   final telemetryService = TelemetryService();
+  final themeController = ThemeController();
   await telemetryService.initialize();
+  await themeController.initialize();
 
   await backend_initializer.initializeBackend(logger, telemetryService);
   await window_configuration.configureWindow();
 
-  runApp(MyApp(telemetryService: telemetryService));
+  runApp(
+    MyApp(
+      telemetryService: telemetryService,
+      themeController: themeController,
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {
   final TelemetryService telemetryService;
+  final ThemeController themeController;
 
-  const MyApp({super.key, required this.telemetryService});
+  const MyApp({
+    super.key,
+    required this.telemetryService,
+    required this.themeController,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      routes: {
-        '/home': (_) => const HomePage(),
-        '/portfolio': (_) => Portfolio(),
-        '/bots': (_) => BotList(),
-        '/test1': (_) => test1(),
-        '/test2': (_) => test2(),
-        '/test3': (_) => test3(),
-        '/settings': (_) => SettingsPage(telemetryService: telemetryService),
-        '/tutorial': (_) => const TutorialPage(),
+    return AnimatedBuilder(
+      animation: themeController,
+      builder: (context, _) {
+        return MaterialApp(
+          routes: {
+            '/home': (_) => const HomePage(),
+            '/portfolio': (_) => Portfolio(),
+            '/bots': (_) => BotList(),
+            '/test1': (_) => test1(),
+            '/test2': (_) => test2(),
+            '/test3': (_) => test3(),
+            '/settings': (_) => SettingsPage(telemetryService: telemetryService),
+            '/tutorial': (_) => const TutorialPage(),
+          },
+          debugShowCheckedModeBanner: false,
+          theme: themeController.themeData,
+          home: const HomeShell(),
+        );
       },
-      debugShowCheckedModeBanner: false,
-      theme: ThemeData(primarySwatch: Colors.blue),
-      home: const HomeShell(),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,11 +44,11 @@ class MyApp extends StatelessWidget {
   final TelemetryService telemetryService;
   final ThemeController themeController;
 
-  const MyApp({
+  MyApp({
     super.key,
     required this.telemetryService,
-    required this.themeController,
-  });
+    ThemeController? themeController,
+  }) : themeController = themeController ?? ThemeController();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/shared/theme/theme_controller.dart
+++ b/lib/shared/theme/theme_controller.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+enum AppTheme { light, dark, highContrast }
+
+class ThemeController extends ChangeNotifier {
+  ThemeController._internal();
+
+  static final ThemeController _instance = ThemeController._internal();
+
+  factory ThemeController() => _instance;
+
+  static const String _preferenceKey = 'preferred_theme';
+
+  final Map<AppTheme, ThemeData> _themes = {
+    AppTheme.light: _buildTheme(
+      brightness: Brightness.light,
+      seed: const Color(0xFF3F51B5),
+    ),
+    AppTheme.dark: _buildTheme(
+      brightness: Brightness.dark,
+      seed: const Color(0xFF3F51B5),
+    ),
+    AppTheme.highContrast: _buildHighContrastTheme(),
+  };
+
+  AppTheme _currentTheme = AppTheme.light;
+  SharedPreferences? _prefs;
+  bool _initialized = false;
+
+  AppTheme get currentTheme => _currentTheme;
+
+  ThemeData get themeData => _themes[_currentTheme]!;
+
+  Iterable<AppTheme> get availableThemes => _themes.keys;
+
+  Future<void> initialize() async {
+    if (_initialized) {
+      return;
+    }
+
+    _prefs = await SharedPreferences.getInstance();
+    final stored = _prefs?.getString(_preferenceKey);
+    if (stored != null) {
+      _currentTheme = AppTheme.values.firstWhere(
+        (theme) => theme.name == stored,
+        orElse: () => AppTheme.light,
+      );
+    }
+    _initialized = true;
+    notifyListeners();
+  }
+
+  Future<void> setTheme(AppTheme theme) async {
+    if (_currentTheme == theme) {
+      return;
+    }
+
+    _currentTheme = theme;
+    notifyListeners();
+    await _ensurePrefs();
+    await _prefs?.setString(_preferenceKey, theme.name);
+  }
+
+  static ThemeData _buildTheme({
+    required Brightness brightness,
+    required Color seed,
+  }) {
+    final colorScheme = ColorScheme.fromSeed(
+      seedColor: seed,
+      brightness: brightness,
+    );
+
+    return ThemeData(
+      useMaterial3: true,
+      brightness: brightness,
+      colorScheme: colorScheme,
+      appBarTheme: AppBarTheme(
+        backgroundColor: colorScheme.surface,
+        foregroundColor: colorScheme.onSurface,
+        elevation: 0,
+      ),
+      snackBarTheme: SnackBarThemeData(
+        behavior: SnackBarBehavior.floating,
+        backgroundColor: colorScheme.inverseSurface,
+        contentTextStyle: TextStyle(color: colorScheme.onInverseSurface),
+      ),
+      cardTheme: CardTheme(
+        color: colorScheme.surface,
+        elevation: 2,
+        margin: const EdgeInsets.symmetric(vertical: 8),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+        ),
+      ),
+      chipTheme: ChipThemeData.fromDefaults(
+        brightness: brightness,
+        secondaryColor: colorScheme.primary,
+        labelStyle: TextStyle(color: colorScheme.onSurface),
+      ),
+    );
+  }
+
+  static ThemeData _buildHighContrastTheme() {
+    const primary = Color(0xFF0A0A0A);
+    const accent = Color(0xFF00B8D9);
+
+    const highContrastScheme = ColorScheme(
+      brightness: Brightness.light,
+      primary: accent,
+      onPrimary: Colors.black,
+      secondary: Colors.black,
+      onSecondary: Colors.white,
+      error: Color(0xFFB00020),
+      onError: Colors.white,
+      background: Colors.white,
+      onBackground: Colors.black,
+      surface: Colors.white,
+      onSurface: Colors.black,
+      primaryContainer: accent,
+      onPrimaryContainer: Colors.black,
+      secondaryContainer: Colors.black,
+      onSecondaryContainer: Colors.white,
+      tertiary: primary,
+      onTertiary: Colors.white,
+      tertiaryContainer: Colors.black,
+      onTertiaryContainer: Colors.white,
+      outline: Colors.black,
+      outlineVariant: Color(0xFF3C3C3C),
+      shadow: Colors.black,
+      surfaceTint: accent,
+      inverseSurface: Colors.black,
+      onInverseSurface: Colors.white,
+      inversePrimary: Colors.white,
+      scrim: Colors.black,
+      surfaceVariant: Colors.white,
+      onSurfaceVariant: Colors.black,
+      errorContainer: Color(0xFFFFCDD2),
+      onErrorContainer: Colors.black,
+    );
+
+    return ThemeData(
+      useMaterial3: true,
+      brightness: Brightness.light,
+      colorScheme: highContrastScheme,
+      appBarTheme: const AppBarTheme(
+        backgroundColor: Colors.white,
+        foregroundColor: Colors.black,
+        elevation: 0,
+        titleTextStyle: TextStyle(
+          color: Colors.black,
+          fontWeight: FontWeight.bold,
+          fontSize: 20,
+        ),
+      ),
+      textTheme: ThemeData(brightness: Brightness.light)
+          .textTheme
+          .apply(fontWeightDelta: 1, bodyColor: Colors.black, displayColor: Colors.black),
+      chipTheme: ChipThemeData(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        selectedColor: accent,
+        disabledColor: Colors.grey.shade400,
+        backgroundColor: Colors.white,
+        labelStyle: const TextStyle(
+          color: Colors.black,
+          fontWeight: FontWeight.bold,
+        ),
+        secondaryLabelStyle: const TextStyle(color: Colors.black),
+        brightness: Brightness.light,
+      ),
+    );
+  }
+
+  Future<void> _ensurePrefs() async {
+    _prefs ??= await SharedPreferences.getInstance();
+  }
+}

--- a/lib/shared/theme/theme_controller.dart
+++ b/lib/shared/theme/theme_controller.dart
@@ -85,7 +85,7 @@ class ThemeController extends ChangeNotifier {
         backgroundColor: colorScheme.inverseSurface,
         contentTextStyle: TextStyle(color: colorScheme.onInverseSurface),
       ),
-      cardTheme: CardTheme(
+      cardTheme: CardThemeData(
         color: colorScheme.surface,
         elevation: 2,
         margin: const EdgeInsets.symmetric(vertical: 8),
@@ -155,7 +155,7 @@ class ThemeController extends ChangeNotifier {
       ),
       textTheme: ThemeData(brightness: Brightness.light)
           .textTheme
-          .apply(fontWeightDelta: 1, bodyColor: Colors.black, displayColor: Colors.black),
+          .apply(bodyColor: Colors.black, displayColor: Colors.black),
       chipTheme: ChipThemeData(
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         selectedColor: accent,


### PR DESCRIPTION
## Summary
- add a shared ThemeController that provides light, dark, and high-contrast palettes backed by SharedPreferences
- drive MaterialApp theming through the controller so the UI reacts immediately to preference changes
- surface theme selectors in the settings screen and window title bars to let users toggle themes quickly

## Testing
- not run (Flutter SDK not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68f3770d5d74832b9775093fcd36d9c1