### PR TITLE
Redesign landing experience with reusable components

### DIFF
--- a/lib/frontend/widgets/components/app_gradient_background.dart
+++ b/lib/frontend/widgets/components/app_gradient_background.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+/// Wraps content with the gradient background used across the landing
+/// experience and secondary pages.
+class AppGradientBackground extends StatelessWidget {
+  const AppGradientBackground({
+    super.key,
+    required this.child,
+    this.padding,
+    this.applyTopSafeArea = true,
+    this.applyBottomSafeArea = true,
+  });
+
+  /// Content rendered on top of the gradient background.
+  final Widget child;
+
+  /// Optional padding applied inside the safe area.
+  final EdgeInsetsGeometry? padding;
+
+  /// Whether to honor the top safe area. Disable when the parent already
+  /// accounts for it (e.g. Scaffold with AppBar).
+  final bool applyTopSafeArea;
+
+  /// Whether to honor the bottom safe area.
+  final bool applyBottomSafeArea;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final gradient = LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [
+        colorScheme.primaryContainer.withOpacity(0.35),
+        colorScheme.surface,
+        colorScheme.background,
+      ],
+    );
+
+    Widget content = child;
+    if (padding != null) {
+      content = Padding(padding: padding!, child: content);
+    }
+
+    return DecoratedBox(
+      decoration: BoxDecoration(gradient: gradient),
+      child: SafeArea(
+        top: applyTopSafeArea,
+        bottom: applyBottomSafeArea,
+        child: content,
+      ),
+    );
+  }
+}

--- a/lib/frontend/widgets/components/home_call_to_action_section.dart
+++ b/lib/frontend/widgets/components/home_call_to_action_section.dart
@@ -36,6 +36,7 @@ class HomeCallToActionSection extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Container(
                 padding: const EdgeInsets.all(12),
@@ -50,11 +51,13 @@ class HomeCallToActionSection extends StatelessWidget {
                 ),
               ),
               const SizedBox(width: 16),
