### PR TITLE
Add installer manifest and UI download components

### DIFF
--- a/public/installers/installers.json
+++ b/public/installers/installers.json
@@ -1,0 +1,21 @@
+{
+  "installers": [
+    {
+      "platform": "Windows",
+      "description": "Installer for Windows 10/11 (64-bit) with bundled dependencies.",
+      "asset": "scriptagher-setup-x64.exe",
+      "releaseNotes": "Includes the latest automation scripts and support for enhanced logging."
+    },
+    {
+      "platform": "macOS",
+      "description": "Universal binary for macOS 13 Ventura and newer.",
+      "asset": "scriptagher-macos-universal.dmg"
+    },
+    {
+      "platform": "Linux",
+      "description": "AppImage package compatible with most modern Linux distributions.",
+      "asset": "scriptagher-linux-x86_64.AppImage",
+      "releaseNotes": "Tested on Ubuntu 22.04, Fedora 39, and Arch Linux with GNOME."
+    }
+  ]
+}

--- a/src/app/components/bot-list/bot-list.component.html
+++ b/src/app/components/bot-list/bot-list.component.html
@@ -1,12 +1,21 @@
 <app-header></app-header>
-<main class="bot-list" id="bots" *ngIf="botSections.length; else errorTemplate">
-  <app-bot-section *ngFor="let section of botSections" [language]="section.language"
-    [bots]="section.botDetails"></app-bot-section>
+<main class="bot-list" id="bots" *ngIf="botSections.length || installers.length; else errorTemplate">
+  <app-bot-section
+    *ngFor="let section of botSections"
+    [language]="section.language"
+    [bots]="section.botDetails"
+  ></app-bot-section>
+
+  <app-installer-section
+    *ngIf="installers.length || installersError"
+    [installers]="installers"
+    [errorMessage]="installers.length ? '' : installersError"
+  ></app-installer-section>
 </main>
 <ng-template #errorTemplate>
   <div class="error-state">
     <h2>Ops, qualcosa è andato storto.</h2>
-    <p>{{ errorMessage || 'No bots available.' }}</p>
+    <p>{{ errorMessage || installersError || 'No bots or installers available.' }}</p>
   </div>
 </ng-template>
 <app-footer></app-footer>

--- a/src/app/components/bot-list/bot-list.component.ts
+++ b/src/app/components/bot-list/bot-list.component.ts
@@ -1,9 +1,11 @@
 import { Component, OnInit } from '@angular/core';
-import { BotService } from '../../services/bot.service';
 import { CommonModule } from '@angular/common';
+import { catchError, forkJoin, of, firstValueFrom } from 'rxjs';
+import { BotService } from '../../services/bot.service';
 import { BotSectionComponent } from '../bot-section/bot-section.component';
 import { HeaderComponent } from '../header/header.component';
 import { FooterComponent } from '../footer/footer.component';
