### PR TITLE
Ensure gh-pages deployments overwrite remote branch

### DIFF
--- a/.github/workflows/flutter-preview.yml
+++ b/.github/workflows/flutter-preview.yml
@@ -45,6 +45,7 @@ jobs:
           publish_dir: build/web
           destination_dir: prev-software/pr-${{ github.event.number }}
           keep_files: true
+          force: true
           user_name: github-actions[bot]
           user_email: 41898282+github-actions[bot]@users.noreply.github.com
 


### PR DESCRIPTION
## Summary
- enable force pushing in the preview deployment workflow so gh-pages updates are not rejected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f37cfbeac4832b9a063953b2999b90