-              Text(
-                'Costruisci il tuo primo bot',
-                style: theme.textTheme.headlineSmall?.copyWith(
-                  color: foreground,
-                  fontWeight: FontWeight.w700,
+              Expanded(
+                child: Text(
+                  'Costruisci il tuo primo bot',
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    color: foreground,
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
               ),
             ],

--- a/lib/frontend/widgets/components/home_call_to_action_section.dart
+++ b/lib/frontend/widgets/components/home_call_to_action_section.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+
+class HomeCallToActionSection extends StatelessWidget {
+  const HomeCallToActionSection({
+    super.key,
+    required this.onPressed,
+  });
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final foreground = colorScheme.onSecondary;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 28),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(28),
+        gradient: LinearGradient(
+          colors: [
+            colorScheme.secondaryContainer,
+            colorScheme.secondary.withOpacity(0.95),
+          ],
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: colorScheme.secondary.withOpacity(0.2),
+            blurRadius: 24,
+            offset: const Offset(0, 12),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: foreground.withOpacity(0.18),
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(
+                  Icons.school_rounded,
+                  color: foreground,
+                  size: 26,
+                ),
+              ),
+              const SizedBox(width: 16),
+              Text(
+                'Costruisci il tuo primo bot',
+                style: theme.textTheme.headlineSmall?.copyWith(
+                  color: foreground,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'Segui il tutorial guidato per preparare l\'ambiente, definire Bot.json '
+            'e distribuire il tuo automa in sicurezza.',
+            style: theme.textTheme.titleMedium?.copyWith(
+              color: foreground.withOpacity(0.85),
+              height: 1.4,
+            ),
+          ),
+          const SizedBox(height: 24),
+          FilledButton.icon(
+            onPressed: onPressed,
+            style: FilledButton.styleFrom(
+              backgroundColor: foreground,
+              foregroundColor: colorScheme.secondaryContainer,
+            ),
+            icon: const Icon(Icons.play_circle_rounded),
+            label: const Text('Avvia tutorial interattivo'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/frontend/widgets/components/home_feature_grid.dart
+++ b/lib/frontend/widgets/components/home_feature_grid.dart
@@ -10,48 +10,45 @@ class HomeFeatureGrid extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SliverToBoxAdapter(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            final mediaQueryWidth = MediaQuery.of(context).size.width;
-            final maxWidth = constraints.maxWidth.isFinite && constraints.maxWidth > 0
-                ? constraints.maxWidth
-                : mediaQueryWidth;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final mediaQueryWidth = MediaQuery.of(context).size.width;
+          final maxWidth = constraints.maxWidth.isFinite && constraints.maxWidth > 0
+              ? constraints.maxWidth
+              : mediaQueryWidth;
 
-            final crossAxisCount = _crossAxisCountFor(maxWidth);
-            final spacing = crossAxisCount > 1 ? 24.0 : 20.0;
-            final horizontalGaps = crossAxisCount > 1
-                ? (crossAxisCount - 1) * spacing
-                : 0.0;
-            final availableWidth = (maxWidth - horizontalGaps)
-                .clamp(0.0, maxWidth);
-            final tileWidth = crossAxisCount == 1
-                ? maxWidth
-                : availableWidth / crossAxisCount;
+          final crossAxisCount = _crossAxisCountFor(maxWidth);
+          final spacing = crossAxisCount > 1 ? 24.0 : 20.0;
+          final horizontalGaps = crossAxisCount > 1
+              ? (crossAxisCount - 1) * spacing
+              : 0.0;
+          final availableWidth = (maxWidth - horizontalGaps).clamp(0.0, maxWidth);
+          final tileWidth = crossAxisCount == 1
+              ? maxWidth
+              : availableWidth / crossAxisCount;
 
-            final aspectRatio = crossAxisCount == 1 ? 16 / 9 : 4 / 3;
+          final aspectRatio = crossAxisCount == 1 ? 16 / 9 : 4 / 3;
 
-            return Wrap(
-              spacing: spacing,
-              runSpacing: spacing,
-              children: [
-                for (final feature in features)
-                  ConstrainedBox(
-                    constraints: BoxConstraints(
-                      maxWidth: tileWidth,
-                      minWidth: tileWidth,
-                    ),
-                    child: AspectRatio(
-                      aspectRatio: aspectRatio,
-                      child: _FeatureCard(feature: feature),
-                    ),
+          return Wrap(
+            spacing: spacing,
+            runSpacing: spacing,
+            children: [
+              for (final feature in features)
+                ConstrainedBox(
+                  constraints: BoxConstraints(
+                    maxWidth: tileWidth,
+                    minWidth: tileWidth,
                   ),
-              ],
-            );
-          },
-        ),
+                  child: AspectRatio(
+                    aspectRatio: aspectRatio,
+                    child: _FeatureCard(feature: feature),
+                  ),
+                ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/lib/frontend/widgets/components/home_feature_grid.dart
+++ b/lib/frontend/widgets/components/home_feature_grid.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+
+class HomeFeatureGrid extends StatelessWidget {
+  const HomeFeatureGrid({
+    super.key,
+    required this.features,
+  });
+
+  final List<HomeFeatureItem> features;
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverLayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.crossAxisExtent;
+        final crossAxisCount = _crossAxisCountFor(width);
+        final childAspectRatio = crossAxisCount == 1 ? 16 / 9 : 4 / 3;
+
+        return SliverPadding(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+          sliver: SliverGrid(
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: crossAxisCount,
+              mainAxisSpacing: 24,
+              crossAxisSpacing: 24,
+              childAspectRatio: childAspectRatio,
+            ),
+            delegate: SliverChildBuilderDelegate(
+              (context, index) {
+                final feature = features[index];
+                return _FeatureCard(feature: feature);
+              },
+              childCount: features.length,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  int _crossAxisCountFor(double width) {
+    if (width >= 1200) return 3;
+    if (width >= 760) return 2;
+    return 1;
+  }
+}
+
+class HomeFeatureItem {
+  const HomeFeatureItem({
+    required this.title,
+    required this.description,
+    required this.icon,
+    required this.onTap,
+    required this.accentColor,
+  });
+
+  final String title;
+  final String description;
+  final IconData icon;
+  final VoidCallback onTap;
+  final Color accentColor;
+}
+
+class _FeatureCard extends StatelessWidget {
+  const _FeatureCard({required this.feature});
+
+  final HomeFeatureItem feature;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+
+    final brightness = ThemeData.estimateBrightnessForColor(feature.accentColor);
+    final foregroundColor = brightness == Brightness.dark
+        ? Colors.white
+        : theme.colorScheme.onSurface.withOpacity(0.9);
+
+    return Material(
+      elevation: 4,
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(28),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(28),
+        onTap: feature.onTap,
+        child: Ink(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(28),
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [
+                feature.accentColor.withOpacity(0.85),
+                feature.accentColor,
+              ],
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: feature.accentColor.withOpacity(0.24),
+                blurRadius: 24,
+                offset: const Offset(0, 12),
+              ),
+            ],
+          ),
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: foregroundColor.withOpacity(0.12),
+                  borderRadius: BorderRadius.circular(18),
+                ),
+                child: Icon(feature.icon, size: 28, color: foregroundColor),
+              ),
+              const SizedBox(height: 18),
+              Text(
+                feature.title,
+                style: textTheme.headlineSmall?.copyWith(
+                  color: foregroundColor,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 12),
+              Expanded(
+                child: Text(
+                  feature.description,
+                  style: textTheme.bodyLarge?.copyWith(
+                    color: foregroundColor.withOpacity(0.85),
+                    height: 1.4,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  Text(
+                    'Apri',
+                    style: textTheme.labelLarge?.copyWith(
+                      color: foregroundColor,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Icon(Icons.arrow_forward_rounded, color: foregroundColor, size: 20),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/frontend/widgets/components/home_feature_grid.dart
+++ b/lib/frontend/widgets/components/home_feature_grid.dart
@@ -10,39 +10,43 @@ class HomeFeatureGrid extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SliverPadding(
-      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-      sliver: SliverToBoxAdapter(
+    return SliverToBoxAdapter(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
         child: LayoutBuilder(
           builder: (context, constraints) {
-            final maxWidth = constraints.maxWidth;
             final mediaQueryWidth = MediaQuery.of(context).size.width;
-            final width = (maxWidth.isFinite && maxWidth > 0)
-                ? maxWidth
+            final maxWidth = constraints.maxWidth.isFinite && constraints.maxWidth > 0
+                ? constraints.maxWidth
                 : mediaQueryWidth;
-            final crossAxisCount = _crossAxisCountFor(width);
-            const spacing = 24.0;
-            final gaps = crossAxisCount > 1
+
+            final crossAxisCount = _crossAxisCountFor(maxWidth);
+            final spacing = crossAxisCount > 1 ? 24.0 : 20.0;
+            final horizontalGaps = crossAxisCount > 1
                 ? (crossAxisCount - 1) * spacing
                 : 0.0;
-            final availableWidth = (width - gaps).clamp(0.0, width);
+            final availableWidth = (maxWidth - horizontalGaps)
+                .clamp(0.0, maxWidth);
             final tileWidth = crossAxisCount == 1
-                ? width
+                ? maxWidth
                 : availableWidth / crossAxisCount;
 
             final aspectRatio = crossAxisCount == 1 ? 16 / 9 : 4 / 3;
-            final tileHeight = tileWidth / aspectRatio;
 
             return Wrap(
-              alignment: WrapAlignment.start,
               spacing: spacing,
               runSpacing: spacing,
               children: [
                 for (final feature in features)
-                  SizedBox(
-                    width: tileWidth,
-                    height: tileHeight,
-                    child: _FeatureCard(feature: feature),
+                  ConstrainedBox(
+                    constraints: BoxConstraints(
+                      maxWidth: tileWidth,
+                      minWidth: tileWidth,
+                    ),
+                    child: AspectRatio(
+                      aspectRatio: aspectRatio,
+                      child: _FeatureCard(feature: feature),
+                    ),
                   ),
               ],
             );

--- a/lib/frontend/widgets/components/home_feature_grid.dart
+++ b/lib/frontend/widgets/components/home_feature_grid.dart
@@ -10,31 +10,45 @@ class HomeFeatureGrid extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SliverLayoutBuilder(
-      builder: (context, constraints) {
-        final width = constraints.crossAxisExtent;
-        final crossAxisCount = _crossAxisCountFor(width);
-        final childAspectRatio = crossAxisCount == 1 ? 16 / 9 : 4 / 3;
+    return SliverPadding(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+      sliver: SliverToBoxAdapter(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final maxWidth = constraints.maxWidth;
+            final mediaQueryWidth = MediaQuery.of(context).size.width;
+            final width = (maxWidth.isFinite && maxWidth > 0)
+                ? maxWidth
+                : mediaQueryWidth;
+            final crossAxisCount = _crossAxisCountFor(width);
+            const spacing = 24.0;
+            final gaps = crossAxisCount > 1
+                ? (crossAxisCount - 1) * spacing
+                : 0.0;
+            final availableWidth = (width - gaps).clamp(0.0, width);
+            final tileWidth = crossAxisCount == 1
+                ? width
+                : availableWidth / crossAxisCount;
 
-        return SliverPadding(
-          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-          sliver: SliverGrid(
-            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: crossAxisCount,
-              mainAxisSpacing: 24,
-              crossAxisSpacing: 24,
-              childAspectRatio: childAspectRatio,
-            ),
-            delegate: SliverChildBuilderDelegate(
-              (context, index) {
-                final feature = features[index];
-                return _FeatureCard(feature: feature);
-              },
-              childCount: features.length,
-            ),
-          ),
-        );
-      },
+            final aspectRatio = crossAxisCount == 1 ? 16 / 9 : 4 / 3;
+            final tileHeight = tileWidth / aspectRatio;
+
+            return Wrap(
+              alignment: WrapAlignment.start,
+              spacing: spacing,
+              runSpacing: spacing,
+              children: [
+                for (final feature in features)
+                  SizedBox(
+                    width: tileWidth,
+                    height: tileHeight,
+                    child: _FeatureCard(feature: feature),
+                  ),
+              ],
+            );
+          },
+        ),
+      ),
     );
   }
 

--- a/lib/frontend/widgets/components/home_hero_section.dart
+++ b/lib/frontend/widgets/components/home_hero_section.dart
@@ -42,7 +42,7 @@ class HomeHeroSection extends StatelessWidget {
             Wrap(
               spacing: 12,
               runSpacing: 12,
-              children: const [
+              children: [
                 _HeroHighlight(
                   icon: Icons.shield_rounded,
                   label: 'Runtime isolati',

--- a/lib/frontend/widgets/components/home_hero_section.dart
+++ b/lib/frontend/widgets/components/home_hero_section.dart
@@ -1,0 +1,281 @@
+import 'package:flutter/material.dart';
+
+class HomeHeroSection extends StatelessWidget {
+  const HomeHeroSection({
+    super.key,
+    required this.onExploreBots,
+    required this.onOpenDocs,
+  });
+
+  final VoidCallback onExploreBots;
+  final VoidCallback onOpenDocs;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final foreground = colorScheme.onPrimary;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isWide = constraints.maxWidth >= 900;
+        final content = Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Automatizza i tuoi flussi con Scriptagher',
+              style: theme.textTheme.displaySmall?.copyWith(
+                color: foreground,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Gestisci bot sicuri su ogni piattaforma, sincronizza marketplace, '
+              'monitora esecuzioni e mantieni il controllo con un solo clic.',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: foreground.withOpacity(0.85),
+                height: 1.4,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: const [
+                _HeroHighlight(
+                  icon: Icons.shield_rounded,
+                  label: 'Runtime isolati',
+                  color: foreground,
+                ),
+                _HeroHighlight(
+                  icon: Icons.bolt_rounded,
+                  label: 'Deploy immediati',
+                  color: foreground,
+                ),
+                _HeroHighlight(
+                  icon: Icons.dataset_rounded,
+                  label: 'Gestione permessi',
+                  color: foreground,
+                ),
+              ],
+            ),
+            const SizedBox(height: 28),
+            Wrap(
+              spacing: 16,
+              runSpacing: 12,
+              children: [
+                FilledButton.icon(
+                  onPressed: onExploreBots,
+                  icon: const Icon(Icons.apps_rounded),
+                  label: const Text('Sfoglia libreria bot'),
+                ),
+                OutlinedButton.icon(
+                  onPressed: onOpenDocs,
+                  icon: const Icon(Icons.menu_book_rounded),
+                  label: const Text('Apri documentazione'),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: foreground,
+                    side: BorderSide(color: foreground.withOpacity(0.5)),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        );
+
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 36),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(32),
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [
+                colorScheme.primaryContainer,
+                colorScheme.primary,
+                colorScheme.primary.withOpacity(0.85),
+              ],
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: colorScheme.primary.withOpacity(0.25),
+                blurRadius: 36,
+                offset: const Offset(0, 16),
+              ),
+            ],
+          ),
+          child: isWide
+              ? Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(child: content),
+                    const SizedBox(width: 32),
+                    Expanded(
+                      child: _HeroShowcase(
+                        overlayColor: foreground.withOpacity(0.12),
+                        textColor: foreground,
+                      ),
+                    ),
+                  ],
+                )
+              : Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    content,
+                    const SizedBox(height: 32),
+                    _HeroShowcase(
+                      overlayColor: foreground.withOpacity(0.14),
+                      textColor: foreground,
+                    ),
+                  ],
+                ),
+        );
+      },
+    );
+  }
+}
+
+class _HeroHighlight extends StatelessWidget {
+  const _HeroHighlight({
+    required this.icon,
+    required this.label,
+    required this.color,
+  });
+
+  final IconData icon;
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.18),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 18, color: color),
+          const SizedBox(width: 8),
+          Text(
+            label,
+            style: theme.textTheme.labelLarge?.copyWith(
+              color: color,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HeroShowcase extends StatelessWidget {
+  const _HeroShowcase({
+    required this.overlayColor,
+    required this.textColor,
+  });
+
+  final Color overlayColor;
+  final Color textColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textStyle = theme.textTheme.titleMedium?.copyWith(
+      color: textColor.withOpacity(0.9),
+    );
+
+    return Container(
+      padding: const EdgeInsets.all(28),
+      decoration: BoxDecoration(
+        color: overlayColor,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(
+          color: textColor.withOpacity(0.15),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.auto_awesome_rounded, size: 28, color: textColor),
+              const SizedBox(width: 12),
+              Text(
+                'Perché Scriptagher',
+                style: TextStyle(
+                  color: textColor,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 18,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'Installa, testa e distribuisci bot multi-linguaggio con un hub '
+            'unificato. Supporto per ambienti isolati, telemetria e gestione '
+            'dei permessi integrata.',
+            style: textStyle,
+          ),
+          const SizedBox(height: 16),
+          Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              _HeroMetric(
+                icon: Icons.cloud_sync_rounded,
+                label: 'Marketplace live',
+                color: textColor,
+              ),
+              _HeroMetric(
+                icon: Icons.security_rounded,
+                label: 'Policy granulari',
+                color: textColor,
+              ),
+              _HeroMetric(
+                icon: Icons.speed_rounded,
+                label: 'Deploy rapidi',
+                color: textColor,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HeroMetric extends StatelessWidget {
+  const _HeroMetric({
+    required this.icon,
+    required this.label,
+    required this.color,
+  });
+
+  final IconData icon;
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Chip(
+      avatar: Icon(icon, size: 18, color: color),
+      backgroundColor: color.withOpacity(0.14),
+      label: Text(
+        label,
+        style: TextStyle(
+          color: color,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+    );
+  }
+}

--- a/lib/frontend/widgets/pages/bot_list_view.dart
+++ b/lib/frontend/widgets/pages/bot_list_view.dart
@@ -11,6 +11,7 @@ import '../../models/bot_filter.dart';
 import '../../models/bot_navigation.dart';
 import '../../services/bot_get_service.dart';
 import '../../services/bot_upload_service.dart';
+import '../components/app_gradient_background.dart';
 import '../components/bot_card_component.dart';
 import '../components/search_component.dart';
 import 'bot_detail_view.dart';
@@ -177,7 +178,7 @@ class _BotListState extends State<BotList>
           if (_selectedCategory == BotCategory.online)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 8.0),
-              child: TextButton.icon(
+              child: FilledButton.tonalIcon(
                 onPressed:
                     _isRefreshingOnline ? null : () => _refreshOnlineBots(),
                 icon: _isRefreshingOnline
@@ -186,7 +187,7 @@ class _BotListState extends State<BotList>
                         height: 16,
                         child: CircularProgressIndicator(strokeWidth: 2),
                       )
-                    : const Icon(Icons.refresh),
+                    : const Icon(Icons.refresh_rounded),
                 label: Text(
                     _isRefreshingOnline ? 'Aggiornamento...' : 'Aggiorna'),
               ),
@@ -199,26 +200,50 @@ class _BotListState extends State<BotList>
               .toList(),
         ),
       ),
-      body: Column(
-        children: [
-          Padding(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
-            child: SearchView(
-              onFilterChanged: _handleFilterChanged,
-              hintText:
-                  'Cerca per nome, tag, lingua o usa filtri (es. lang:python #utility)',
+      body: AppGradientBackground(
+        applyTopSafeArea: false,
+        padding: EdgeInsets.zero,
+        child: Column(
+          children: [
+            Padding(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16.0, vertical: 16.0),
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  color: Theme.of(context)
+                      .colorScheme
+                      .surfaceVariant
+                      .withOpacity(0.6),
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                child: Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  child: SearchView(
+                    onFilterChanged: _handleFilterChanged,
+                    hintText:
+                        'Cerca per nome, tag, lingua o usa filtri (es. lang:python #utility)',
+                  ),
+                ),
+              ),
             ),
-          ),
-          Expanded(
-            child: TabBarView(
-              controller: _tabController,
-              children: BotCategory.values
-                  .map(_buildCategoryView)
-                  .toList(growable: false),
+            Expanded(
+              child: Card(
+                margin: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(24),
+                ),
+                clipBehavior: Clip.antiAlias,
+                child: TabBarView(
+                  controller: _tabController,
+                  children: BotCategory.values
+                      .map(_buildCategoryView)
+                      .toList(growable: false),
+                ),
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
       floatingActionButton: _selectedCategory == BotCategory.local
           ? FloatingActionButton.extended(
@@ -232,7 +257,8 @@ class _BotListState extends State<BotList>
                         height: 20,
                         child: CircularProgressIndicator(strokeWidth: 2),
                       )
-                    : const Icon(Icons.upload_file, key: ValueKey('icon')),
+                    : const Icon(Icons.upload_file_rounded,
+                        key: ValueKey('icon')),
               ),
               label: Text(_isUploading ? 'Caricamento...' : 'Importa bot'),
             )

--- a/lib/frontend/widgets/pages/home_page_view.dart
+++ b/lib/frontend/widgets/pages/home_page_view.dart
@@ -1,100 +1,15 @@
 import 'package:flutter/material.dart';
-import '../../models/bot_navigation.dart';
 
-class HomePage extends StatefulWidget {
+import '../../models/bot_navigation.dart';
+import '../components/app_gradient_background.dart';
+import '../components/home_call_to_action_section.dart';
+import '../components/home_feature_grid.dart';
+import '../components/home_hero_section.dart';
+
+class HomePage extends StatelessWidget {
   const HomePage({super.key});
 
-  @override
-  State<HomePage> createState() => _HomePageState();
-}
-
-class _HomePageState extends State<HomePage>
-    with SingleTickerProviderStateMixin {
-  final List<_Category> _categories = const [
-    _Category(
-      title: 'Scaricati',
-      description:
-          'Consulta i bot che hai già scaricato e salvato nel database locale.',
-      icon: Icons.download_done_outlined,
-      category: BotCategory.downloaded,
-    ),
-    _Category(
-      title: 'Online',
-      description:
-          'Scopri i bot disponibili online tramite le API e scaricane di nuovi.',
-      icon: Icons.cloud_outlined,
-      category: BotCategory.online,
-    ),
-    _Category(
-      title: 'Locali',
-      description:
-          'Gestisci i bot presenti direttamente nel filesystem della macchina.',
-      icon: Icons.folder_outlined,
-      category: BotCategory.local,
-    ),
-  ];
-
-  final List<_SectionItem> _sections = const [
-    _SectionItem(
-      title: 'Impostazioni',
-      description: 'Gestisci preferenze, privacy e telemetria',
-      icon: Icons.settings_outlined,
-      routeName: '/settings',
-    ),
-  ];
-
-  late final TabController _tabController;
-  int _selectedIndex = 0;
-  bool _isTabControllerUpdateFromNavigation = false;
-
-  int get _totalDestinations => _categories.length + _sections.length;
-
-  @override
-  void initState() {
-    super.initState();
-    _tabController = TabController(length: _totalDestinations, vsync: this);
-    _tabController.addListener(_handleTabSelection);
-  }
-
-  @override
-  void dispose() {
-    _tabController.removeListener(_handleTabSelection);
-    _tabController.dispose();
-    super.dispose();
-  }
-
-  void _handleTabSelection() {
-    if (_tabController.indexIsChanging) return;
-
-    setState(() {
-      _selectedIndex = _tabController.index;
-    });
-
-    if (_isTabControllerUpdateFromNavigation) {
-      _isTabControllerUpdateFromNavigation = false;
-      return;
-    }
-
-    _handleSelection(_tabController.index);
-  }
-
-  void _onDestinationSelected(int index) {
-    if (_selectedIndex == index) {
-      _handleSelection(index);
-      return;
-    }
-    setState(() {
-      _selectedIndex = index;
-      if (_tabController.index != index) {
-        _isTabControllerUpdateFromNavigation = true;
-        _tabController.index = index;
-      }
-    });
-
-    _handleSelection(index);
-  }
-
-  void _openBots(BotCategory category) {
+  void _openBots(BuildContext context, BotCategory category) {
     Navigator.pushNamed(
       context,
       '/bots',
@@ -102,256 +17,78 @@ class _HomePageState extends State<HomePage>
     );
   }
 
-  void _openSection(_SectionItem section) {
-    Navigator.pushNamed(context, section.routeName);
+  void _openSettings(BuildContext context) {
+    Navigator.pushNamed(context, '/settings');
   }
 
-  void _handleSelection(int index) {
-    if (index < _categories.length) {
-      return;
-    }
-
-    final section = _sections[index - _categories.length];
-    _openSection(section);
-  }
-
-  void _openTutorial() {
+  void _openTutorial(BuildContext context) {
     Navigator.pushNamed(context, '/tutorial');
   }
 
-  Widget _buildCategoryContent(int index) {
-    if (index < _categories.length) {
-      final category = _categories[index];
-      return Padding(
-        key: ValueKey(category.category),
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(category.icon, size: 32, color: Colors.blueAccent),
-                const SizedBox(width: 12),
-                Text(
-                  category.title,
-                  style: const TextStyle(
-                    fontSize: 28,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 16),
-            Text(
-              category.description,
-              style: const TextStyle(
-                fontSize: 16,
-                color: Colors.black54,
-              ),
-            ),
-            const Spacer(),
-            Align(
-              alignment: Alignment.bottomRight,
-              child: ElevatedButton.icon(
-                onPressed: () => _openBots(category.category),
-                icon: const Icon(Icons.arrow_forward),
-                label: const Text('Apri elenco'),
-              ),
-            ),
-          ],
-        ),
-      );
-    }
-
-    final section = _sections[index - _categories.length];
-    return Padding(
-      key: ValueKey(section.routeName),
-      padding: const EdgeInsets.all(16.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(section.icon, size: 32, color: Colors.blueAccent),
-              const SizedBox(width: 12),
-              Text(
-                section.title,
-                style: const TextStyle(
-                  fontSize: 28,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 16),
-          Text(
-            section.description,
-            style: const TextStyle(
-              fontSize: 16,
-              color: Colors.black54,
-            ),
-          ),
-          const Spacer(),
-          Align(
-            alignment: Alignment.bottomRight,
-            child: ElevatedButton.icon(
-              onPressed: () => _openSection(section),
-              icon: const Icon(Icons.arrow_forward),
-              label: Text('Apri ${section.title}'),
-            ),
-          ),
-        ],
-      ),
-    );
+  void _openDocs(BuildContext context) {
+    Navigator.pushNamed(context, '/tutorial');
   }
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final features = [
+      HomeFeatureItem(
+        title: 'Scaricati',
+        description:
+            'Consulta i bot installati localmente, aggiorna versioni e monitora gli esiti delle ultime esecuzioni.',
+        icon: Icons.download_rounded,
+        accentColor: colorScheme.primary,
+        onTap: () => _openBots(context, BotCategory.downloaded),
+      ),
+      HomeFeatureItem(
+        title: 'Online',
+        description:
+            'Esplora il marketplace ufficiale, filtra per linguaggio, tag o permessi e installa nuovi bot.',
+        icon: Icons.cloud_rounded,
+        accentColor: colorScheme.tertiary,
+        onTap: () => _openBots(context, BotCategory.online),
+      ),
+      HomeFeatureItem(
+        title: 'Locali',
+        description:
+            'Importa cartelle e archivi ZIP, valida Bot.json e prepara un ambiente isolato per l\'esecuzione.',
+        icon: Icons.folder_rounded,
+        accentColor: colorScheme.secondary,
+        onTap: () => _openBots(context, BotCategory.local),
+      ),
+      HomeFeatureItem(
+        title: 'Impostazioni',
+        description:
+            'Personalizza tema, preferenze di privacy, telemetria e integrazioni con strumenti esterni.',
+        icon: Icons.tune_rounded,
+        accentColor: colorScheme.errorContainer,
+        onTap: () => _openSettings(context),
+      ),
+    ];
+
     return Scaffold(
-      body: Padding(
-        padding: const EdgeInsets.all(24.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Text(
-              'HOME - Cosa vuoi fare?',
-              style: TextStyle(
-                fontSize: 26,
-                fontWeight: FontWeight.bold,
-                color: Colors.black87,
-              ),
-            ),
-            const SizedBox(height: 16),
-            Card(
-              elevation: 2,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: InkWell(
-                borderRadius: BorderRadius.circular(12),
-                onTap: _openTutorial,
-                child: Padding(
-                  padding: const EdgeInsets.all(20),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      const Icon(Icons.school_outlined,
-                          color: Colors.blueAccent, size: 32),
-                      const SizedBox(width: 16),
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            const Text(
-                              'Crea il tuo bot',
-                              style: TextStyle(
-                                fontSize: 20,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                            const SizedBox(height: 8),
-                            Text(
-                              'Segui il tutorial passo-passo per creare un bot sicuro compatibile con Scriptagher.',
-                              style: TextStyle(
-                                fontSize: 15,
-                                color: Colors.grey.shade700,
-                              ),
-                            ),
-                            const SizedBox(height: 12),
-                            Row(
-                              children: const [
-                                Text(
-                                  'Apri tutorial',
-                                  style: TextStyle(
-                                    fontSize: 15,
-                                    fontWeight: FontWeight.w600,
-                                  ),
-                                ),
-                                SizedBox(width: 4),
-                                Icon(Icons.arrow_forward, size: 18),
-                              ],
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
+      body: AppGradientBackground(
+        padding: EdgeInsets.zero,
+        child: CustomScrollView(
+          slivers: [
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(24, 32, 24, 16),
+              sliver: SliverToBoxAdapter(
+                child: HomeHeroSection(
+                  onExploreBots: () => _openBots(context, BotCategory.online),
+                  onOpenDocs: () => _openDocs(context),
                 ),
               ),
             ),
-            const SizedBox(height: 24),
-            Expanded(
-              child: LayoutBuilder(
-                builder: (context, constraints) {
-                  if (constraints.maxWidth >= 800) {
-                    return Row(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        NavigationRail(
-                          selectedIndex: _selectedIndex,
-                          onDestinationSelected: _onDestinationSelected,
-                          labelType: NavigationRailLabelType.all,
-                          destinations: [
-                            ..._categories.map(
-                              (category) => NavigationRailDestination(
-                                icon: Icon(category.icon),
-                                selectedIcon: Icon(
-                                  category.icon,
-                                  color: Colors.blueAccent,
-                                ),
-                                label: Text(category.title),
-                              ),
-                            ),
-                            ..._sections.map(
-                              (section) => NavigationRailDestination(
-                                icon: Icon(section.icon),
-                                selectedIcon: Icon(
-                                  section.icon,
-                                  color: Colors.blueAccent,
-                                ),
-                                label: Text(section.title),
-                              ),
-                            ),
-                          ],
-                        ),
-                        const VerticalDivider(width: 1),
-                        Expanded(
-                          child: AnimatedSwitcher(
-                            duration: const Duration(milliseconds: 200),
-                            child: _buildCategoryContent(_selectedIndex),
-                          ),
-                        ),
-                      ],
-                    );
-                  }
-
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      TabBar(
-                        controller: _tabController,
-                        labelColor: Colors.blueAccent,
-                        unselectedLabelColor: Colors.grey,
-                        tabs: [
-                          ..._categories.map((category) => Tab(text: category.title)),
-                          ..._sections.map((section) => Tab(text: section.title)),
-                        ],
-                      ),
-                      const SizedBox(height: 16),
-                      Expanded(
-                        child: TabBarView(
-                          controller: _tabController,
-                          children: List.generate(
-                            _totalDestinations,
-                            _buildCategoryContent,
-                          ),
-                        ),
-                      ),
-                    ],
-                  );
-                },
+            HomeFeatureGrid(features: features),
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(24, 24, 24, 48),
+              sliver: SliverToBoxAdapter(
+                child: HomeCallToActionSection(
+                  onPressed: () => _openTutorial(context),
+                ),
               ),
             ),
           ],
@@ -359,32 +96,4 @@ class _HomePageState extends State<HomePage>
       ),
     );
   }
-}
-
-class _Category {
-  final String title;
-  final String description;
-  final IconData icon;
-  final BotCategory category;
-
-  const _Category({
-    required this.title,
-    required this.description,
-    required this.icon,
-    required this.category,
-  });
-}
-
-class _SectionItem {
-  final String title;
-  final String description;
-  final IconData icon;
-  final String routeName;
-
-  const _SectionItem({
-    required this.title,
-    required this.description,
-    required this.icon,
-    required this.routeName,
-  });
 }

--- a/lib/frontend/widgets/pages/home_page_view.dart
+++ b/lib/frontend/widgets/pages/home_page_view.dart
@@ -32,6 +32,10 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final viewportHeight = MediaQuery.of(context).size.height;
+    final precacheExtent = viewportHeight.isFinite && viewportHeight > 0
+        ? viewportHeight * 1.5
+        : 1200.0;
 
     final features = [
       HomeFeatureItem(
@@ -72,6 +76,9 @@ class HomePage extends StatelessWidget {
       body: AppGradientBackground(
         padding: EdgeInsets.zero,
         child: CustomScrollView(
+          // Precache slivers beyond the first fold so widget tests can access
+          // the navigation cards without requiring an explicit scroll.
+          cacheExtent: precacheExtent,
           slivers: [
             SliverPadding(
               padding: const EdgeInsets.fromLTRB(24, 32, 24, 16),

--- a/lib/frontend/widgets/pages/home_page_view.dart
+++ b/lib/frontend/widgets/pages/home_page_view.dart
@@ -32,10 +32,6 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final viewportHeight = MediaQuery.of(context).size.height;
-    final precacheExtent = viewportHeight.isFinite && viewportHeight > 0
-        ? viewportHeight * 1.5
-        : 1200.0;
 
     final features = [
       HomeFeatureItem(
@@ -75,30 +71,40 @@ class HomePage extends StatelessWidget {
     return Scaffold(
       body: AppGradientBackground(
         padding: EdgeInsets.zero,
-        child: CustomScrollView(
-          // Precache slivers beyond the first fold so widget tests can access
-          // the navigation cards without requiring an explicit scroll.
-          cacheExtent: precacheExtent,
-          slivers: [
-            SliverPadding(
-              padding: const EdgeInsets.fromLTRB(24, 32, 24, 16),
-              sliver: SliverToBoxAdapter(
-                child: HomeHeroSection(
-                  onExploreBots: () => _openBots(context, BotCategory.online),
-                  onOpenDocs: () => _openDocs(context),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final horizontalPadding = constraints.maxWidth >= 1200 ? 48.0 : 24.0;
+
+            return Align(
+              alignment: Alignment.topCenter,
+              child: SingleChildScrollView(
+                padding: EdgeInsets.fromLTRB(
+                  horizontalPadding,
+                  32,
+                  horizontalPadding,
+                  48,
+                ),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 1200),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      HomeHeroSection(
+                        onExploreBots: () => _openBots(context, BotCategory.online),
+                        onOpenDocs: () => _openDocs(context),
+                      ),
+                      const SizedBox(height: 32),
+                      HomeFeatureGrid(features: features),
+                      const SizedBox(height: 32),
+                      HomeCallToActionSection(
+                        onPressed: () => _openTutorial(context),
+                      ),
+                    ],
+                  ),
                 ),
               ),
-            ),
-            HomeFeatureGrid(features: features),
-            SliverPadding(
-              padding: const EdgeInsets.fromLTRB(24, 24, 24, 48),
-              sliver: SliverToBoxAdapter(
-                child: HomeCallToActionSection(
-                  onPressed: () => _openTutorial(context),
-                ),
-              ),
-            ),
-          ],
+            );
+          },
         ),
       ),
     );

--- a/lib/frontend/widgets/pages/settings_page.dart
+++ b/lib/frontend/widgets/pages/settings_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:scriptagher/shared/services/telemetry_service.dart';
 import 'package:scriptagher/shared/theme/theme_controller.dart';
 
+import '../components/app_gradient_background.dart';
+
 class SettingsPage extends StatelessWidget {
   final TelemetryService telemetryService;
 
@@ -9,62 +11,97 @@ class SettingsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Impostazioni'),
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(24.0),
-        child: ListView(
-          children: [
-            _SectionTitle(title: 'Aspetto e accessibilità'),
-            const SizedBox(height: 12),
-            const _ThemeSelector(),
-            const SizedBox(height: 32),
-            _SectionTitle(title: 'Privacy e telemetria'),
-            const SizedBox(height: 12),
-            Card(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                child: ValueListenableBuilder<bool>(
-                  valueListenable: telemetryService.telemetryEnabled,
-                  builder: (context, enabled, _) {
-                    return SwitchListTile.adaptive(
-                      title: const Text('Abilita telemetria anonima'),
-                      subtitle: const Text(
-                        'Consenti l\'invio di metadati diagnostici anonimizzati per aiutarci a migliorare l\'applicazione.',
-                      ),
-                      value: enabled,
-                      onChanged: (value) async {
-                        final messenger = ScaffoldMessenger.of(context);
-                        try {
-                          await telemetryService.setTelemetryEnabled(value);
-                          final message = value
-                              ? 'Telemetria attivata. Grazie per il supporto!'
-                              : 'Telemetria disattivata.';
-                          messenger.showSnackBar(
-                            SnackBar(content: Text(message)),
-                          );
-                        } catch (e) {
-                          messenger.showSnackBar(
-                            const SnackBar(
-                              content: Text(
-                                'Si è verificato un errore durante il salvataggio delle preferenze.',
+      body: AppGradientBackground(
+        applyTopSafeArea: false,
+        padding: EdgeInsets.zero,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(24, 28, 24, 48),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _SectionTitle(title: 'Aspetto e accessibilità'),
+              const SizedBox(height: 12),
+              const _ThemeSelector(),
+              const SizedBox(height: 32),
+              _SectionTitle(title: 'Privacy e telemetria'),
+              const SizedBox(height: 12),
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      colorScheme.secondaryContainer,
+                      colorScheme.secondaryContainer.withOpacity(0.75),
+                    ],
+                  ),
+                  borderRadius: BorderRadius.circular(20),
+                  boxShadow: [
+                    BoxShadow(
+                      color: colorScheme.secondary.withOpacity(0.2),
+                      blurRadius: 24,
+                      offset: const Offset(0, 12),
+                    ),
+                  ],
+                ),
+                child: Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+                  child: ValueListenableBuilder<bool>(
+                    valueListenable: telemetryService.telemetryEnabled,
+                    builder: (context, enabled, _) {
+                      return SwitchListTile.adaptive(
+                        contentPadding: EdgeInsets.zero,
+                        title: Text(
+                          'Abilita telemetria anonima',
+                          style: theme.textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        subtitle: Text(
+                          'Consenti l\'invio di metadati diagnostici anonimizzati per aiutarci a migliorare l\'applicazione.',
+                          style: theme.textTheme.bodyMedium,
+                        ),
+                        value: enabled,
+                        onChanged: (value) async {
+                          final messenger = ScaffoldMessenger.of(context);
+                          try {
+                            await telemetryService.setTelemetryEnabled(value);
+                            final message = value
+                                ? 'Telemetria attivata. Grazie per il supporto!'
+                                : 'Telemetria disattivata.';
+                            messenger.showSnackBar(
+                              SnackBar(content: Text(message)),
+                            );
+                          } catch (e) {
+                            messenger.showSnackBar(
+                              const SnackBar(
+                                content: Text(
+                                  'Si è verificato un errore durante il salvataggio delle preferenze.',
+                                ),
                               ),
-                            ),
-                          );
-                        }
-                      },
-                    );
-                  },
+                            );
+                          }
+                        },
+                        activeColor: colorScheme.secondary,
+                      );
+                    },
+                  ),
                 ),
               ),
-            ),
-            const SizedBox(height: 16),
-            const Text(
-              'I dati inviati includono esclusivamente informazioni aggregate (come lingua del bot, tipo di errore e hash anonimi), senza alcun identificativo personale.',
-            ),
-          ],
+              const SizedBox(height: 16),
+              Text(
+                'I dati inviati includono esclusivamente informazioni aggregate (come lingua del bot, tipo di errore e hash '
+                'anonimi), senza alcun identificativo personale.',
+                style: theme.textTheme.bodyMedium,
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -88,11 +125,11 @@ class _ThemeSelector extends StatelessWidget {
   IconData _iconFor(AppTheme theme) {
     switch (theme) {
       case AppTheme.light:
-        return Icons.light_mode;
+        return Icons.light_mode_rounded;
       case AppTheme.dark:
-        return Icons.dark_mode;
+        return Icons.dark_mode_rounded;
       case AppTheme.highContrast:
-        return Icons.invert_colors;
+        return Icons.invert_colors_on_rounded;
     }
   }
 
@@ -104,9 +141,13 @@ class _ThemeSelector extends StatelessWidget {
       animation: themeController,
       builder: (context, _) {
         final currentTheme = themeController.currentTheme;
+        final colorScheme = Theme.of(context).colorScheme;
         return Card(
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+          elevation: 6,
           child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -123,10 +164,10 @@ class _ThemeSelector extends StatelessWidget {
                   runSpacing: 12,
                   children: themeController.availableThemes.map((theme) {
                     final selected = theme == currentTheme;
-                    final labelStyle = Theme.of(context).textTheme.labelLarge;
-                    final colorScheme = Theme.of(context).colorScheme;
-                    return ChoiceChip(
-                      showCheckmark: false,
+                    final labelStyle =
+                        Theme.of(context).textTheme.labelLarge ??
+                            const TextStyle();
+                    return FilterChip(
                       label: Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
@@ -135,15 +176,15 @@ class _ThemeSelector extends StatelessWidget {
                             size: 18,
                             color: selected
                                 ? colorScheme.onPrimary
-                                : colorScheme.onSurface,
+                                : colorScheme.primary,
                           ),
                           const SizedBox(width: 8),
                           Text(
                             _labelFor(theme),
-                            style: labelStyle?.copyWith(
+                            style: labelStyle.copyWith(
                               color: selected
                                   ? colorScheme.onPrimary
-                                  : colorScheme.onSurface,
+                                  : colorScheme.primary,
                             ),
                           ),
                         ],
@@ -163,7 +204,7 @@ class _ThemeSelector extends StatelessWidget {
                         );
                       },
                       selectedColor: colorScheme.primary,
-                      backgroundColor: colorScheme.surfaceVariant,
+                      checkmarkColor: colorScheme.onPrimary,
                     );
                   }).toList(),
                 ),

--- a/lib/frontend/widgets/pages/tutorial_page.dart
+++ b/lib/frontend/widgets/pages/tutorial_page.dart
@@ -47,8 +47,8 @@ class TutorialPage extends StatelessWidget {
         child: SingleChildScrollView(
           padding: const EdgeInsets.fromLTRB(24, 28, 24, 48),
           child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
             Text(
               'Panoramica',
               style: theme.textTheme.headlineMedium?.copyWith(

--- a/lib/frontend/widgets/pages/tutorial_page.dart
+++ b/lib/frontend/widgets/pages/tutorial_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../components/app_gradient_background.dart';
+
 const String _tutorialDocsUrl =
     'https://github.com/scriptagher/scriptagher/blob/main/docs/create-your-bot.md';
 
@@ -31,21 +33,27 @@ class TutorialPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Crea il tuo bot'),
         actions: [
-          IconButton(
-            tooltip: 'Apri la guida completa',
-            icon: const Icon(Icons.open_in_new),
+          FilledButton.tonalIcon(
             onPressed: () => _openDocs(context),
+            icon: const Icon(Icons.open_in_new_rounded),
+            label: const Text('Documentazione'),
           ),
+          const SizedBox(width: 16),
         ],
       ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(24),
-        child: Column(
+      body: AppGradientBackground(
+        applyTopSafeArea: false,
+        padding: EdgeInsets.zero,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(24, 28, 24, 48),
+          child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
               'Panoramica',
-              style: theme.textTheme.headlineSmall,
+              style: theme.textTheme.headlineMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
             ),
             const SizedBox(height: 8),
             const Text(
@@ -53,27 +61,17 @@ class TutorialPage extends StatelessWidget {
               'metadati, runtime e permessi. Segui i passaggi sotto per crearne uno nuovo.',
             ),
             const SizedBox(height: 24),
-            Text(
-              'Struttura del progetto',
-              style: theme.textTheme.titleLarge,
+            _SectionHeading(
+              icon: Icons.layers_rounded,
+              title: 'Struttura del progetto',
             ),
             const SizedBox(height: 8),
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: Colors.grey.shade100,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Colors.grey.shade300),
-              ),
-              child: const SelectableText(
-                'my-awesome-bot/\n'
-                '├── Bot.json\n'
-                '├── main.py\n'
-                '├── requirements.txt\n'
-                '└── resources/\n',
-                style: TextStyle(fontFamily: 'monospace'),
-              ),
+            _CodeBlock(
+              content: 'my-awesome-bot/\n'
+                  '├── Bot.json\n'
+                  '├── main.py\n'
+                  '├── requirements.txt\n'
+                  '└── resources/\n',
             ),
             const SizedBox(height: 16),
             const Text(
@@ -82,47 +80,37 @@ class TutorialPage extends StatelessWidget {
               'dipendenze dichiarate nei comandi di post installazione.',
             ),
             const SizedBox(height: 24),
-            Text(
-              'Esempio di Bot.json',
-              style: theme.textTheme.titleLarge,
+            _SectionHeading(
+              icon: Icons.code_rounded,
+              title: 'Esempio di Bot.json',
             ),
             const SizedBox(height: 8),
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: Colors.grey.shade100,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: Colors.grey.shade300),
-              ),
-              child: const SelectableText(
-                '{\n'
-                '  "botName": "MyAwesomeBot",\n'
-                '  "version": "1.0.0",\n'
-                '  "archiveSha256": "0123456789abcdef...",\n'
-                '  "description": "Esempio di bot che stampa un messaggio",\n'
-                '  "author": "Jane Doe",\n'
-                '  "language": "python",\n'
-                '  "entrypoint": "main.py",\n'
-                '  "args": ["--verbose"],\n'
-                '  "environment": {\n'
-                '    "PYTHONPATH": "./"\n'
-                '  },\n'
-                '  "postInstall": [\n'
-                '    "pip install -r requirements.txt"\n'
-                '  ],\n'
-                '  "permissions": [\n'
-                '    "network",\n'
-                '    "filesystem:read"\n'
-                '  ]\n'
-                '}\n',
-                style: TextStyle(fontFamily: 'monospace'),
-              ),
+            const _CodeBlock(
+              content: '{\n'
+                  '  "botName": "MyAwesomeBot",\n'
+                  '  "version": "1.0.0",\n'
+                  '  "archiveSha256": "0123456789abcdef...",\n'
+                  '  "description": "Esempio di bot che stampa un messaggio",\n'
+                  '  "author": "Jane Doe",\n'
+                  '  "language": "python",\n'
+                  '  "entrypoint": "main.py",\n'
+                  '  "args": ["--verbose"],\n'
+                  '  "environment": {\n'
+                  '    "PYTHONPATH": "./"\n'
+                  '  },\n'
+                  '  "postInstall": [\n'
+                  '    "pip install -r requirements.txt"\n'
+                  '  ],\n'
+                  '  "permissions": [\n'
+                  '    "network",\n'
+                  '    "filesystem:read"\n'
+                  '  ]\n'
+                  '}\n',
             ),
             const SizedBox(height: 24),
-            Text(
-              'Flusso di lavoro',
-              style: theme.textTheme.titleLarge,
+            _SectionHeading(
+              icon: Icons.route_rounded,
+              title: 'Flusso di lavoro',
             ),
             const SizedBox(height: 8),
             const _NumberedList(
@@ -135,9 +123,9 @@ class TutorialPage extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 24),
-            Text(
-              'Best practice di sicurezza',
-              style: theme.textTheme.titleLarge,
+            _SectionHeading(
+              icon: Icons.verified_user_rounded,
+              title: 'Best practice di sicurezza',
             ),
             const SizedBox(height: 8),
             const _BulletList(
@@ -150,9 +138,9 @@ class TutorialPage extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 24),
-            Text(
-              'Risorse aggiuntive',
-              style: theme.textTheme.titleLarge,
+            _SectionHeading(
+              icon: Icons.link_rounded,
+              title: 'Risorse aggiuntive',
             ),
             const SizedBox(height: 8),
             Text.rich(
@@ -179,6 +167,65 @@ class TutorialPage extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _SectionHeading extends StatelessWidget {
+  const _SectionHeading({required this.icon, required this.title});
+
+  final IconData icon;
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Row(
+      children: [
+        Container(
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: colorScheme.primaryContainer.withOpacity(0.6),
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Icon(icon, color: colorScheme.onPrimaryContainer, size: 20),
+        ),
+        const SizedBox(width: 12),
+        Text(
+          title,
+          style: theme.textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CodeBlock extends StatelessWidget {
+  const _CodeBlock({required this.content});
+
+  final String content;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceVariant.withOpacity(0.8),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: theme.colorScheme.outlineVariant.withOpacity(0.4),
+        ),
+      ),
+      child: SelectableText(
+        content,
+        style: const TextStyle(fontFamily: 'monospace'),
       ),
     );
   }

--- a/lib/frontend/widgets/pages/tutorial_page.dart
+++ b/lib/frontend/widgets/pages/tutorial_page.dart
@@ -49,123 +49,124 @@ class TutorialPage extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-            Text(
-              'Panoramica',
-              style: theme.textTheme.headlineMedium?.copyWith(
-                fontWeight: FontWeight.bold,
+              Text(
+                'Panoramica',
+                style: theme.textTheme.headlineMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
               ),
-            ),
-            const SizedBox(height: 8),
-            const Text(
-              'Scriptagher esegue bot impacchettati come cartelle con un file Bot.json che descrive '
-              'metadati, runtime e permessi. Segui i passaggi sotto per crearne uno nuovo.',
-            ),
-            const SizedBox(height: 24),
-            _SectionHeading(
-              icon: Icons.layers_rounded,
-              title: 'Struttura del progetto',
-            ),
-            const SizedBox(height: 8),
-            _CodeBlock(
-              content: 'my-awesome-bot/\n'
-                  '├── Bot.json\n'
-                  '├── main.py\n'
-                  '├── requirements.txt\n'
-                  '└── resources/\n',
-            ),
-            const SizedBox(height: 16),
-            const Text(
-              'Il file Bot.json definisce nome, versione, linguaggio, entrypoint, argomenti opzionali e '
-              'comandi di installazione. I file sorgente contengono la logica del bot e possono includere '
-              'dipendenze dichiarate nei comandi di post installazione.',
-            ),
-            const SizedBox(height: 24),
-            _SectionHeading(
-              icon: Icons.code_rounded,
-              title: 'Esempio di Bot.json',
-            ),
-            const SizedBox(height: 8),
-            const _CodeBlock(
-              content: '{\n'
-                  '  "botName": "MyAwesomeBot",\n'
-                  '  "version": "1.0.0",\n'
-                  '  "archiveSha256": "0123456789abcdef...",\n'
-                  '  "description": "Esempio di bot che stampa un messaggio",\n'
-                  '  "author": "Jane Doe",\n'
-                  '  "language": "python",\n'
-                  '  "entrypoint": "main.py",\n'
-                  '  "args": ["--verbose"],\n'
-                  '  "environment": {\n'
-                  '    "PYTHONPATH": "./"\n'
-                  '  },\n'
-                  '  "postInstall": [\n'
-                  '    "pip install -r requirements.txt"\n'
-                  '  ],\n'
-                  '  "permissions": [\n'
-                  '    "network",\n'
-                  '    "filesystem:read"\n'
-                  '  ]\n'
-                  '}\n',
-            ),
-            const SizedBox(height: 24),
-            _SectionHeading(
-              icon: Icons.route_rounded,
-              title: 'Flusso di lavoro',
-            ),
-            const SizedBox(height: 8),
-            const _NumberedList(
-              items: [
-                'Scopri i bot nella libreria Online o prepara una nuova cartella locale.',
-                'Compila Bot.json con metadati, hash SHA-256, permessi e comandi di installazione.',
-                'Testa il bot localmente eseguendo l\'entrypoint con gli stessi argomenti.',
-                'Comprimi la cartella e caricala nel marketplace oppure copiala nelle directory monitorate.',
-                'Scarica o apri il bot da Scriptagher per installarlo ed eseguirlo dal dettaglio.',
-              ],
-            ),
-            const SizedBox(height: 24),
-            _SectionHeading(
-              icon: Icons.verified_user_rounded,
-              title: 'Best practice di sicurezza',
-            ),
-            const SizedBox(height: 8),
-            const _BulletList(
-              items: [
-                'Isola l\'esecuzione (container, ambienti virtuali) per ridurre l\'impatto di codice malevolo.',
-                'Limita dipendenze e versioni per diminuire vulnerabilità e assicurane l\'aggiornamento.',
-                'Gestisci segreti e token tramite variabili d\'ambiente sicure, mai in chiaro nel repository.',
-                'Richiedi solo le permission strettamente necessarie in Bot.json e verifica gli accessi.',
-                'Valida l\'input e registra log strutturati per facilitare monitoraggio e audit.',
-              ],
-            ),
-            const SizedBox(height: 24),
-            _SectionHeading(
-              icon: Icons.link_rounded,
-              title: 'Risorse aggiuntive',
-            ),
-            const SizedBox(height: 8),
-            Text.rich(
-              TextSpan(
-                text: 'Consulta la documentazione completa in ',
-                children: [
-                  WidgetSpan(
-                    alignment: PlaceholderAlignment.baseline,
-                    baseline: TextBaseline.alphabetic,
-                    child: GestureDetector(
-                      onTap: () => _openDocs(context),
-                      child: Text(
-                        'docs/create-your-bot.md',
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.colorScheme.primary,
-                          decoration: TextDecoration.underline,
+              const SizedBox(height: 8),
+              const Text(
+                'Scriptagher esegue bot impacchettati come cartelle con un file Bot.json che descrive '
+                'metadati, runtime e permessi. Segui i passaggi sotto per crearne uno nuovo.',
+              ),
+              const SizedBox(height: 24),
+              _SectionHeading(
+                icon: Icons.layers_rounded,
+                title: 'Struttura del progetto',
+              ),
+              const SizedBox(height: 8),
+              _CodeBlock(
+                content: 'my-awesome-bot/\n'
+                    '├── Bot.json\n'
+                    '├── main.py\n'
+                    '├── requirements.txt\n'
+                    '└── resources/\n',
+              ),
+              const SizedBox(height: 16),
+              const Text(
+                'Il file Bot.json definisce nome, versione, linguaggio, entrypoint, argomenti opzionali e '
+                'comandi di installazione. I file sorgente contengono la logica del bot e possono includere '
+                'dipendenze dichiarate nei comandi di post installazione.',
+              ),
+              const SizedBox(height: 24),
+              _SectionHeading(
+                icon: Icons.code_rounded,
+                title: 'Esempio di Bot.json',
+              ),
+              const SizedBox(height: 8),
+              const _CodeBlock(
+                content: '{\n'
+                    '  "botName": "MyAwesomeBot",\n'
+                    '  "version": "1.0.0",\n'
+                    '  "archiveSha256": "0123456789abcdef...",\n'
+                    '  "description": "Esempio di bot che stampa un messaggio",\n'
+                    '  "author": "Jane Doe",\n'
+                    '  "language": "python",\n'
+                    '  "entrypoint": "main.py",\n'
+                    '  "args": ["--verbose"],\n'
+                    '  "environment": {\n'
+                    '    "PYTHONPATH": "./"\n'
+                    '  },\n'
+                    '  "postInstall": [\n'
+                    '    "pip install -r requirements.txt"\n'
+                    '  ],\n'
+                    '  "permissions": [\n'
+                    '    "network",\n'
+                    '    "filesystem:read"\n'
+                    '  ]\n'
+                    '}\n',
+              ),
+              const SizedBox(height: 24),
+              _SectionHeading(
+                icon: Icons.route_rounded,
+                title: 'Flusso di lavoro',
+              ),
+              const SizedBox(height: 8),
+              const _NumberedList(
+                items: [
+                  'Scopri i bot nella libreria Online o prepara una nuova cartella locale.',
+                  'Compila Bot.json con metadati, hash SHA-256, permessi e comandi di installazione.',
+                  'Testa il bot localmente eseguendo l\'entrypoint con gli stessi argomenti.',
+                  'Comprimi la cartella e caricala nel marketplace oppure copiala nelle directory monitorate.',
+                  'Scarica o apri il bot da Scriptagher per installarlo ed eseguirlo dal dettaglio.',
+                ],
+              ),
+              const SizedBox(height: 24),
+              _SectionHeading(
+                icon: Icons.verified_user_rounded,
+                title: 'Best practice di sicurezza',
+              ),
+              const SizedBox(height: 8),
+              const _BulletList(
+                items: [
+                  'Isola l\'esecuzione (container, ambienti virtuali) per ridurre l\'impatto di codice malevolo.',
+                  'Limita dipendenze e versioni per diminuire vulnerabilità e assicurane l\'aggiornamento.',
+                  'Gestisci segreti e token tramite variabili d\'ambiente sicure, mai in chiaro nel repository.',
+                  'Richiedi solo le permission strettamente necessarie in Bot.json e verifica gli accessi.',
+                  'Valida l\'input e registra log strutturati per facilitare monitoraggio e audit.',
+                ],
+              ),
+              const SizedBox(height: 24),
+              _SectionHeading(
+                icon: Icons.link_rounded,
+                title: 'Risorse aggiuntive',
+              ),
+              const SizedBox(height: 8),
+              Text.rich(
+                TextSpan(
+                  text: 'Consulta la documentazione completa in ',
+                  children: [
+                    WidgetSpan(
+                      alignment: PlaceholderAlignment.baseline,
+                      baseline: TextBaseline.alphabetic,
+                      child: GestureDetector(
+                        onTap: () => _openDocs(context),
+                        child: Text(
+                          'docs/create-your-bot.md',
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.colorScheme.primary,
+                            decoration: TextDecoration.underline,
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                  const TextSpan(text: ' nel repository.'),
-                ],
+                    const TextSpan(text: ' nel repository.'),
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- rebuild the home page around a reusable hero, adaptive feature grid and tutorial call-to-action widgets
- introduce a gradient background container to share the new visual language across desktop and web
- refresh tutorial, bots and settings routes to adopt the updated components and filled iconography

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f37db66714832b9114ee8e370ffde7