### PR TITLE
Guard custom logger against web file access

### DIFF
--- a/lib/shared/custom_logger_io.dart
+++ b/lib/shared/custom_logger_io.dart
@@ -1,0 +1,35 @@
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+class LogWriter {
+  LogWriter(this.todayDate);
+
+  final String todayDate;
+
+  Future<void> write(String logMessage, String component) async {
+    final directory = await getApplicationDocumentsDirectory();
+    final logDirectory =
+        Directory('${directory.path}/.scriptagher/logs/$todayDate');
+
+    if (!await logDirectory.exists()) {
+      await logDirectory.create(recursive: true);
+    }
+
+    final logFile = File('${logDirectory.path}/$component.log');
+    final fileSize = await logFile.exists() ? await logFile.length() : 0;
+    if (fileSize > 10 * 1024 * 1024) {
+      await _rotateLogFile(logFile);
+    }
+
+    await logFile.writeAsString('$logMessage\n', mode: FileMode.append);
+  }
+
+  Future<void> _rotateLogFile(File logFile) async {
+    final now = DateTime.now();
+    final archiveName = '${logFile.path}_${now.toIso8601String()}.log';
+
+    await logFile.rename(archiveName);
+    await logFile.create();
+  }
+}

--- a/lib/shared/custom_logger_web.dart
+++ b/lib/shared/custom_logger_web.dart
@@ -1,0 +1,7 @@
+class LogWriter {
+  LogWriter(String todayDate);
+
+  Future<void> write(String logMessage, String component) async {
+    // No-op on the web to avoid using dart:io APIs.
+  }
+}


### PR DESCRIPTION
## Summary
- add conditional LogWriter implementations to isolate dart:io usage
- guard the custom logger from performing file operations on the web while keeping console logging

## Testing
- Not run (flutter is not installed in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68f3ad792660832b882a7f155cc2df8e