### PR TITLE
Redesign home experience with reusable gradient layout

### DIFF
--- a/lib/frontend/widgets/components/call_to_action_banner.dart
+++ b/lib/frontend/widgets/components/call_to_action_banner.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+
+class CallToActionBanner extends StatelessWidget {
+  const CallToActionBanner({
+    super.key,
+    required this.title,
+    required this.subtitle,
+    required this.primaryAction,
+    this.secondaryAction,
+    this.gradient,
+    this.icon,
+  });
+
+  final String title;
+  final String subtitle;
+  final Widget primaryAction;
+  final Widget? secondaryAction;
+  final Gradient? gradient;
+  final IconData? icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final resolvedGradient = gradient ??
+        const LinearGradient(
+          colors: [Color(0xFF11998E), Color(0xFF38EF7D)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        );
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        gradient: resolvedGradient,
+        borderRadius: BorderRadius.circular(24),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 26,
+            offset: const Offset(0, 18),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final isWide = constraints.maxWidth > 720;
+            final content = Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w700,
+                      ) ??
+                      const TextStyle(
+                        fontSize: 24,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.white,
+                      ),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  subtitle,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                        color: Colors.white.withOpacity(0.9),
+                        height: 1.4,
+                      ) ??
+                      const TextStyle(
+                        fontSize: 16,
+                        color: Colors.white70,
+                      ),
+                ),
+                const SizedBox(height: 20),
+                Wrap(
+                  spacing: 12,
+                  runSpacing: 12,
+                  children: [
+                    primaryAction,
+                    if (secondaryAction != null) secondaryAction!,
+                  ],
+                ),
+              ],
+            );
+
+            if (!isWide) {
+              return content;
+            }
+
+            return Row(
+              children: [
+                Expanded(child: content),
+                if (icon != null)
+                  Icon(
+                    icon,
+                    color: Colors.white.withOpacity(0.2),
+                    size: 96,
+                  ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/frontend/widgets/components/feature_grid_section.dart
+++ b/lib/frontend/widgets/components/feature_grid_section.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+
+class FeatureGridItem {
+  const FeatureGridItem({
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.onTap,
+    this.accentColor,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+  final VoidCallback onTap;
+  final Color? accentColor;
+}
+
+class FeatureGridSection extends StatelessWidget {
+  const FeatureGridSection({
+    super.key,
+    required this.items,
+    required this.crossAxisCount,
+    this.gap = 18,
+  });
+
+  final List<FeatureGridItem> items;
+  final int crossAxisCount;
+  final double gap;
+
+  @override
+  Widget build(BuildContext context) {
+    if (crossAxisCount <= 1) {
+      return SliverList.separated(
+        itemBuilder: (context, index) => _FeatureCard(item: items[index]),
+        separatorBuilder: (_, __) => SizedBox(height: gap),
+        itemCount: items.length,
+      );
+    }
+
+    return SliverGrid(
+      delegate: SliverChildBuilderDelegate(
+        (context, index) => _FeatureCard(item: items[index]),
+        childCount: items.length,
+      ),
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: crossAxisCount,
+        crossAxisSpacing: gap,
+        mainAxisSpacing: gap,
+        childAspectRatio: 1.2,
+      ),
+    );
+  }
+}
+
+class _FeatureCard extends StatelessWidget {
+  const _FeatureCard({required this.item});
+
+  final FeatureGridItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cardColor = theme.colorScheme.surface;
+    final accent = item.accentColor ?? theme.colorScheme.primary;
+
+    return InkWell(
+      borderRadius: BorderRadius.circular(20),
+      onTap: item.onTap,
+      child: Ink(
+        decoration: BoxDecoration(
+          color: cardColor,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: accent.withOpacity(0.08)),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.05),
+              blurRadius: 18,
+              offset: const Offset(0, 12),
+            ),
+          ],
+        ),
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            DecoratedBox(
+              decoration: BoxDecoration(
+                color: accent.withOpacity(0.12),
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(10),
+                child: Icon(item.icon, color: accent, size: 28),
+              ),
+            ),
+            const SizedBox(height: 18),
+            Text(
+              item.title,
+              style: theme.textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 10),
+            Expanded(
+              child: Text(
+                item.description,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'Esplora',
+                  style: theme.textTheme.labelLarge?.copyWith(
+                    color: accent,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                Icon(Icons.arrow_outward_rounded, color: accent, size: 20),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/frontend/widgets/components/gradient_hero_section.dart
+++ b/lib/frontend/widgets/components/gradient_hero_section.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+
+class GradientHeroSection extends StatelessWidget {
+  const GradientHeroSection({
+    super.key,
+    this.eyebrow,
+    required this.title,
+    required this.subtitle,
+    this.primaryAction,
+    this.secondaryAction,
+    this.icon,
+    this.leading,
+    this.alignment = CrossAxisAlignment.start,
+    this.padding = const EdgeInsets.all(24),
+    this.gradient,
+  });
+
+  final String? eyebrow;
+  final String title;
+  final String subtitle;
+  final Widget? primaryAction;
+  final Widget? secondaryAction;
+  final IconData? icon;
+  final Widget? leading;
+  final CrossAxisAlignment alignment;
+  final EdgeInsets padding;
+  final Gradient? gradient;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final resolvedGradient = gradient ??
+        const LinearGradient(
+          colors: [Color(0xFF4E54C8), Color(0xFF8F94FB)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        );
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isWide = constraints.maxWidth > 680;
+        final textTheme = theme.textTheme;
+
+        final content = Column(
+          crossAxisAlignment: alignment,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            if (eyebrow != null)
+              Text(
+                eyebrow!,
+                style: textTheme.labelLarge?.copyWith(
+                  color: Colors.white70,
+                  letterSpacing: 1.2,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            Text(
+              title,
+              style: textTheme.displaySmall?.copyWith(
+                    color: Colors.white,
+                    height: 1.05,
+                    fontWeight: FontWeight.w700,
+                  ) ??
+                  const TextStyle(
+                    fontSize: 34,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              subtitle,
+              style: textTheme.titleMedium?.copyWith(
+                    color: Colors.white.withOpacity(0.9),
+                    height: 1.4,
+                  ) ??
+                  const TextStyle(
+                    fontSize: 16,
+                    color: Colors.white70,
+                  ),
+            ),
+            const SizedBox(height: 20),
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: [
+                if (primaryAction != null) primaryAction!,
+                if (secondaryAction != null) secondaryAction!,
+              ],
+            ),
+          ],
+        );
+
+        return DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: resolvedGradient,
+            borderRadius: BorderRadius.circular(28),
+          ),
+          child: Padding(
+            padding: padding.add(EdgeInsets.only(
+              top: leading != null ? 12 : 0,
+            )),
+            child: Stack(
+              children: [
+                if (leading != null)
+                  Positioned(
+                    top: 0,
+                    left: 0,
+                    child: leading!,
+                  ),
+                if (isWide)
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Expanded(child: content),
+                      if (icon != null)
+                        Flexible(
+                          child: Align(
+                            alignment: Alignment.centerRight,
+                            child: Icon(
+                              icon,
+                              size: 120,
+                              color: Colors.white.withOpacity(0.18),
+                            ),
+                          ),
+                        ),
+                    ],
+                  )
+                else
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      if (icon != null)
+                        Align(
+                          alignment: Alignment.centerLeft,
+                          child: Icon(
+                            icon,
+                            size: 72,
+                            color: Colors.white.withOpacity(0.2),
+                          ),
+                        ),
+                      content,
+                    ],
+                  ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/frontend/widgets/pages/bot_list_view.dart
+++ b/lib/frontend/widgets/pages/bot_list_view.dart
@@ -530,7 +530,34 @@ class _BotListState extends State<BotList>
         setState(() {
           _isUploading = false;
         });
+      }
     }
+  }
+ 
+  void _refreshCategory(BotCategory category) {
+    setState(() {
+      switch (category) {
+        case BotCategory.downloaded:
+          _categoryFutures[category] = _botGetService.fetchDownloadedBots();
+          break;
+        case BotCategory.online:
+          _categoryFutures[category] = _botGetService.fetchOnlineBots();
+          break;
+        case BotCategory.local:
+          _categoryFutures[category] = _botGetService.fetchLocalBots();
+          break;
+      }
+    });
+  }
+
+  void _showSnackBar(String message, {bool isError = false}) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: isError ? Theme.of(context).colorScheme.error : null,
+      ),
+    );
   }
 }
 
@@ -564,7 +591,8 @@ class _BotTabBarHeaderDelegate extends SliverPersistentHeaderDelegate {
       ),
       child: DecoratedBox(
         decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.35),
+          color:
+              Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.35),
           borderRadius: BorderRadius.circular(18),
         ),
         child: tabBar,
