### PR TITLE
Gate desktop window configuration by platform

### DIFF
--- a/lib/shared/platform/window_configuration_desktop.dart
+++ b/lib/shared/platform/window_configuration_desktop.dart
@@ -1,7 +1,15 @@
-import 'package:flutter/material.dart';
-import 'package:bitsdojo_window/bitsdojo_window.dart';
+import 'dart:io' show Platform;
 
+import 'package:bitsdojo_window/bitsdojo_window.dart';
+import 'package:flutter/material.dart';
+
+/// General fallback used across platforms, but configuration is effective only
+/// for desktop targets.
 Future<void> configureWindow() async {
+  if (!(Platform.isWindows || Platform.isLinux || Platform.isMacOS)) {
+    return;
+  }
+
   doWhenWindowReady(() {
     final win = appWindow;
     win.minSize = const Size(800, 600);


### PR DESCRIPTION
## Summary
- import `dart:io` to detect the running platform
- skip window configuration on non-desktop targets and document the limitation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3786c5cbc832bb48f9f387b524d1e