+import { InstallerSectionComponent } from '../installer-section/installer-section.component';
 
 @Component({
   selector: 'app-bot-list',
@@ -14,12 +16,15 @@ import { FooterComponent } from '../footer/footer.component';
     CommonModule,
     HeaderComponent,
     BotSectionComponent,
+    InstallerSectionComponent,
     FooterComponent
   ]
 })
 export class BotListComponent implements OnInit {
   botSections: any[] = [];
   errorMessage: string = '';
+  installers: any[] = [];
+  installersError: string = '';
 
   constructor(private botService: BotService) {}
 
@@ -28,32 +33,66 @@ export class BotListComponent implements OnInit {
   }
 
   populateBotList() {
-    this.botService.getBotsConfig().subscribe({
-      next: async (botsConfig) => {
+    forkJoin({
+      botsConfig: this.botService.getBotsConfig().pipe(
+        catchError((err) => {
+          console.error('Error fetching bots configuration:', err);
+          this.errorMessage = 'Failed to load the bot list.';
+          return of(null);
+        })
+      ),
+      installers: this.botService.getInstallers().pipe(
+        catchError((err) => {
+          console.error('Error fetching installers manifest:', err);
+          this.installersError = 'Failed to load installers.';
+          return of({ installers: [], __error: true });
+        })
+      )
+    }).subscribe(({ botsConfig, installers }) => {
+      const hasInstallerError = !!(installers as any)?.__error;
+      const installerList = Array.isArray(installers)
+        ? installers
+        : installers?.installers ?? [];
+      this.installersError = hasInstallerError ? this.installersError : '';
+      this.installers = installerList.filter(Boolean);
+
+      if (!botsConfig) {
         this.botSections = [];
-        for (const language in botsConfig) {
-          const bots = botsConfig[language];
-          if (!bots || bots.length === 0) continue;
-          const botDetails = await Promise.all(
-            bots.map(async (bot: any) => {
-              try {
-                bot.language = language;
-                return await this.botService.getBotDetails(bot).toPromise();
-              } catch {
-                return { botName: bot.botName, description: 'Error loading details' };
-              }
-            })
-          );
-          this.botSections.push({
-            language,
-            botDetails,
-          });
+        return;
+      }
+
+      const languages = Object.keys(botsConfig);
+      const sectionPromises = languages.map(async (language) => {
+        const bots = botsConfig[language];
+        if (!bots || bots.length === 0) {
+          return null;
         }
-      },
-      error: (err) => {
-        console.error('Error fetching bots configuration:', err);
-        this.errorMessage = 'Failed to load the bot list.';
-      },
+
+        const botDetails = await Promise.all(
+          bots.map(async (bot: any) => {
+            try {
+              bot.language = language;
+              return await firstValueFrom(this.botService.getBotDetails(bot));
+            } catch {
+              return { botName: bot.botName, description: 'Error loading details' };
+            }
+          })
+        );
+
+        return {
+          language,
+          botDetails
+        };
+      });
+
+      Promise.all(sectionPromises)
+        .then((sections) => {
+          this.botSections = sections.filter((section): section is { language: string; botDetails: any[] } => !!section);
+        })
+        .catch((err) => {
+          console.error('Error building bot sections:', err);
+          this.errorMessage = 'Failed to process the bot list.';
+        });
     });
   }
 }

--- a/src/app/components/installer-card/installer-card.component.html
+++ b/src/app/components/installer-card/installer-card.component.html
@@ -1,0 +1,16 @@
+<div class="installer-card">
+  <div class="installer-surface">
+    <div class="installer-header">
+      <h3>{{ installer.platform }}</h3>
+      <span class="installer-asset" *ngIf="installer.asset">{{ installer.asset }}</span>
+    </div>
+    <p class="installer-description">{{ installer.description }}</p>
+    <div class="installer-notes" *ngIf="installer.releaseNotes">
+      <span>Release notes</span>
+      <p>{{ installer.releaseNotes }}</p>
+    </div>
+    <div class="installer-actions">
+      <button class="btn btn-primary" type="button" (click)="onDownload()">Download</button>
+    </div>
+  </div>
+</div>

--- a/src/app/components/installer-card/installer-card.component.scss
+++ b/src/app/components/installer-card/installer-card.component.scss
@@ -1,0 +1,117 @@
+.installer-card {
+  position: relative;
+  padding: 1px;
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(129, 140, 248, 0.35), rgba(56, 189, 248, 0.28));
+  transition: transform 0.3s ease, filter 0.3s ease;
+  isolation: isolate;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(circle at top left, rgba(192, 132, 252, 0.35), transparent 60%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+  }
+
+  &:hover {
+    transform: translateY(-6px);
+    filter: drop-shadow(0 28px 40px rgba(30, 64, 175, 0.35));
+
+    &::before {
+      opacity: 1;
+    }
+  }
+
+  .installer-surface {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    padding: clamp(1.6rem, 3.5vw, 2.1rem);
+    border-radius: 27px;
+    background: linear-gradient(165deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.72));
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    backdrop-filter: blur(18px);
+  }
+
+  .installer-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+
+    h3 {
+      margin: 0;
+      font-size: 1.35rem;
+      letter-spacing: 0.04em;
+    }
+
+    .installer-asset {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.7rem;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      padding: 0.35rem 0.8rem;
+      border-radius: 999px;
+      color: rgba(226, 232, 240, 0.85);
+      background: rgba(59, 130, 246, 0.2);
+      border: 1px solid rgba(59, 130, 246, 0.35);
+      box-shadow: inset 0 0 16px rgba(37, 99, 235, 0.18);
+    }
+  }
+
+  .installer-description {
+    margin: 0;
+    color: rgba(226, 232, 240, 0.78);
+    line-height: 1.7;
+  }
+
+  .installer-notes {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    padding: 1.1rem;
+    border-radius: 18px;
+    background: rgba(15, 23, 42, 0.78);
+    border: 1px solid rgba(192, 132, 252, 0.25);
+    box-shadow: inset 0 0 0 1px rgba(129, 140, 248, 0.18);
+
+    span {
+      font-size: 0.75rem;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: rgba(192, 132, 252, 0.85);
+    }
+
+    p {
+      margin: 0;
+      color: rgba(226, 232, 240, 0.85);
+      line-height: 1.6;
+    }
+  }
+
+  .installer-actions {
+    display: flex;
+    gap: 0.75rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .installer-card {
+    .installer-actions {
+      flex-direction: column;
+
+      .btn {
+        width: 100%;
+        justify-content: center;
+      }
+    }
+  }
+}

--- a/src/app/components/installer-card/installer-card.component.ts
+++ b/src/app/components/installer-card/installer-card.component.ts
@@ -1,0 +1,18 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-installer-card',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './installer-card.component.html',
+  styleUrl: './installer-card.component.scss'
+})
+export class InstallerCardComponent {
+  @Input() installer: any;
+  @Output() download = new EventEmitter<void>();
+
+  onDownload(): void {
+    this.download.emit();
+  }
+}

