### PR TITLE
Fix styleUrls usage in Angular components

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,7 +6,7 @@ import { RouterOutlet } from '@angular/router';
   standalone: true,
   imports: [RouterOutlet],
   templateUrl: './app.component.html',
-  styleUrl: './app.component.scss'
+  styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
   title = 'bot-list';

--- a/src/app/components/bot-card/bot-card.component.ts
+++ b/src/app/components/bot-card/bot-card.component.ts
@@ -8,7 +8,7 @@ import { BotService } from '../../services/bot.service';
   standalone: true,
   imports: [CommonModule],
   templateUrl: './bot-card.component.html',
-  styleUrl: './bot-card.component.scss'
+  styleUrls: ['./bot-card.component.scss']
 })
 export class BotCardComponent {
   @Input() bot: any;

--- a/src/app/components/bot-section/bot-section.component.ts
+++ b/src/app/components/bot-section/bot-section.component.ts
@@ -11,7 +11,7 @@ import { BotService } from '../../services/bot.service';
     BotCardComponent
   ],
   templateUrl: './bot-section.component.html',
-  styleUrl: './bot-section.component.scss'
+  styleUrls: ['./bot-section.component.scss']
 })
 export class BotSectionComponent{
   @Input() language: string = '';

--- a/src/app/components/footer/footer.component.ts
+++ b/src/app/components/footer/footer.component.ts
@@ -5,7 +5,7 @@ import { Component } from '@angular/core';
   standalone: true,
   imports: [],
   templateUrl: './footer.component.html',
-  styleUrl: './footer.component.scss'
+  styleUrls: ['./footer.component.scss']
 })
 export class FooterComponent {
 

--- a/src/app/components/not-found/not-found.component.ts
+++ b/src/app/components/not-found/not-found.component.ts
@@ -6,7 +6,7 @@ import { Router, NavigationEnd } from '@angular/router';
   standalone: true,
   imports: [],
   templateUrl: './not-found.component.html',
-  styleUrl: './not-found.component.scss'
+  styleUrls: ['./not-found.component.scss']
 })
 export class NotFoundComponent {
 


### PR DESCRIPTION
## Summary
- replace deprecated `styleUrl` decorator option with `styleUrls` across root and shared components so styles load correctly
- no runtime behavior changes; only decorator metadata updates

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f3b8149030832b82996261ba6268b6