@@ -577,32 +605,5 @@ class _BotTabBarHeaderDelegate extends SliverPersistentHeaderDelegate {
     return oldDelegate.tabBar != tabBar ||
         oldDelegate.horizontalPadding != horizontalPadding ||
         oldDelegate.backgroundColor != backgroundColor;
-  }
-}
-
-  void _refreshCategory(BotCategory category) {
-    setState(() {
-      switch (category) {
-        case BotCategory.downloaded:
-          _categoryFutures[category] = _botGetService.fetchDownloadedBots();
-          break;
-        case BotCategory.online:
-          _categoryFutures[category] = _botGetService.fetchOnlineBots();
-          break;
-        case BotCategory.local:
-          _categoryFutures[category] = _botGetService.fetchLocalBots();
-          break;
-      }
-    });
-  }
-
-  void _showSnackBar(String message, {bool isError = false}) {
-    if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(message),
-        backgroundColor: isError ? Theme.of(context).colorScheme.error : null,
-      ),
-    );
   }
 }

--- a/lib/frontend/widgets/pages/home_page_view.dart
+++ b/lib/frontend/widgets/pages/home_page_view.dart
@@ -38,15 +38,15 @@ class HomePage extends StatelessWidget {
       ),
       FeatureGridItem(
         icon: Icons.cloud_rounded,
-        title: 'Marketplace Online',
+        title: 'Online',
         description:
-            'Scopri le ultime novità dalla libreria remota e installa nuovi bot.',
+            'Scopri le ultime novità dal marketplace remoto e installa nuovi bot.',
         accentColor: const Color(0xFF5AC8FA),
         onTap: () => _openBots(context, BotCategory.online),
       ),
       FeatureGridItem(
         icon: Icons.folder_rounded,
-        title: 'Bot Locali',
+        title: 'Locali',
         description:
             'Gestisci i bot presenti sul filesystem con strumenti di import rapido.',
         accentColor: const Color(0xFFFFB74D),

--- a/lib/frontend/widgets/pages/home_page_view.dart
+++ b/lib/frontend/widgets/pages/home_page_view.dart
@@ -1,100 +1,13 @@
 import 'package:flutter/material.dart';
 import '../../models/bot_navigation.dart';
+import '../components/call_to_action_banner.dart';
+import '../components/feature_grid_section.dart';
+import '../components/gradient_hero_section.dart';
 
-class HomePage extends StatefulWidget {
+class HomePage extends StatelessWidget {
   const HomePage({super.key});
 
-  @override
-  State<HomePage> createState() => _HomePageState();
-}
-
-class _HomePageState extends State<HomePage>
-    with SingleTickerProviderStateMixin {
-  final List<_Category> _categories = const [
-    _Category(
-      title: 'Scaricati',
-      description:
-          'Consulta i bot che hai già scaricato e salvato nel database locale.',
-      icon: Icons.download_done_outlined,
-      category: BotCategory.downloaded,
-    ),
-    _Category(
-      title: 'Online',
-      description:
-          'Scopri i bot disponibili online tramite le API e scaricane di nuovi.',
-      icon: Icons.cloud_outlined,
-      category: BotCategory.online,
-    ),
-    _Category(
-      title: 'Locali',
-      description:
-          'Gestisci i bot presenti direttamente nel filesystem della macchina.',
-      icon: Icons.folder_outlined,
-      category: BotCategory.local,
-    ),
-  ];
-
-  final List<_SectionItem> _sections = const [
-    _SectionItem(
-      title: 'Impostazioni',
-      description: 'Gestisci preferenze, privacy e telemetria',
-      icon: Icons.settings_outlined,
-      routeName: '/settings',
-    ),
-  ];
-
-  late final TabController _tabController;
-  int _selectedIndex = 0;
-  bool _isTabControllerUpdateFromNavigation = false;
-
-  int get _totalDestinations => _categories.length + _sections.length;
-
-  @override
-  void initState() {
-    super.initState();
-    _tabController = TabController(length: _totalDestinations, vsync: this);
-    _tabController.addListener(_handleTabSelection);
-  }
-
-  @override
-  void dispose() {
-    _tabController.removeListener(_handleTabSelection);
-    _tabController.dispose();
-    super.dispose();
-  }
-
-  void _handleTabSelection() {
-    if (_tabController.indexIsChanging) return;
-
-    setState(() {
-      _selectedIndex = _tabController.index;
-    });
-
-    if (_isTabControllerUpdateFromNavigation) {
-      _isTabControllerUpdateFromNavigation = false;
-      return;
-    }
-
-    _handleSelection(_tabController.index);
-  }
-
-  void _onDestinationSelected(int index) {
-    if (_selectedIndex == index) {
-      _handleSelection(index);
-      return;
-    }
-    setState(() {
-      _selectedIndex = index;
-      if (_tabController.index != index) {
-        _isTabControllerUpdateFromNavigation = true;
-        _tabController.index = index;
-      }
-    });
-
-    _handleSelection(index);
-  }
-
-  void _openBots(BotCategory category) {
+  void _openBots(BuildContext context, BotCategory category) {
     Navigator.pushNamed(
       context,
       '/bots',
@@ -102,289 +15,153 @@ class _HomePageState extends State<HomePage>
     );
   }
 
-  void _openSection(_SectionItem section) {
-    Navigator.pushNamed(context, section.routeName);
+  void _openSettings(BuildContext context) {
+    Navigator.pushNamed(context, '/settings');
   }
 
-  void _handleSelection(int index) {
-    if (index < _categories.length) {
-      return;
-    }
-
-    final section = _sections[index - _categories.length];
-    _openSection(section);
-  }
-
-  void _openTutorial() {
+  void _openTutorial(BuildContext context) {
     Navigator.pushNamed(context, '/tutorial');
   }
 
-  Widget _buildCategoryContent(int index) {
-    if (index < _categories.length) {
-      final category = _categories[index];
-      return Padding(
-        key: ValueKey(category.category),
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(category.icon, size: 32, color: Colors.blueAccent),
-                const SizedBox(width: 12),
-                Text(
-                  category.title,
-                  style: const TextStyle(
-                    fontSize: 28,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 16),
-            Text(
-              category.description,
-              style: const TextStyle(
-                fontSize: 16,
-                color: Colors.black54,
-              ),
-            ),
-            const Spacer(),
-            Align(
-              alignment: Alignment.bottomRight,
-              child: ElevatedButton.icon(
-                onPressed: () => _openBots(category.category),
-                icon: const Icon(Icons.arrow_forward),
-                label: const Text('Apri elenco'),
-              ),
-            ),
-          ],
-        ),
-      );
-    }
+  List<FeatureGridItem> _buildFeatureItems(BuildContext context) {
+    final theme = Theme.of(context);
+    final accent = theme.colorScheme.primary;
 
-    final section = _sections[index - _categories.length];
-    return Padding(
-      key: ValueKey(section.routeName),
-      padding: const EdgeInsets.all(16.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(section.icon, size: 32, color: Colors.blueAccent),
-              const SizedBox(width: 12),
-              Text(
-                section.title,
-                style: const TextStyle(
-                  fontSize: 28,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 16),
-          Text(
-            section.description,
-            style: const TextStyle(
-              fontSize: 16,
-              color: Colors.black54,
-            ),
-          ),
-          const Spacer(),
-          Align(
-            alignment: Alignment.bottomRight,
-            child: ElevatedButton.icon(
-              onPressed: () => _openSection(section),
-              icon: const Icon(Icons.arrow_forward),
-              label: Text('Apri ${section.title}'),
-            ),
-          ),
-        ],
+    return [
+      FeatureGridItem(
+        icon: Icons.download_rounded,
+        title: 'Scaricati',
+        description:
+            'Consulta i bot già installati, organizzati per linguaggio e tag.',
+        accentColor: accent,
+        onTap: () => _openBots(context, BotCategory.downloaded),
       ),
-    );
+      FeatureGridItem(
+        icon: Icons.cloud_rounded,
+        title: 'Marketplace Online',
+        description:
+            'Scopri le ultime novità dalla libreria remota e installa nuovi bot.',
+        accentColor: const Color(0xFF5AC8FA),
+        onTap: () => _openBots(context, BotCategory.online),
+      ),
+      FeatureGridItem(
+        icon: Icons.folder_rounded,
+        title: 'Bot Locali',
+        description:
+            'Gestisci i bot presenti sul filesystem con strumenti di import rapido.',
+        accentColor: const Color(0xFFFFB74D),
+        onTap: () => _openBots(context, BotCategory.local),
+      ),
+      FeatureGridItem(
+        icon: Icons.settings_rounded,
+        title: 'Impostazioni',
+        description:
+            'Personalizza preferenze, telemetria e comportamento dell’applicazione.',
+        accentColor: const Color(0xFF7E57C2),
+        onTap: () => _openSettings(context),
+      ),
+    ];
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: Padding(
-        padding: const EdgeInsets.all(24.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Text(
-              'HOME - Cosa vuoi fare?',
-              style: TextStyle(
-                fontSize: 26,
-                fontWeight: FontWeight.bold,
-                color: Colors.black87,
-              ),
-            ),
-            const SizedBox(height: 16),
-            Card(
-              elevation: 2,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: InkWell(
-                borderRadius: BorderRadius.circular(12),
-                onTap: _openTutorial,
-                child: Padding(
-                  padding: const EdgeInsets.all(20),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      const Icon(Icons.school_outlined,
-                          color: Colors.blueAccent, size: 32),
-                      const SizedBox(width: 16),
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            const Text(
-                              'Crea il tuo bot',
-                              style: TextStyle(
-                                fontSize: 20,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                            const SizedBox(height: 8),
-                            Text(
-                              'Segui il tutorial passo-passo per creare un bot sicuro compatibile con Scriptagher.',
-                              style: TextStyle(
-                                fontSize: 15,
-                                color: Colors.grey.shade700,
-                              ),
-                            ),
-                            const SizedBox(height: 12),
-                            Row(
-                              children: const [
-                                Text(
-                                  'Apri tutorial',
-                                  style: TextStyle(
-                                    fontSize: 15,
-                                    fontWeight: FontWeight.w600,
-                                  ),
-                                ),
-                                SizedBox(width: 4),
-                                Icon(Icons.arrow_forward, size: 18),
-                              ],
-                            ),
-                          ],
-                        ),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isDesktop = constraints.maxWidth >= 1100;
+        final isTablet = constraints.maxWidth >= 720 && constraints.maxWidth < 1100;
+        final crossAxisCount = isDesktop ? 3 : (isTablet ? 2 : 1);
+        final horizontalPadding = isDesktop
+            ? 120.0
+            : isTablet
+                ? 64.0
+                : 24.0;
+
+        return Scaffold(
+          backgroundColor: Theme.of(context).colorScheme.surface,
+          body: CustomScrollView(
+            physics: const BouncingScrollPhysics(),
+            slivers: [
+              SliverPadding(
+                padding: EdgeInsets.fromLTRB(
+                  horizontalPadding,
+                  isDesktop ? 64 : 32,
+                  horizontalPadding,
+                  28,
+                ),
+                sliver: SliverToBoxAdapter(
+                  child: GradientHeroSection(
+                    eyebrow: 'Scriptagher',
+                    title: 'Automatizza i tuoi workflow in sicurezza',
+                    subtitle:
+                        'Organizza, installa e monitora bot Python pronti all’uso da un’unica dashboard.'
+                        ' Il nuovo design offre un’esperienza coerente su desktop e web.',
+                    icon: Icons.smart_toy_rounded,
+                    primaryAction: FilledButton.icon(
+                      style: FilledButton.styleFrom(
+                        backgroundColor: Colors.white,
+                        foregroundColor: Theme.of(context).colorScheme.primary,
                       ),
-                    ],
+                      onPressed: () => _openBots(context, BotCategory.online),
+                      icon: const Icon(Icons.explore_rounded),
+                      label: const Text('Esplora i bot online'),
+                    ),
+                    secondaryAction: OutlinedButton.icon(
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: Colors.white,
+                        side: const BorderSide(color: Colors.white70),
+                      ),
+                      onPressed: () => _openTutorial(context),
+                      icon: const Icon(Icons.school_rounded),
+                      label: const Text('Impara a crearne uno'),
+                    ),
                   ),
                 ),
               ),
-            ),
-            const SizedBox(height: 24),
-            Expanded(
-              child: LayoutBuilder(
-                builder: (context, constraints) {
-                  if (constraints.maxWidth >= 800) {
-                    return Row(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        NavigationRail(
-                          selectedIndex: _selectedIndex,
-                          onDestinationSelected: _onDestinationSelected,
-                          labelType: NavigationRailLabelType.all,
-                          destinations: [
-                            ..._categories.map(
-                              (category) => NavigationRailDestination(
-                                icon: Icon(category.icon),
-                                selectedIcon: Icon(
-                                  category.icon,
-                                  color: Colors.blueAccent,
-                                ),
-                                label: Text(category.title),
-                              ),
-                            ),
-                            ..._sections.map(
-                              (section) => NavigationRailDestination(
-                                icon: Icon(section.icon),
-                                selectedIcon: Icon(
-                                  section.icon,
-                                  color: Colors.blueAccent,
-                                ),
-                                label: Text(section.title),
-                              ),
-                            ),
-                          ],
-                        ),
-                        const VerticalDivider(width: 1),
-                        Expanded(
-                          child: AnimatedSwitcher(
-                            duration: const Duration(milliseconds: 200),
-                            child: _buildCategoryContent(_selectedIndex),
-                          ),
-                        ),
-                      ],
-                    );
-                  }
-
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      TabBar(
-                        controller: _tabController,
-                        labelColor: Colors.blueAccent,
-                        unselectedLabelColor: Colors.grey,
-                        tabs: [
-                          ..._categories.map((category) => Tab(text: category.title)),
-                          ..._sections.map((section) => Tab(text: section.title)),
-                        ],
-                      ),
-                      const SizedBox(height: 16),
-                      Expanded(
-                        child: TabBarView(
-                          controller: _tabController,
-                          children: List.generate(
-                            _totalDestinations,
-                            _buildCategoryContent,
-                          ),
-                        ),
-                      ),
-                    ],
-                  );
-                },
+              SliverPadding(
+                padding: EdgeInsets.symmetric(
+                  horizontal: horizontalPadding,
+                  vertical: 12,
+                ),
+                sliver: FeatureGridSection(
+                  items: _buildFeatureItems(context),
+                  crossAxisCount: crossAxisCount,
+                ),
               ),
-            ),
-          ],
-        ),
-      ),
+              SliverPadding(
+                padding: EdgeInsets.fromLTRB(
+                  horizontalPadding,
+                  32,
+                  horizontalPadding,
+                  isDesktop ? 64 : 32,
+                ),
+                sliver: SliverToBoxAdapter(
+                  child: CallToActionBanner(
+                    title: 'Pubblica il tuo primo bot in pochi minuti',
+                    subtitle:
+                        'Segui il tutorial guidato per preparare l’ambiente, definire il manifesto Bot.json '
+                        'e distribuire in sicurezza automazioni riutilizzabili.',
+                    icon: Icons.rocket_launch_rounded,
+                    primaryAction: FilledButton.icon(
+                      onPressed: () => _openTutorial(context),
+                      icon: const Icon(Icons.play_circle_fill_rounded),
+                      label: const Text('Avvia il tutorial'),
+                    ),
+                    secondaryAction: OutlinedButton.icon(
+                      onPressed: () => _openBots(context, BotCategory.local),
+                      icon: const Icon(Icons.folder_open_rounded),
+                      label: const Text('Gestisci bot locali'),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: Colors.white,
+                        side: const BorderSide(color: Colors.white70),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
-}
-
-class _Category {
-  final String title;
-  final String description;
-  final IconData icon;
-  final BotCategory category;
-
-  const _Category({
-    required this.title,
-    required this.description,
-    required this.icon,
-    required this.category,
-  });
-}
-
-class _SectionItem {
-  final String title;
-  final String description;
-  final IconData icon;
-  final String routeName;
-
-  const _SectionItem({
-    required this.title,
-    required this.description,
-    required this.icon,
-    required this.routeName,
-  });
 }

--- a/lib/frontend/widgets/pages/settings_page.dart
+++ b/lib/frontend/widgets/pages/settings_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:scriptagher/shared/services/telemetry_service.dart';
 
+import '../components/gradient_hero_section.dart';
+
 class SettingsPage extends StatelessWidget {
   final TelemetryService telemetryService;
 
@@ -8,67 +10,127 @@ class SettingsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Impostazioni'),
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(24.0),
-        child: ListView(
-          children: [
-            Text(
-              'Privacy e telemetria',
-              style: Theme.of(context)
-                  .textTheme
-                  .headlineMedium
-                  ?.copyWith(fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 24),
-            Card(
-              elevation: 2,
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                child: ValueListenableBuilder<bool>(
-                  valueListenable: telemetryService.telemetryEnabled,
-                  builder: (context, enabled, _) {
-                    return SwitchListTile.adaptive(
-                      title: const Text('Abilita telemetria anonima'),
-                      subtitle: const Text(
-                        'Consenti l\'invio di metadati diagnostici anonimizzati per aiutarci a migliorare l\'applicazione.',
+    final theme = Theme.of(context);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isDesktop = constraints.maxWidth >= 1100;
+        final isTablet = constraints.maxWidth >= 720 && constraints.maxWidth < 1100;
+        final horizontalPadding = isDesktop
+            ? 120.0
+            : isTablet
+                ? 72.0
+                : 24.0;
+
+        return Scaffold(
+          backgroundColor: theme.colorScheme.surface,
+          body: CustomScrollView(
+            physics: const BouncingScrollPhysics(),
+            slivers: [
+              SliverPadding(
+                padding: EdgeInsets.fromLTRB(
+                  horizontalPadding,
+                  isDesktop ? 56 : 24,
+                  horizontalPadding,
+                  24,
+                ),
+                sliver: SliverToBoxAdapter(
+                  child: GradientHeroSection(
+                    leading: IconButton(
+                      style: IconButton.styleFrom(
+                        backgroundColor: Colors.white.withOpacity(0.16),
+                        foregroundColor: Colors.white,
                       ),
-                      value: enabled,
-                      onChanged: (value) async {
-                        final messenger = ScaffoldMessenger.of(context);
-                        try {
-                          await telemetryService.setTelemetryEnabled(value);
-                          final message = value
-                              ? 'Telemetria attivata. Grazie per il supporto!'
-                              : 'Telemetria disattivata.';
-                          messenger.showSnackBar(
-                            SnackBar(content: Text(message)),
-                          );
-                        } catch (e) {
-                          messenger.showSnackBar(
-                            const SnackBar(
-                              content: Text(
-                                'Si è verificato un errore durante il salvataggio delle preferenze.',
-                              ),
-                            ),
-                          );
-                        }
-                      },
-                    );
-                  },
+                      onPressed: () => Navigator.maybePop(context),
+                      icon: const Icon(Icons.arrow_back_rounded),
+                    ),
+                    eyebrow: 'Preferenze',
+                    title: 'Controlla privacy e telemetria',
+                    subtitle:
+                        'Gestisci il consenso all’invio di metriche anonime e personalizza l’esperienza di Scriptagher.',
+                    icon: Icons.tune_rounded,
+                    primaryAction: FilledButton.icon(
+                      onPressed: () => Navigator.pushNamed(context, '/tutorial'),
+                      icon: const Icon(Icons.help_rounded),
+                      label: const Text('Scopri come funzionano i dati'),
+                    ),
+                  ),
                 ),
               ),
-            ),
-            const SizedBox(height: 16),
-            const Text(
-              'I dati inviati includono esclusivamente informazioni aggregate (come lingua del bot, tipo di errore e hash anonimi), senza alcun identificativo personale.',
-            ),
-          ],
-        ),
-      ),
+              SliverPadding(
+                padding: EdgeInsets.symmetric(
+                  horizontal: horizontalPadding,
+                  vertical: 12,
+                ),
+                sliver: SliverToBoxAdapter(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      DecoratedBox(
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.surfaceVariant.withOpacity(0.6),
+                          borderRadius: BorderRadius.circular(20),
+                          border: Border.all(
+                            color: theme.colorScheme.outlineVariant.withOpacity(0.3),
+                          ),
+                        ),
+                        child: Padding(
+                          padding: const EdgeInsets.all(20),
+                          child: ValueListenableBuilder<bool>(
+                            valueListenable: telemetryService.telemetryEnabled,
+                            builder: (context, enabled, _) {
+                              return SwitchListTile.adaptive(
+                                contentPadding: EdgeInsets.zero,
+                                title: Text(
+                                  'Abilita telemetria anonima',
+                                  style: theme.textTheme.titleMedium?.copyWith(
+                                    fontWeight: FontWeight.w700,
+                                  ),
+                                ),
+                                subtitle: Text(
+                                  'Consenti l\'invio di metadati diagnostici anonimizzati per aiutarci a migliorare l\'applicazione.',
+                                  style: theme.textTheme.bodyMedium,
+                                ),
+                                value: enabled,
+                                onChanged: (value) async {
+                                  final messenger = ScaffoldMessenger.of(context);
+                                  try {
+                                    await telemetryService.setTelemetryEnabled(value);
+                                    final message = value
+                                        ? 'Telemetria attivata. Grazie per il supporto!'
+                                        : 'Telemetria disattivata.';
+                                    messenger.showSnackBar(
+                                      SnackBar(content: Text(message)),
+                                    );
+                                  } catch (e) {
+                                    messenger.showSnackBar(
+                                      const SnackBar(
+                                        content: Text(
+                                          'Si è verificato un errore durante il salvataggio delle preferenze.',
+                                        ),
+                                      ),
+                                    );
+                                  }
+                                },
+                              );
+                            },
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 20),
+                      Text(
+                        'I dati inviati includono esclusivamente informazioni aggregate (come lingua del bot, tipo di errore e hash anonimi), senza alcun identificativo personale.',
+                        style: theme.textTheme.bodyLarge,
+                      ),
+                      const SizedBox(height: 48),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/frontend/widgets/pages/tutorial_page.dart
+++ b/lib/frontend/widgets/pages/tutorial_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../components/gradient_hero_section.dart';
+
 const String _tutorialDocsUrl =
     'https://github.com/scriptagher/scriptagher/blob/main/docs/create-your-bot.md';
 
@@ -27,159 +29,237 @@ class TutorialPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Crea il tuo bot'),
-        actions: [
-          IconButton(
-            tooltip: 'Apri la guida completa',
-            icon: const Icon(Icons.open_in_new),
-            onPressed: () => _openDocs(context),
-          ),
-        ],
-      ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              'Panoramica',
-              style: theme.textTheme.headlineSmall,
-            ),
-            const SizedBox(height: 8),
-            const Text(
-              'Scriptagher esegue bot impacchettati come cartelle con un file Bot.json che descrive '
-              'metadati, runtime e permessi. Segui i passaggi sotto per crearne uno nuovo.',
-            ),
-            const SizedBox(height: 24),
-            Text(
-              'Struttura del progetto',
-              style: theme.textTheme.titleLarge,
-            ),
-            const SizedBox(height: 8),
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: Colors.grey.shade100,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Colors.grey.shade300),
-              ),
-              child: const SelectableText(
-                'my-awesome-bot/\n'
-                '├── Bot.json\n'
-                '├── main.py\n'
-                '├── requirements.txt\n'
-                '└── resources/\n',
-                style: TextStyle(fontFamily: 'monospace'),
-              ),
-            ),
-            const SizedBox(height: 16),
-            const Text(
-              'Il file Bot.json definisce nome, versione, linguaggio, entrypoint, argomenti opzionali e '
-              'comandi di installazione. I file sorgente contengono la logica del bot e possono includere '
-              'dipendenze dichiarate nei comandi di post installazione.',
-            ),
-            const SizedBox(height: 24),
-            Text(
-              'Esempio di Bot.json',
-              style: theme.textTheme.titleLarge,
-            ),
-            const SizedBox(height: 8),
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: Colors.grey.shade100,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Colors.grey.shade300),
-              ),
-              child: const SelectableText(
-                '{\n'
-                '  "botName": "MyAwesomeBot",\n'
-                '  "version": "1.0.0",\n'
-                '  "archiveSha256": "0123456789abcdef...",\n'
-                '  "description": "Esempio di bot che stampa un messaggio",\n'
-                '  "author": "Jane Doe",\n'
-                '  "language": "python",\n'
-                '  "entrypoint": "main.py",\n'
-                '  "args": ["--verbose"],\n'
-                '  "environment": {\n'
-                '    "PYTHONPATH": "./"\n'
-                '  },\n'
-                '  "postInstall": [\n'
-                '    "pip install -r requirements.txt"\n'
-                '  ],\n'
-                '  "permissions": [\n'
-                '    "network",\n'
-                '    "filesystem:read"\n'
-                '  ]\n'
-                '}\n',
-                style: TextStyle(fontFamily: 'monospace'),
-              ),
-            ),
-            const SizedBox(height: 24),
-            Text(
-              'Flusso di lavoro',
-              style: theme.textTheme.titleLarge,
-            ),
-            const SizedBox(height: 8),
-            const _NumberedList(
-              items: [
-                'Scopri i bot nella libreria Online o prepara una nuova cartella locale.',
-                'Compila Bot.json con metadati, hash SHA-256, permessi e comandi di installazione.',
-                'Testa il bot localmente eseguendo l\'entrypoint con gli stessi argomenti.',
-                'Comprimi la cartella e caricala nel marketplace oppure copiala nelle directory monitorate.',
-                'Scarica o apri il bot da Scriptagher per installarlo ed eseguirlo dal dettaglio.',
-              ],
-            ),
-            const SizedBox(height: 24),
-            Text(
-              'Best practice di sicurezza',
-              style: theme.textTheme.titleLarge,
-            ),
-            const SizedBox(height: 8),
-            const _BulletList(
-              items: [
-                'Isola l\'esecuzione (container, ambienti virtuali) per ridurre l\'impatto di codice malevolo.',
-                'Limita dipendenze e versioni per diminuire vulnerabilità e assicurane l\'aggiornamento.',
-                'Gestisci segreti e token tramite variabili d\'ambiente sicure, mai in chiaro nel repository.',
-                'Richiedi solo le permission strettamente necessarie in Bot.json e verifica gli accessi.',
-                'Valida l\'input e registra log strutturati per facilitare monitoraggio e audit.',
-              ],
-            ),
-            const SizedBox(height: 24),
-            Text(
-              'Risorse aggiuntive',
-              style: theme.textTheme.titleLarge,
-            ),
-            const SizedBox(height: 8),
-            Text.rich(
-              TextSpan(
-                text: 'Consulta la documentazione completa in ',
-                children: [
-                  WidgetSpan(
-                    alignment: PlaceholderAlignment.baseline,
-                    baseline: TextBaseline.alphabetic,
-                    child: GestureDetector(
-                      onTap: () => _openDocs(context),
-                      child: Text(
-                        'docs/create-your-bot.md',
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.colorScheme.primary,
-                          decoration: TextDecoration.underline,
-                        ),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isDesktop = constraints.maxWidth >= 1100;
+        final isTablet = constraints.maxWidth >= 720 && constraints.maxWidth < 1100;
+        final horizontalPadding = isDesktop
+            ? 120.0
+            : isTablet
+                ? 72.0
+                : 24.0;
+
+        return Scaffold(
+          backgroundColor: theme.colorScheme.surface,
+          body: CustomScrollView(
+            physics: const BouncingScrollPhysics(),
+            slivers: [
+              SliverPadding(
+                padding: EdgeInsets.fromLTRB(
+                  horizontalPadding,
+                  isDesktop ? 56 : 24,
+                  horizontalPadding,
+                  24,
+                ),
+                sliver: SliverToBoxAdapter(
+                  child: GradientHeroSection(
+                    leading: IconButton(
+                      style: IconButton.styleFrom(
+                        backgroundColor: Colors.white.withOpacity(0.16),
+                        foregroundColor: Colors.white,
+                      ),
+                      onPressed: () => Navigator.maybePop(context),
+                      icon: const Icon(Icons.arrow_back_rounded),
+                    ),
+                    eyebrow: 'Guida rapida',
+                    title: 'Crea il tuo bot',
+                    subtitle:
+                        'Impara a strutturare un pacchetto compatibile con Scriptagher e pubblicalo nel marketplace o nel tuo filesystem.',
+                    icon: Icons.school_rounded,
+                    primaryAction: FilledButton.icon(
+                      onPressed: () => _openDocs(context),
+                      icon: const Icon(Icons.menu_book_rounded),
+                      label: const Text('Apri la guida completa'),
+                    ),
+                    secondaryAction: OutlinedButton.icon(
+                      onPressed: () => _openDocs(context),
+                      icon: const Icon(Icons.open_in_new_rounded),
+                      label: const Text('Documentazione online'),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: Colors.white,
+                        side: const BorderSide(color: Colors.white54),
                       ),
                     ),
                   ),
-                  const TextSpan(text: ' nel repository.'),
-                ],
+                ),
               ),
-            ),
-          ],
+              SliverPadding(
+                padding: EdgeInsets.symmetric(
+                  horizontal: horizontalPadding,
+                  vertical: 12,
+                ),
+                sliver: SliverToBoxAdapter(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Panoramica',
+                        style: theme.textTheme.headlineSmall?.copyWith(
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Scriptagher esegue bot impacchettati come cartelle con un file Bot.json che descrive metadati, runtime e permessi. Segui i passaggi sotto per crearne uno nuovo.',
+                        style: theme.textTheme.bodyLarge,
+                      ),
+                      const SizedBox(height: 28),
+                      _TutorialSectionCard(
+                        title: 'Struttura del progetto',
+                        child: const SelectableText(
+                          'my-awesome-bot/\n'
+                          '├── Bot.json\n'
+                          '├── main.py\n'
+                          '├── requirements.txt\n'
+                          '└── resources/\n',
+                          style: TextStyle(fontFamily: 'monospace'),
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        'Il file Bot.json definisce nome, versione, linguaggio, entrypoint, argomenti opzionali e comandi di installazione. I file sorgente contengono la logica del bot e possono includere dipendenze dichiarate nei comandi di post installazione.',
+                        style: theme.textTheme.bodyLarge,
+                      ),
+                      const SizedBox(height: 28),
+                      _TutorialSectionCard(
+                        title: 'Esempio di Bot.json',
+                        child: const SelectableText(
+                          '{\n'
+                          '  "botName": "MyAwesomeBot",\n'
+                          '  "version": "1.0.0",\n'
+                          '  "archiveSha256": "0123456789abcdef...",\n'
+                          '  "description": "Esempio di bot che stampa un messaggio",\n'
+                          '  "author": "Jane Doe",\n'
+                          '  "language": "python",\n'
+                          '  "entrypoint": "main.py",\n'
+                          '  "args": ["--verbose"],\n'
+                          '  "environment": {\n'
+                          '    "PYTHONPATH": "./"\n'
+                          '  },\n'
+                          '  "postInstall": [\n'
+                          '    "pip install -r requirements.txt"\n'
+                          '  ],\n'
+                          '  "permissions": [\n'
+                          '    "network",\n'
+                          '    "filesystem:read"\n'
+                          '  ]\n'
+                          '}\n',
+                          style: TextStyle(fontFamily: 'monospace'),
+                        ),
+                      ),
+                      const SizedBox(height: 28),
+                      Text(
+                        'Flusso di lavoro',
+                        style: theme.textTheme.titleLarge?.copyWith(
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      const _NumberedList(
+                        items: [
+                          'Scopri i bot nella libreria Online o prepara una nuova cartella locale.',
+                          'Compila Bot.json con metadati, hash SHA-256, permessi e comandi di installazione.',
+                          'Testa il bot localmente eseguendo l\'entrypoint con gli stessi argomenti.',
+                          'Comprimi la cartella e caricala nel marketplace oppure copiala nelle directory monitorate.',
+                          'Scarica o apri il bot da Scriptagher per installarlo ed eseguirlo dal dettaglio.',
+                        ],
+                      ),
+                      const SizedBox(height: 28),
+                      Text(
+                        'Best practice di sicurezza',
+                        style: theme.textTheme.titleLarge?.copyWith(
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      const _BulletList(
+                        items: [
+                          'Isola l\'esecuzione (container, ambienti virtuali) per ridurre l\'impatto di codice malevolo.',
+                          'Limita dipendenze e versioni per diminuire vulnerabilità e assicurane l\'aggiornamento.',
+                          'Gestisci segreti e token tramite variabili d\'ambiente sicure, mai in chiaro nel repository.',
+                          'Richiedi solo le permission strettamente necessarie in Bot.json e verifica gli accessi.',
+                          'Valida l\'input e registra log strutturati per facilitare monitoraggio e audit.',
+                        ],
+                      ),
+                      const SizedBox(height: 28),
+                      Text(
+                        'Risorse aggiuntive',
+                        style: theme.textTheme.titleLarge?.copyWith(
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Text.rich(
+                        TextSpan(
+                          text: 'Consulta la documentazione completa in ',
+                          children: [
+                            WidgetSpan(
+                              alignment: PlaceholderAlignment.baseline,
+                              baseline: TextBaseline.alphabetic,
+                              child: GestureDetector(
+                                onTap: () => _openDocs(context),
+                                child: Text(
+                                  'docs/create-your-bot.md',
+                                  style: theme.textTheme.bodyMedium?.copyWith(
+                                    color: theme.colorScheme.primary,
+                                    decoration: TextDecoration.underline,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ),
+                            ),
+                            const TextSpan(text: ' nel repository.'),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 48),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _TutorialSectionCard extends StatelessWidget {
+  const _TutorialSectionCard({required this.title, required this.child});
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cardColor = theme.colorScheme.surfaceVariant.withOpacity(0.4);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: theme.textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
         ),
-      ),
+        const SizedBox(height: 12),
+        DecoratedBox(
+          decoration: BoxDecoration(
+            color: cardColor,
+            borderRadius: BorderRadius.circular(18),
+            border: Border.all(
+              color: theme.colorScheme.outlineVariant.withOpacity(0.4),
+            ),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: child,
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- extract reusable hero, feature grid, and call-to-action widgets for the landing experience
- rebuild the home page with adaptive sliver grid layout and updated design system visuals
- refresh tutorial, bot list, and settings routes to reuse the new gradient layout components for visual consistency

## Testing
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f3770e0c98832ba4bf2f0e068a9845