--- a/src/app/components/installer-section/installer-section.component.html
+++ b/src/app/components/installer-section/installer-section.component.html
@@ -1,0 +1,22 @@
+<section class="installer-section" *ngIf="installers.length; else installerError">
+  <div class="section-header">
+    <span class="section-badge">Installers</span>
+    <h2>Platform downloads</h2>
+  </div>
+  <div class="installer-grid">
+    <app-installer-card
+      *ngFor="let installer of installers"
+      [installer]="installer"
+      (download)="downloadInstaller(installer)"
+    ></app-installer-card>
+  </div>
+</section>
+<ng-template #installerError>
+  <section class="installer-section installer-section--empty" *ngIf="errorMessage">
+    <div class="section-header">
+      <span class="section-badge">Installers</span>
+      <h2>Platform downloads</h2>
+    </div>
+    <p class="installer-message">{{ errorMessage }}</p>
+  </section>
+</ng-template>

--- a/src/app/components/installer-section/installer-section.component.scss
+++ b/src/app/components/installer-section/installer-section.component.scss
@@ -1,0 +1,95 @@
+.installer-section {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 5vw, 2.6rem);
+  padding: clamp(2.4rem, 5vw, 3.4rem);
+  border-radius: 36px;
+  background: linear-gradient(160deg, rgba(10, 18, 36, 0.9), rgba(30, 41, 59, 0.62));
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: var(--shadow-strong);
+  backdrop-filter: blur(20px);
+  overflow: hidden;
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  &::before {
+    background: radial-gradient(circle at top left, rgba(192, 132, 252, 0.2), transparent 55%);
+  }
+
+  &::after {
+    border-radius: inherit;
+    border: 1px solid rgba(129, 140, 248, 0.25);
+    opacity: 0.35;
+  }
+
+  .section-header {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .section-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.78rem;
+    letter-spacing: 0.26em;
+    text-transform: uppercase;
+    color: rgba(226, 232, 240, 0.85);
+    background: rgba(79, 70, 229, 0.25);
+    padding: 0.38rem 1rem;
+    border-radius: 999px;
+    border: 1px solid rgba(129, 140, 248, 0.35);
+    box-shadow: inset 0 0 20px rgba(129, 140, 248, 0.12);
+  }
+
+  h2 {
+    margin: 0;
+    font-size: clamp(1.7rem, 4vw, 2.1rem);
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: capitalize;
+    background: linear-gradient(120deg, #818cf8 0%, #c084fc 50%, #38bdf8 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+
+  .installer-grid {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: clamp(1.4rem, 4vw, 1.8rem);
+  }
+
+  &--empty {
+    align-items: flex-start;
+  }
+
+  .installer-message {
+    position: relative;
+    z-index: 1;
+    margin: 0;
+    color: rgba(226, 232, 240, 0.7);
+  }
+}
+
+@media (max-width: 640px) {
+  .installer-section {
+    .section-header {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+  }
+}

--- a/src/app/components/installer-section/installer-section.component.ts
+++ b/src/app/components/installer-section/installer-section.component.ts
@@ -1,0 +1,41 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { BotService } from '../../services/bot.service';
+import { InstallerCardComponent } from '../installer-card/installer-card.component';
+
+@Component({
+  selector: 'app-installer-section',
+  standalone: true,
+  imports: [CommonModule, InstallerCardComponent],
+  templateUrl: './installer-section.component.html',
+  styleUrl: './installer-section.component.scss'
+})
+export class InstallerSectionComponent {
+  @Input() installers: any[] = [];
+  @Input() errorMessage: string = '';
+
+  constructor(private botService: BotService) {}
+
+  downloadInstaller(installer: any): void {
+    if (!installer?.asset && !installer?.filename) {
+      console.warn('Installer asset missing for', installer);
+      return;
+    }
+
+    this.botService.downloadInstaller(installer).subscribe({
+      next: (blob: Blob) => {
+        const link = document.createElement('a');
+        const objectUrl = window.URL.createObjectURL(blob);
+        link.href = objectUrl;
+        const assetName = installer.asset || installer.filename || 'installer';
+        link.download = assetName;
+        link.click();
+        window.URL.revokeObjectURL(objectUrl);
+      },
+      error: (error: any) => {
+        console.error('Error downloading installer:', error);
+        alert('Could not download the installer. Please try again later.');
+      }
+    });
+  }
+}

--- a/src/app/services/bot.service.ts
+++ b/src/app/services/bot.service.ts
@@ -9,6 +9,7 @@ import { APP_BASE_HREF, DOCUMENT } from '@angular/common';
 export class BotService {
   private readonly botsBaseUrl: URL;
   private readonly botsSourceBaseUrl: URL;
+  private readonly installersBaseUrl: URL;
 
   constructor(
     private http: HttpClient,
@@ -18,6 +19,7 @@ export class BotService {
     const baseUrl = this.resolveBaseUrl();
     this.botsBaseUrl = new URL('bots/', baseUrl);
     this.botsSourceBaseUrl = new URL('bots/', baseUrl);
+    this.installersBaseUrl = new URL('installers/', baseUrl);
   }
 
   private resolveBaseUrl(): string {
@@ -46,6 +48,14 @@ export class BotService {
   }
 
   /**
+   * Fetch the installers manifest from installers.json.
+   */
+  getInstallers(): Observable<any> {
+    const installersJsonPath = new URL('installers.json', this.installersBaseUrl).toString();
+    return this.http.get(installersJsonPath);
+  }
+
+  /**
    * Costruisce il percorso completo per ottenere i dettagli di un bot specifico.
    * Fetch detailed bot information from Bot.json.
    * @param bot - The bot's name.
@@ -63,6 +73,16 @@ export class BotService {
     const assetName = bot.path || `${bot.botName}.zip`;
     const zipPath = new URL(`${bot.language}/${bot.botName}/${assetName}`, this.botsBaseUrl).toString();
     return this.http.get(zipPath, { responseType: 'blob' });
+  }
+
+  /**
+   * Fetch and download a platform installer asset.
+   * @param installer - Installer metadata containing the asset filename.
+   */
+  downloadInstaller(installer: any): Observable<Blob> {
+    const assetName = installer?.asset || installer?.filename;
+    const installerPath = new URL(`${assetName}`, this.installersBaseUrl).toString();
+    return this.http.get(installerPath, { responseType: 'blob' });
   }
 
   /**


### PR DESCRIPTION
## Summary
- add an installers manifest describing platform-specific downloads
- extend the bot service with installer fetching and download helpers
- render a glassmorphism-style installer section with cards beneath the bot list

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68f3adeca604832b8c7f542d7333719d