### PR TITLE
Add GitHub Actions pipeline for building installers

### DIFF
--- a/.github/workflows/deploy-installers.yml
+++ b/.github/workflows/deploy-installers.yml
@@ -1,0 +1,289 @@
+name: Build and Publish Installers
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  FLUTTER_CHANNEL: stable
+
+jobs:
+  build-android:
+    name: Build Android APK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: ${{ env.FLUTTER_CHANNEL }}
+          cache: true
+
+      - name: Generate Android platform project
+        run: flutter create . --platforms=android
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build debug APK
+        run: flutter build apk --debug
+
+      - name: Collect artifact
+        run: |
+          mkdir -p installers/android
+          cp build/app/outputs/flutter-apk/app-debug.apk installers/android/scriptagher-debug.apk
+
+      - name: Upload Android artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk
+          path: installers/android
+
+  build-linux:
+    name: Build Linux bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Linux build prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: ${{ env.FLUTTER_CHANNEL }}
+          cache: true
+
+      - name: Generate Linux platform project
+        run: flutter create . --platforms=linux
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build release bundle
+        run: flutter build linux --release
+
+      - name: Package Linux artifact
+        run: |
+          mkdir -p installers/linux
+          tar -czf installers/linux/scriptagher-linux-x64.tar.gz -C build/linux/x64/release bundle
+
+      - name: Upload Linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-bundle
+          path: installers/linux
+
+  build-windows:
+    name: Build Windows installer
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: ${{ env.FLUTTER_CHANNEL }}
+          cache: true
+
+      - name: Generate Windows platform project
+        run: flutter create . --platforms=windows
+
+      - name: Install dependencies
+        run: flutter pub get
+        shell: pwsh
+
+      - name: Build release binaries
+        run: flutter build windows --release
+        shell: pwsh
+
+      - name: Install Inno Setup
+        run: choco install innosetup --no-progress -y
+        shell: pwsh
+
+      - name: Extract version
+        id: version
+        shell: pwsh
+        run: |
+          $pattern = '^version:\s*(.+)$'
+          $match = Select-String -Path pubspec.yaml -Pattern $pattern | Select-Object -First 1
+          if (-not $match) {
+            throw 'Unable to determine version from pubspec.yaml'
+          }
+          $version = $match.Matches[0].Groups[1].Value.Trim()
+          "app_version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Prepare installer output directory
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path installers/windows | Out-Null
+
+      - name: Build Windows installer
+        shell: pwsh
+        run: |
+          $sourceDir = Resolve-Path 'build/windows/x64/runner/Release'
+          $outputDir = Resolve-Path 'installers/windows'
+          $iscc = Resolve-Path "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          & $iscc "/DAPP_VERSION=${{ steps.version.outputs.app_version }}" "/DSOURCE_DIR=$sourceDir" "/DOUTPUT_DIR=$outputDir" "tool/windows-installer.iss"
+
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-installer
+          path: installers/windows
+
+  build-macos:
+    name: Build macOS disk image
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: ${{ env.FLUTTER_CHANNEL }}
+          cache: true
+
+      - name: Generate macOS platform project
+        run: flutter create . --platforms=macos
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build release app
+        run: flutter build macos --release
+
+      - name: Package DMG
+        run: |
+          mkdir -p installers/macos
+          APP_PATH="build/macos/Build/Products/Release/Scriptagher.app"
+          if [ ! -d "$APP_PATH" ]; then
+            echo "macOS app bundle not found at $APP_PATH" >&2
+            exit 1
+          fi
+          mkdir -p dist-dmg
+          cp -R "$APP_PATH" dist-dmg/
+          hdiutil create installers/macos/Scriptagher-macos.dmg -volname "Scriptagher" -srcfolder dist-dmg -ov -format UDZO
+
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-dmg
+          path: installers/macos
+
+  build-ios:
+    name: Build iOS archive
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: ${{ env.FLUTTER_CHANNEL }}
+          cache: true
+
+      - name: Generate iOS platform project
+        run: flutter create . --platforms=ios
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build unsigned iOS app
+        run: flutter build ios --release --no-codesign
+
+      - name: Package IPA
+        run: |
+          mkdir -p installers/ios
+          APP_PATH="build/ios/iphoneos/Runner.app"
+          if [ ! -d "$APP_PATH" ]; then
+            echo "iOS app bundle not found at $APP_PATH" >&2
+            exit 1
+          fi
+          WORK_DIR="Payload"
+          rm -rf "$WORK_DIR"
+          mkdir -p "$WORK_DIR"
+          cp -R "$APP_PATH" "$WORK_DIR/"
+          zip -r installers/ios/Scriptagher-ios.ipa "$WORK_DIR"
+
+      - name: Upload iOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-ipa
+          path: installers/ios
+
+  deploy-gh-pages:
+    name: Publish installers to GitHub Pages
+    needs:
+      - build-android
+      - build-linux
+      - build-windows
+      - build-macos
+      - build-ios
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Prepare installers directory
+        run: |
+          rm -rf installers
+          mkdir -p installers
+
+      - name: Download Android artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: android-apk
+          path: installers/android
+
+      - name: Download Linux artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-bundle
+          path: installers/linux
+
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-installer
+          path: installers/windows
+
+      - name: Download macOS artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-dmg
+          path: installers/macos
+
+      - name: Download iOS artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ios-ipa
+          path: installers/ios
+
+      - name: Create .nojekyll marker
+        run: touch installers/.nojekyll
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: installers
+          destination_dir: installers
+          keep_files: true
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/tool/windows-installer.iss
+++ b/tool/windows-installer.iss
@@ -1,0 +1,42 @@
+#ifndef APP_VERSION
+  #error "APP_VERSION is not defined"
+#endif
+#ifndef SOURCE_DIR
+  #error "SOURCE_DIR is not defined"
+#endif
+#ifndef OUTPUT_DIR
+  #error "OUTPUT_DIR is not defined"
+#endif
+
+[Setup]
+AppId={{92D2E67D-59F5-4F6B-86E7-1F6C4B647C0D}}
+AppName=Scriptagher
+AppVersion={#APP_VERSION}
+AppPublisher=Scriptagher
+AppPublisherURL=https://github.com/scriptagher/scriptagher
+AppSupportURL=https://github.com/scriptagher/scriptagher
+AppUpdatesURL=https://github.com/scriptagher/scriptagher
+DefaultDirName={autopf}\\Scriptagher
+DisableProgramGroupPage=yes
+OutputDir={#OUTPUT_DIR}
+OutputBaseFilename=ScriptagherSetup
+Compression=lzma
+SolidCompression=yes
+WizardStyle=modern
+ArchitecturesInstallIn64BitMode=x64
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a &desktop shortcut"; GroupDescription: "Additional shortcuts:"; Flags: unchecked
+
+[Files]
+Source: "{#SOURCE_DIR}\\*"; DestDir: "{app}"; Flags: recursesubdirs ignoreversion createallsubdirs
+
+[Icons]
+Name: "{autoprograms}\\Scriptagher"; Filename: "{app}\\Scriptagher.exe"
+Name: "{autodesktop}\\Scriptagher"; Filename: "{app}\\Scriptagher.exe"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\\Scriptagher.exe"; Description: "Launch Scriptagher"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds installers for Android, Linux, Windows, macOS, and iOS after merges to `main`
- publish the generated artifacts to the `installers/` directory on `gh-pages`
- add an Inno Setup script to package the Windows release as an installer

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68f39e2dea40832bbe496f8152d30100