### PR TITLE
Refresh Scriptagher logo assets

### DIFF
--- a/assets/icons/scriptagher_logo.svg
+++ b/assets/icons/scriptagher_logo.svg
@@ -1,19 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">Scriptagher Logo</title>
+  <desc id="desc">Stylised S monogram within a rounded gradient square</desc>
   <defs>
     <linearGradient id="scriptagher-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#4338CA" />
-      <stop offset="50%" stop-color="#6366F1" />
-      <stop offset="100%" stop-color="#06B6D4" />
+      <stop offset="0%" stop-color="#0F172A" />
+      <stop offset="45%" stop-color="#1E3A8A" />
+      <stop offset="100%" stop-color="#0EA5E9" />
     </linearGradient>
-    <radialGradient id="scriptagher-glow" cx="50%" cy="35%" r="60%">
-      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.65" />
-      <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0" />
-    </radialGradient>
+    <linearGradient id="scriptagher-highlight" x1="15%" y1="15%" x2="85%" y2="85%">
+      <stop offset="0%" stop-color="#38BDF8" stop-opacity="0.65" />
+      <stop offset="100%" stop-color="#38BDF8" stop-opacity="0" />
+    </linearGradient>
   </defs>
   <rect width="256" height="256" rx="56" fill="url(#scriptagher-gradient)" />
-  <rect width="256" height="256" rx="56" fill="url(#scriptagher-glow)" />
+  <rect width="256" height="256" rx="56" fill="url(#scriptagher-highlight)" />
   <path
     fill="#F8FAFC"
-    d="M186 74c-15-18-37-28-63-28-46 0-80 29-80 68 0 32 21 48 52 58 25 7 35 14 35 27 0 13-13 21-32 21-21 0-39-9-52-24l-20 25c19 21 48 34 79 34 48 0 83-29 83-68 0-32-21-49-54-58-24-7-34-14-34-26 0-12 12-21 30-21 17 0 32 6 43 18z"
+    d="M74 74c20-24 56-34 88-26 22 5 40 19 46 37 10 28-10 52-54 63-38 9-46 18-42 30 4 13 22 20 44 18 20-2 36-10 47-23l28 24c-18 22-46 36-79 39-54 5-102-26-106-71-3-32 16-56 56-68 34-10 46-18 42-30-3-12-20-18-38-16-16 3-28 11-40 25z"
   />
 </svg>

--- a/web/favicon.svg
+++ b/web/favicon.svg
@@ -1,14 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Scriptagher Favicon</title>
+  <desc id="desc">Gradient tile with stylised S</desc>
   <defs>
-    <linearGradient id="scriptagher-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#4338CA" />
-      <stop offset="50%" stop-color="#6366F1" />
-      <stop offset="100%" stop-color="#06B6D4" />
+    <linearGradient id="fav-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0F172A" />
+      <stop offset="50%" stop-color="#1E3A8A" />
+      <stop offset="100%" stop-color="#0EA5E9" />
     </linearGradient>
   </defs>
-  <rect width="256" height="256" rx="56" fill="url(#scriptagher-gradient)" />
+  <rect width="64" height="64" rx="14" fill="url(#fav-gradient)" />
   <path
     fill="#F8FAFC"
-    d="M186 74c-15-18-37-28-63-28-46 0-80 29-80 68 0 32 21 48 52 58 25 7 35 14 35 27 0 13-13 21-32 21-21 0-39-9-52-24l-20 25c19 21 48 34 79 34 48 0 83-29 83-68 0-32-21-49-54-58-24-7-34-14-34-26 0-12 12-21 30-21 17 0 32 6 43 18z"
+    d="M19 19c6-7 17-9 26-7 7 2 12 6 14 11 3 9-3 16-16 19-11 3-14 6-12 10 1 4 7 6 13 6 6 0 11-2 14-6l8 7c-6 7-13 11-23 12-16 1-30-8-31-22-1-9 5-16 17-19 10-3 14-6 12-10s-7-5-11-4c-5 1-9 4-12 8z"
   />
 </svg>

--- a/web/icons/app-icon.svg
+++ b/web/icons/app-icon.svg
@@ -1,19 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">Scriptagher App Icon</title>
+  <desc id="desc">Rounded gradient square with a stylised S monogram</desc>
   <defs>
-    <linearGradient id="scriptagher-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#4338CA" />
-      <stop offset="50%" stop-color="#6366F1" />
-      <stop offset="100%" stop-color="#06B6D4" />
+    <linearGradient id="app-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0F172A" />
+      <stop offset="45%" stop-color="#1E3A8A" />
+      <stop offset="100%" stop-color="#0EA5E9" />
     </linearGradient>
-    <radialGradient id="scriptagher-glow" cx="50%" cy="35%" r="60%">
-      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.6" />
-      <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0" />
-    </radialGradient>
+    <linearGradient id="app-highlight" x1="18%" y1="18%" x2="82%" y2="82%">
+      <stop offset="0%" stop-color="#38BDF8" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="#38BDF8" stop-opacity="0" />
+    </linearGradient>
   </defs>
-  <rect width="256" height="256" rx="56" fill="url(#scriptagher-gradient)" />
-  <rect width="256" height="256" rx="56" fill="url(#scriptagher-glow)" />
+  <rect width="256" height="256" rx="56" fill="url(#app-gradient)" />
+  <rect width="256" height="256" rx="56" fill="url(#app-highlight)" />
   <path
     fill="#F8FAFC"
-    d="M186 74c-15-18-37-28-63-28-46 0-80 29-80 68 0 32 21 48 52 58 25 7 35 14 35 27 0 13-13 21-32 21-21 0-39-9-52-24l-20 25c19 21 48 34 79 34 48 0 83-29 83-68 0-32-21-49-54-58-24-7-34-14-34-26 0-12 12-21 30-21 17 0 32 6 43 18z"
+    d="M74 74c20-24 56-34 88-26 22 5 40 19 46 37 10 28-10 52-54 63-38 9-46 18-42 30 4 13 22 20 44 18 20-2 36-10 47-23l28 24c-18 22-46 36-79 39-54 5-102-26-106-71-3-32 16-56 56-68 34-10 46-18 42-30-3-12-20-18-38-16-16 3-28 11-40 25z"
   />
 </svg>


### PR DESCRIPTION
## Summary
- replace the Scriptagher asset logo with a new gradient "S" monogram SVG
- update the web app icon and favicon SVGs to the new artwork and ensure accessibility metadata
- keep web manifest references aligned with the SVG assets

## Testing
- `flutter build web` *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f389cb62d8832b96627394d8f32b97