### PR TITLE
Handle desktop-specific sqflite initialization

### DIFF
--- a/lib/backend/setup/backend_initializer_desktop.dart
+++ b/lib/backend/setup/backend_initializer_desktop.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import '../../shared/constants/LOGS.dart';
@@ -15,16 +17,20 @@ Future<void> initializeBackend(
 }
 
 Future<void> _startDB(CustomLogger logger) async {
-  databaseFactory = databaseFactoryFfi;
   final botDatabase = BotDatabase();
 
   try {
     logger.info(LOGS.serverStart, 'Attempting to initialize database...');
+    if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
+      databaseFactory = databaseFactoryFfi;
+    }
     await botDatabase.database;
     logger.info(LOGS.serverStart, 'Database initialized successfully');
   } catch (e) {
     logger.error(LOGS.serverError, 'Error initializing database: $e');
-    rethrow;
+    if (!(Platform.isAndroid || Platform.isIOS)) {
+      rethrow;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add platform check when choosing the sqflite FFI database factory
- keep mobile platforms on the default sqflite driver while still initializing the database
- avoid rethrowing handled mobile initialization errors while preserving logging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3786cc86c832b8e874f7ea394e958