### PR TITLE
Add installers PR teardown workflow

### DIFF
--- a/.github/workflows/installers-pr-teardown.yml
+++ b/.github/workflows/installers-pr-teardown.yml
@@ -1,0 +1,72 @@
+name: Installers PR Teardown
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup-or-restore:
+    name: Cleanup or Restore installers backup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Configure Git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Remove backup after merge
+        if: ${{ github.event.pull_request.merged }}
+        run: |
+          set -e
+          BACKUP_DIR="installers-backups/pr-${{ github.event.number }}"
+          if [ -d "$BACKUP_DIR" ]; then
+            echo "Removing backup directory $BACKUP_DIR because the PR was merged."
+            rm -rf "$BACKUP_DIR"
+          else
+            echo "No backup directory found for PR #${{ github.event.number }}, skipping removal."
+          fi
+
+      - name: Restore installers from backup
+        if: ${{ !github.event.pull_request.merged }}
+        run: |
+          set -e
+          BACKUP_DIR="installers-backups/pr-${{ github.event.number }}"
+          if [ -d "$BACKUP_DIR" ]; then
+            echo "Restoring installers from $BACKUP_DIR because the PR was closed without merge."
+            rm -rf installers
+            if [ -d "$BACKUP_DIR/installers" ]; then
+              cp -a "$BACKUP_DIR/installers" ./
+            else
+              mkdir -p installers
+              cp -a "$BACKUP_DIR"/. installers/
+            fi
+            rm -rf "$BACKUP_DIR"
+          else
+            echo "No backup directory found for PR #${{ github.event.number }}, nothing to restore."
+          fi
+
+      - name: Commit and push changes
+        run: |
+          set -e
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git add -A
+          if [ "${{ github.event.pull_request.merged }}" = "true" ]; then
+            COMMIT_MESSAGE="chore: remove installers backup for PR #${{ github.event.number }}"
+          else
+            COMMIT_MESSAGE="chore: restore installers after PR #${{ github.event.number }} was closed"
+          fi
+          git commit -m "$COMMIT_MESSAGE"
+          git push origin gh-pages

--- a/README.md
+++ b/README.md
@@ -213,6 +213,17 @@ flutter build web
 
 Carica i file generati nella cartella `build/web` su un server web per renderli accessibili tramite un browser.
 
+### Flusso di backup e ripristino degli installer
+
+Per aiutare i maintainer a gestire in sicurezza gli asset pubblicati su `gh-pages`, ogni pull request che modifica gli installer viene accompagnata da un backup automatico. Quando la PR viene chiusa entra in azione il workflow [`installers-pr-teardown.yml`](.github/workflows/installers-pr-teardown.yml):
+
+1. Il workflow si attiva alla chiusura della PR e lavora direttamente sul branch `gh-pages` con permessi di scrittura.
+2. Se la PR è stata **mergeata**, viene eliminata la cartella di backup `installers-backups/pr-<numero_pr>` relativa a quella PR (se presente).
+3. Se la PR è stata **chiusa senza merge**, il workflow ripristina la cartella `installers/` copiandola dal backup `installers-backups/pr-<numero_pr>` e poi rimuove il backup ormai inutile.
+4. In assenza di backup (ad esempio per PR che non toccano gli installer) il workflow registra semplicemente un messaggio e non effettua modifiche.
+
+> **Nota per i maintainer:** non è necessario alcun intervento manuale nella maggior parte dei casi. Se dovesse servire un ripristino manuale, è sufficiente copiare i contenuti da `installers-backups/pr-<numero_pr>` nel branch `gh-pages` seguendo la stessa struttura usata dal workflow.
+
 ## Considerazioni Finali
 - Ogni piattaforma (Android, iOS, Linux, Windows, macOS) ha il suo proprio flusso di lavoro e requisiti di distribuzione.
 - Flutter rende possibile la creazione di un'app con un'unica base di codice per più piattaforme, ma la configurazione specifica di ciascuna piattaforma richiede attenzione ai dettagli.


### PR DESCRIPTION
## Summary
- add a teardown workflow that removes or restores installers backups when PRs close
- document the automatic installers backup/restore process for maintainers in the README

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68f3ac837a74832bb2b356755e114c98