### PR TITLE
Add GitHub installer discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,40 @@ bots/
 
 ### 🛡 License
 By contributing, you agree that your bot will be open-sourced under the same license as this repository. Ensure you have the rights to share the bot.
+
+## ⚙️ GitHub installer configuration
+
+The application now fetches installer binaries directly from the `installers/` directory of a GitHub repository (default branch: `gh-pages`).
+Configure the runtime environment with the following variables so the Angular app can call the GitHub Contents API:
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `NG_APP_GITHUB_OWNER` | Repository owner or organization. | – |
+| `NG_APP_GITHUB_REPO` | Repository name that hosts the installers. | – |
+| `NG_APP_GITHUB_TOKEN` | **Optional.** Personal access token used for authenticated requests. Required for private repositories and recommended to avoid unauthenticated rate limits. | – |
+| `NG_APP_GITHUB_API_URL` | Base URL for the GitHub API. Override when using GitHub Enterprise. | `https://api.github.com` |
+| `NG_APP_GITHUB_API_VERSION` | Custom `X-GitHub-Api-Version` header value. | GitHub default |
+| `NG_APP_GITHUB_INSTALLERS_BRANCH` | Branch where the `installers/` directory lives. | `gh-pages` |
+| `NG_APP_GITHUB_INSTALLERS_PATH` | Directory path containing installer binaries. | `installers` |
+
+> ℹ️ The service also checks for the same variables without the `NG_APP_` prefix (e.g. `GITHUB_OWNER`) to support hosting platforms that expose only unprefixed environment variables.
+
+### Authentication and rate limits
+
+* Public repositories can be queried without a token, but the GitHub REST API enforces a limit of **60 requests per hour** for unauthenticated traffic. Provide a token to raise the limit to the authenticated quota (typically 5,000 requests per hour).
+* The token only needs the `public_repo` scope for public repositories and the `repo` scope for private repositories. Store it securely (for example by injecting it at runtime through a server-rendered `window.__env = { ... }` script).
+* Private repositories require either a fine-grained personal access token or a GitHub App installation token with `contents:read` permission because the installers are retrieved via the [Contents API](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#list-repository-contents).
+* When using GitHub Enterprise Server, set `NG_APP_GITHUB_API_URL` to your enterprise API endpoint (e.g. `https://ghe.example.com/api/v3`).
+
+Example runtime configuration snippet to inject from the hosting platform:
+
+```html
+<script>
+  window.__env = {
+    NG_APP_GITHUB_OWNER: 'my-org',
+    NG_APP_GITHUB_REPO: 'my-repo',
+    NG_APP_GITHUB_TOKEN: '<token-with-contents-read>',
+    NG_APP_GITHUB_INSTALLERS_BRANCH: 'gh-pages'
+  };
+</script>
+```

--- a/src/app/components/bot-list/bot-list.component.html
+++ b/src/app/components/bot-list/bot-list.component.html
@@ -1,4 +1,9 @@
 <app-header></app-header>
+<app-installer-section
+  *ngIf="installerAssets.length"
+  [installers]="installerAssets"
+></app-installer-section>
+
 <main class="bot-list" id="bots" *ngIf="botSections.length; else errorTemplate">
   <app-bot-section *ngFor="let section of botSections" [language]="section.language"
     [bots]="section.botDetails"></app-bot-section>

--- a/src/app/components/bot-list/bot-list.component.ts
+++ b/src/app/components/bot-list/bot-list.component.ts
@@ -1,9 +1,11 @@
 import { Component, OnInit } from '@angular/core';
-import { BotService } from '../../services/bot.service';
+import { BotService, InstallerAsset } from '../../services/bot.service';
 import { CommonModule } from '@angular/common';
 import { BotSectionComponent } from '../bot-section/bot-section.component';
 import { HeaderComponent } from '../header/header.component';
 import { FooterComponent } from '../footer/footer.component';
+import { InstallerSectionComponent } from '../installer-section/installer-section.component';
+import { forkJoin } from 'rxjs';
 
 @Component({
   selector: 'app-bot-list',
@@ -14,12 +16,14 @@ import { FooterComponent } from '../footer/footer.component';
     CommonModule,
     HeaderComponent,
     BotSectionComponent,
+    InstallerSectionComponent,
     FooterComponent
   ]
 })
 export class BotListComponent implements OnInit {
   botSections: any[] = [];
   errorMessage: string = '';
+  installerAssets: InstallerAsset[] = [];
 
   constructor(private botService: BotService) {}
 
@@ -28,9 +32,13 @@ export class BotListComponent implements OnInit {
   }
 
   populateBotList() {
-    this.botService.getBotsConfig().subscribe({
-      next: async (botsConfig) => {
+    forkJoin({
+      botsConfig: this.botService.getBotsConfig(),
+      installers: this.botService.listInstallerAssets()
+    }).subscribe({
+      next: async ({ botsConfig, installers }) => {
         this.botSections = [];
+        this.installerAssets = installers ?? [];
         for (const language in botsConfig) {
           const bots = botsConfig[language];
           if (!bots || bots.length === 0) continue;

--- a/src/app/components/installer-section/installer-section.component.html
+++ b/src/app/components/installer-section/installer-section.component.html
@@ -1,0 +1,50 @@
+<section class="installer-section" *ngIf="installers?.length">
+  <h2 class="installer-section__title">Installers</h2>
+  <ul class="installer-section__list">
+    <li
+      class="installer-section__item"
+      *ngFor="let installer of installers; trackBy: trackByPath"
+    >
+      <div class="installer-section__header">
+        <div class="installer-section__name-group">
+          <span class="installer-section__name">{{ getDisplayName(installer) }}</span>
+          <span class="installer-section__platform">{{ installer.platform }}</span>
+        </div>
+        <a
+          class="installer-section__download"
+          [href]="installer.downloadUrl"
+          target="_blank"
+          rel="noopener"
+          [attr.download]="installer.filename"
+        >
+          Download
+        </a>
+      </div>
+      <p class="installer-section__description" *ngIf="installer.metadata?.description">
+        {{ installer.metadata?.description }}
+      </p>
+      <dl class="installer-section__meta">
+        <div *ngIf="installer.size" class="installer-section__meta-item">
+          <dt>Size</dt>
+          <dd>{{ installer.size | number }} bytes</dd>
+        </div>
+        <div *ngIf="installer.metadata?.checksum" class="installer-section__meta-item">
+          <dt>Checksum</dt>
+          <dd>{{ installer.metadata?.checksum }}</dd>
+        </div>
+        <div *ngIf="installer.metadata?.releaseNotesUrl" class="installer-section__meta-item">
+          <dt>Release notes</dt>
+          <dd>
+            <a
+              [href]="installer.metadata?.releaseNotesUrl"
+              target="_blank"
+              rel="noopener"
+            >
+              View
+            </a>
+          </dd>
+        </div>
+      </dl>
+    </li>
+  </ul>
+</section>

--- a/src/app/components/installer-section/installer-section.component.scss
+++ b/src/app/components/installer-section/installer-section.component.scss
@@ -1,0 +1,112 @@
+.installer-section {
+  margin: 3rem auto;
+  max-width: 960px;
+  padding: 0 1.5rem;
+
+  &__title {
+    font-size: 2rem;
+    margin-bottom: 1.5rem;
+    text-align: center;
+  }
+
+  &__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  &__item {
+    background: #ffffff;
+    border-radius: 12px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  &__name-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__name {
+    font-size: 1.25rem;
+    font-weight: 600;
+  }
+
+  &__platform {
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: #555;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  &__download {
+    background: #0078d7;
+    color: #fff;
+    padding: 0.5rem 1.25rem;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 600;
+    transition: background 0.2s ease-in-out;
+
+    &:hover,
+    &:focus {
+      background: #005fa3;
+    }
+  }
+
+  &__description {
+    margin: 0;
+    color: #333;
+    line-height: 1.5;
+  }
+
+  &__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    margin: 0;
+  }
+
+  &__meta-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+
+    dt {
+      font-weight: 600;
+      color: #444;
+    }
+
+    dd {
+      margin: 0;
+      color: #222;
+      word-break: break-all;
+    }
+
+    a {
+      color: #0078d7;
+      text-decoration: none;
+
+      &:hover,
+      &:focus {
+        text-decoration: underline;
+      }
+    }
+  }
+}

--- a/src/app/components/installer-section/installer-section.component.ts
+++ b/src/app/components/installer-section/installer-section.component.ts
@@ -1,0 +1,22 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { InstallerAsset } from '../../services/bot.service';
+
+@Component({
+  selector: 'app-installer-section',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './installer-section.component.html',
+  styleUrl: './installer-section.component.scss'
+})
+export class InstallerSectionComponent {
+  @Input() installers: InstallerAsset[] = [];
+
+  trackByPath(_: number, installer: InstallerAsset): string {
+    return installer.path ?? installer.filename;
+  }
+
+  getDisplayName(installer: InstallerAsset): string {
+    return installer.metadata?.displayName || installer.name || installer.filename;
+  }
+}

--- a/src/app/services/bot.service.ts
+++ b/src/app/services/bot.service.ts
@@ -185,7 +185,7 @@ export class BotService {
         try {
           const metadata = JSON.parse(decoded) as InstallerMetadata;
           const key = this.getMetadataKey(file.name);
-          return [key, metadata];
+          return [key, metadata] as [string, InstallerMetadata];
         } catch (error) {
           console.error(`Invalid installer metadata in ${file.path}`, error);
           return null;

--- a/src/app/services/bot.service.ts
+++ b/src/app/services/bot.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Optional } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { Observable, forkJoin, map, of, switchMap, catchError } from 'rxjs';
 import { APP_BASE_HREF, DOCUMENT } from '@angular/common';
 
 @Injectable({
@@ -9,6 +9,13 @@ import { APP_BASE_HREF, DOCUMENT } from '@angular/common';
 export class BotService {
   private readonly botsBaseUrl: URL;
   private readonly botsSourceBaseUrl: URL;
+  private readonly githubApiBaseUrl: string;
+  private readonly githubRepoOwner: string;
+  private readonly githubRepoName: string;
+  private readonly githubToken: string | undefined;
+  private readonly githubApiVersion: string | undefined;
+  private readonly githubInstallersBranch: string;
+  private readonly githubInstallersPath: string;
 
   constructor(
     private http: HttpClient,
@@ -18,6 +25,25 @@ export class BotService {
     const baseUrl = this.resolveBaseUrl();
     this.botsBaseUrl = new URL('bots/', baseUrl);
     this.botsSourceBaseUrl = new URL('bots/', baseUrl);
+    this.githubApiBaseUrl = this.getEnvironmentValue('NG_APP_GITHUB_API_URL')
+      || this.getEnvironmentValue('GITHUB_API_URL')
+      || 'https://api.github.com';
+    this.githubRepoOwner = this.getEnvironmentValue('NG_APP_GITHUB_OWNER')
+      || this.getEnvironmentValue('GITHUB_OWNER')
+      || '';
+    this.githubRepoName = this.getEnvironmentValue('NG_APP_GITHUB_REPO')
+      || this.getEnvironmentValue('GITHUB_REPO')
+      || '';
+    this.githubToken = this.getEnvironmentValue('NG_APP_GITHUB_TOKEN')
+      || this.getEnvironmentValue('GITHUB_TOKEN');
+    this.githubApiVersion = this.getEnvironmentValue('NG_APP_GITHUB_API_VERSION')
+      || this.getEnvironmentValue('GITHUB_API_VERSION');
+    this.githubInstallersBranch = this.getEnvironmentValue('NG_APP_GITHUB_INSTALLERS_BRANCH')
+      || this.getEnvironmentValue('GITHUB_INSTALLERS_BRANCH')
+      || 'gh-pages';
+    this.githubInstallersPath = this.getEnvironmentValue('NG_APP_GITHUB_INSTALLERS_PATH')
+      || this.getEnvironmentValue('GITHUB_INSTALLERS_PATH')
+      || 'installers';
   }
 
   private resolveBaseUrl(): string {
@@ -35,6 +61,53 @@ export class BotService {
 
   private ensureTrailingSlash(url: string): string {
     return url.endsWith('/') ? url : `${url}/`;
+  }
+
+  listInstallerAssets(): Observable<InstallerAsset[]> {
+    if (!this.githubRepoOwner || !this.githubRepoName) {
+      return of([]);
+    }
+
+    const url = this.buildContentsUrl(this.githubInstallersPath);
+    const params = new HttpParams().set('ref', this.githubInstallersBranch);
+
+    return this.http.get<GitHubContentItem[]>(url, { headers: this.buildGithubHeaders(), params }).pipe(
+      switchMap((items) => {
+        const files = items.filter((item) => item.type === 'file');
+        const metadataFiles = files.filter((item) => this.isMetadataFile(item.name));
+        const binaryFiles = files.filter((item) => this.isBinaryFile(item.name));
+
+        const metadataRequests = metadataFiles.map((file) => this.fetchMetadataForFile(file));
+        const metadataStream = metadataRequests.length ? forkJoin(metadataRequests) : of([]);
+
+        return metadataStream.pipe(
+          map((metadataEntries) => {
+            const metadataMap = new Map<string, InstallerMetadata>();
+            const metadataByPlatform = new Map<string, InstallerMetadata>();
+
+            for (const entry of metadataEntries) {
+              if (!entry) {
+                continue;
+              }
+              const [key, metadata] = entry;
+              metadataMap.set(key, metadata);
+              if (metadata?.platform) {
+                const normalizedPlatform = this.normalizePlatform(metadata.platform).toLowerCase();
+                metadataByPlatform.set(normalizedPlatform, metadata);
+              }
+            }
+
+            return binaryFiles.map((file) =>
+              this.mapGithubContentToInstaller(file, metadataMap, metadataByPlatform)
+            );
+          })
+        );
+      }),
+      catchError((error) => {
+        console.error('Error fetching installer assets from GitHub:', error);
+        return of([]);
+      })
+    );
   }
 
   /**
@@ -74,4 +147,323 @@ export class BotService {
     const sourcePath = new URL(`${bot.language}/${bot.botName}/${assetName}`, this.botsSourceBaseUrl).toString();
     window.open(sourcePath, '_blank');
   }
+
+  private buildContentsUrl(path: string): string {
+    const sanitizedPath = path.replace(/^\/+/, '');
+    return `${this.githubApiBaseUrl.replace(/\/$/, '')}/repos/${this.githubRepoOwner}/${this.githubRepoName}/contents/${sanitizedPath}`;
+  }
+
+  private buildGithubHeaders(raw = false): HttpHeaders {
+    let headers = new HttpHeaders({
+      Accept: raw ? 'application/vnd.github.v3.raw' : 'application/vnd.github.v3+json'
+    });
+
+    if (this.githubToken) {
+      headers = headers.set('Authorization', `Bearer ${this.githubToken}`);
+    }
+
+    if (this.githubApiVersion) {
+      headers = headers.set('X-GitHub-Api-Version', this.githubApiVersion);
+    }
+
+    return headers;
+  }
+
+  private fetchMetadataForFile(file: GitHubContentItem): Observable<[string, InstallerMetadata] | null> {
+    const url = this.buildContentsUrl(file.path);
+    const params = new HttpParams().set('ref', this.githubInstallersBranch);
+
+    return this.http.get<GitHubFileContent>(url, { headers: this.buildGithubHeaders(), params }).pipe(
+      map((response) => {
+        if (!response?.content) {
+          return null;
+        }
+        const decoded = this.decodeBase64(response.content);
+        if (!decoded) {
+          return null;
+        }
+        try {
+          const metadata = JSON.parse(decoded) as InstallerMetadata;
+          const key = this.getMetadataKey(file.name);
+          return [key, metadata];
+        } catch (error) {
+          console.error(`Invalid installer metadata in ${file.path}`, error);
+          return null;
+        }
+      }),
+      catchError((error) => {
+        console.error(`Unable to load installer metadata from ${file.path}`, error);
+        return of(null);
+      })
+    );
+  }
+
+  private mapGithubContentToInstaller(
+    item: GitHubContentItem,
+    metadataMap: Map<string, InstallerMetadata>,
+    metadataByPlatform: Map<string, InstallerMetadata>
+  ): InstallerAsset {
+    const metadataKey = this.getMetadataKeyForBinary(item.name);
+    const directMetadata = metadataMap.get(metadataKey) || metadataMap.get(item.name.toLowerCase());
+    const inferredPlatform = this.normalizePlatform(
+      directMetadata?.platform ?? this.inferPlatformFromName(item.name)
+    );
+    const platformMetadata = metadataByPlatform.get(inferredPlatform.toLowerCase());
+    const mergedMetadata = {
+      ...(platformMetadata ?? {}),
+      ...(directMetadata ?? {})
+    } as InstallerMetadata;
+    const metadata = Object.keys(mergedMetadata).length ? mergedMetadata : undefined;
+
+    return {
+      name: metadata?.displayName ?? metadata?.name ?? item.name,
+      filename: item.name,
+      path: item.path,
+      downloadUrl: metadata?.downloadUrl
+        ?? item.download_url
+        ?? `${this.buildContentsUrl(item.path)}?ref=${encodeURIComponent(this.githubInstallersBranch)}`,
+      size: item.size,
+      platform: this.normalizePlatform(metadata?.platform ?? inferredPlatform),
+      contentType: metadata?.contentType ?? this.inferContentType(item.name),
+      metadata: metadata ?? undefined,
+    };
+  }
+
+  private isMetadataFile(name: string): boolean {
+    return name.toLowerCase().endsWith('.json');
+  }
+
+  private isBinaryFile(name: string): boolean {
+    const lowerName = name.toLowerCase();
+    const binaryExtensions = [
+      '.exe',
+      '.msi',
+      '.zip',
+      '.tar.gz',
+      '.tgz',
+      '.tar.xz',
+      '.tar.bz2',
+      '.dmg',
+      '.pkg',
+      '.appimage',
+      '.deb',
+      '.rpm',
+      '.apk',
+      '.aab',
+      '.ipa'
+    ];
+
+    return binaryExtensions.some((extension) => lowerName.endsWith(extension));
+  }
+
+  private getMetadataKey(name: string): string {
+    return name.replace(/\.json$/i, '').toLowerCase();
+  }
+
+  private getMetadataKeyForBinary(name: string): string {
+    const lower = name.toLowerCase();
+    if (lower.endsWith('.tar.gz')) {
+      return lower.replace(/\.tar\.gz$/, '');
+    }
+    if (lower.endsWith('.tar.xz')) {
+      return lower.replace(/\.tar\.xz$/, '');
+    }
+    if (lower.endsWith('.tar.bz2')) {
+      return lower.replace(/\.tar\.bz2$/, '');
+    }
+    const lastDotIndex = lower.lastIndexOf('.');
+    return lastDotIndex >= 0 ? lower.substring(0, lastDotIndex) : lower;
+  }
+
+  private inferPlatformFromName(name: string): string {
+    const lower = name.toLowerCase();
+    if (/(windows|win32|win64|\.exe$|\.msi$)/.test(lower)) {
+      return 'Windows';
+    }
+    if (/(mac|darwin|osx|\.dmg$|\.pkg$)/.test(lower)) {
+      return 'macOS';
+    }
+    if (/(linux|\.appimage$|\.deb$|\.rpm$|\.tar\.gz$|\.tar\.xz$|\.tar\.bz2$|\.tgz$)/.test(lower)) {
+      return 'Linux';
+    }
+    if (/(android|\.apk$|\.aab$)/.test(lower)) {
+      return 'Android';
+    }
+    if (/(ios|\.ipa$)/.test(lower)) {
+      return 'iOS';
+    }
+    return 'Other';
+  }
+
+  private normalizePlatform(platform: string | undefined): string {
+    if (!platform) {
+      return 'Other';
+    }
+    const normalized = platform.trim().toLowerCase();
+    switch (normalized) {
+      case 'windows':
+      case 'win':
+      case 'win32':
+      case 'win64':
+        return 'Windows';
+      case 'mac':
+      case 'macos':
+      case 'osx':
+        return 'macOS';
+      case 'linux':
+        return 'Linux';
+      case 'android':
+        return 'Android';
+      case 'ios':
+      case 'iphone':
+      case 'ipad':
+        return 'iOS';
+      default:
+        return platform;
+    }
+  }
+
+  private inferContentType(name: string): string | undefined {
+    const lower = name.toLowerCase();
+    if (lower.endsWith('.exe')) {
+      return 'application/vnd.microsoft.portable-executable';
+    }
+    if (lower.endsWith('.msi')) {
+      return 'application/x-msi';
+    }
+    if (lower.endsWith('.zip')) {
+      return 'application/zip';
+    }
+    if (lower.endsWith('.tar.gz') || lower.endsWith('.tgz')) {
+      return 'application/gzip';
+    }
+    if (lower.endsWith('.tar.xz')) {
+      return 'application/x-xz';
+    }
+    if (lower.endsWith('.tar.bz2')) {
+      return 'application/x-bzip2';
+    }
+    if (lower.endsWith('.dmg')) {
+      return 'application/x-apple-diskimage';
+    }
+    if (lower.endsWith('.pkg')) {
+      return 'application/octet-stream';
+    }
+    if (lower.endsWith('.appimage')) {
+      return 'application/octet-stream';
+    }
+    if (lower.endsWith('.deb')) {
+      return 'application/vnd.debian.binary-package';
+    }
+    if (lower.endsWith('.rpm')) {
+      return 'application/x-rpm';
+    }
+    if (lower.endsWith('.apk')) {
+      return 'application/vnd.android.package-archive';
+    }
+    if (lower.endsWith('.aab')) {
+      return 'application/octet-stream';
+    }
+    if (lower.endsWith('.ipa')) {
+      return 'application/octet-stream';
+    }
+    return undefined;
+  }
+
+  private decodeBase64(content: string): string {
+    if (!content) {
+      return '';
+    }
+
+    if (typeof atob === 'function') {
+      try {
+        const binary = atob(content);
+        const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+        if (typeof TextDecoder !== 'undefined') {
+          return new TextDecoder('utf-8').decode(bytes);
+        }
+        return binary;
+      } catch {
+        return atob(content);
+      }
+    }
+
+    const globalBuffer = typeof globalThis !== 'undefined' ? (globalThis as any).Buffer : undefined;
+    if (globalBuffer) {
+      return globalBuffer.from(content, 'base64').toString('utf-8');
+    }
+
+    return content;
+  }
+
+  private getEnvironmentValue(key: string): string | undefined {
+    if (!key) {
+      return undefined;
+    }
+
+    const globalObj: any = typeof globalThis !== 'undefined' ? globalThis : {};
+    if (typeof globalObj[key] === 'string') {
+      return globalObj[key];
+    }
+    if (globalObj.__env && typeof globalObj.__env[key] === 'string') {
+      return globalObj.__env[key];
+    }
+    if (globalObj.env && typeof globalObj.env[key] === 'string') {
+      return globalObj.env[key];
+    }
+    try {
+      const metaEnv = (import.meta as any)?.env;
+      if (metaEnv && typeof metaEnv[key] === 'string') {
+        return metaEnv[key];
+      }
+    } catch {
+      // ignore missing import.meta
+    }
+
+    return undefined;
+  }
+}
+
+interface GitHubContentItem {
+  name: string;
+  path: string;
+  sha: string;
+  size: number;
+  url: string;
+  html_url: string;
+  download_url: string | null;
+  type: 'file' | 'dir' | 'symlink' | 'submodule';
+}
+
+interface GitHubFileContent {
+  content: string;
+  encoding: string;
+  name: string;
+  path: string;
+  sha: string;
+  size: number;
+  url: string;
+}
+
+export interface InstallerMetadata {
+  name?: string;
+  displayName?: string;
+  description?: string;
+  platform?: string;
+  contentType?: string;
+  checksum?: string;
+  releaseNotesUrl?: string;
+  downloadUrl?: string;
+  [key: string]: any;
+}
+
+export interface InstallerAsset {
+  name: string;
+  filename: string;
+  path: string;
+  downloadUrl: string;
+  size: number;
+  platform: string;
+  contentType?: string;
+  metadata?: InstallerMetadata;
 }


### PR DESCRIPTION
## Summary
- integrate the GitHub Contents API into the bot service to list installer binaries with optional metadata
- surface installers in a new installer section component and have the bot list consume the dynamic data
- document environment variables and authentication guidance for configuring GitHub access

## Testing
- npm run build *(fails: ng command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f3b8144a4c832ba4b1514efb4e034f