### PR TITLE
Modernize installer section and footer

### DIFF
--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -1,3 +1,12 @@
-<footer>
-    <p>&copy; 2024 Scriptagher · Crafted with passion for automation</p>
+<footer class="site-footer">
+    <div class="site-footer__content">
+        <p class="site-footer__copy">&copy; 2024 Scriptagher · Crafted with passion for automation</p>
+        <p class="site-footer__legal">
+            Distribuito per la community maker: controlla sempre le note di rilascio e le licenze prima di utilizzare gli automation bot.
+        </p>
+        <nav class="site-footer__links" aria-label="Link sviluppatore">
+            <a href="https://diegofcj.github.io/portfolio/" target="_blank" rel="noopener" class="site-footer__link">Portfolio</a>
+            <a href="https://github.com/DiegoFCJ" target="_blank" rel="noopener" class="site-footer__link">GitHub</a>
+        </nav>
+    </div>
 </footer>

--- a/src/app/components/footer/footer.component.scss
+++ b/src/app/components/footer/footer.component.scss
@@ -1,30 +1,90 @@
-footer {
+.site-footer {
   position: relative;
   margin-top: clamp(3.5rem, 8vw, 5.5rem);
-  padding: 3rem 1rem 2.5rem;
-  text-align: center;
-  color: rgba(148, 163, 184, 0.85);
+  padding: clamp(2.5rem, 6vw, 3.5rem) clamp(1.5rem, 4vw, 2.5rem);
   border-top: 1px solid rgba(148, 163, 184, 0.12);
-  background: linear-gradient(180deg, rgba(2, 8, 23, 0), rgba(2, 8, 23, 0.8));
-  backdrop-filter: blur(14px);
+  background: linear-gradient(180deg, rgba(2, 8, 23, 0.05), rgba(2, 8, 23, 0.85));
+  backdrop-filter: blur(16px);
   overflow: hidden;
 
   &::before {
     content: '';
     position: absolute;
     inset: 0;
-    background: radial-gradient(circle at top, rgba(56, 189, 248, 0.18), transparent 60%);
+    background: radial-gradient(circle at top, rgba(56, 189, 248, 0.18), transparent 65%);
+    opacity: 0.8;
     pointer-events: none;
   }
 
-  p {
+  &__content {
     position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    align-items: center;
+    text-align: center;
+    max-width: 960px;
+    margin: 0 auto;
+  }
+
+  &__copy {
     margin: 0;
-    font-size: 0.95rem;
-    letter-spacing: 0.18em;
+    font-size: 0.9rem;
+    letter-spacing: 0.22em;
     text-transform: uppercase;
     background: linear-gradient(120deg, rgba(148, 163, 184, 0.85), rgba(56, 189, 248, 0.85));
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
+  }
+
+  &__legal {
+    margin: 0;
+    max-width: 640px;
+    color: rgba(148, 163, 184, 0.85);
+    font-size: 0.95rem;
+    line-height: 1.6;
+  }
+
+  &__links {
+    display: inline-flex;
+    align-items: center;
+    gap: 1.25rem;
+  }
+
+  &__link {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.45rem 1.15rem;
+    border-radius: 999px;
+    border: 1px solid rgba(56, 189, 248, 0.25);
+    background: rgba(8, 47, 73, 0.28);
+    color: var(--accent);
+    font-size: 0.9rem;
+    text-decoration: none;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+    &:hover,
+    &:focus {
+      transform: translateY(-2px);
+      box-shadow: 0 18px 35px rgba(14, 165, 233, 0.15);
+    }
+  }
+}
+
+@media (max-width: 480px) {
+  .site-footer {
+    &__links {
+      flex-direction: column;
+      width: 100%;
+    }
+
+    &__link {
+      width: 100%;
+      justify-content: center;
+    }
   }
 }

--- a/src/app/components/installer-section/installer-section.component.html
+++ b/src/app/components/installer-section/installer-section.component.html
@@ -1,14 +1,16 @@
 <section class="installer-section" *ngIf="installers?.length">
-  <h2 class="installer-section__title">Installers</h2>
+  <header class="installer-section__intro">
+    <h2 class="installer-section__title">Installers</h2>
+    <p class="installer-section__subtitle">
+      Pacchetti pronti all'uso con checksum verificabili, note di rilascio e licenze sempre in evidenza.
+    </p>
+  </header>
 
-  <ul class="installer-section__list" *ngIf="rootInstallers.length">
-    <li
-      class="installer-section__item"
-      *ngFor="let installer of rootInstallers; trackBy: trackByPath"
-    >
+  <div class="installer-section__grid" *ngIf="rootInstallers.length">
+    <ng-container *ngFor="let installer of rootInstallers; trackBy: trackByPath">
       <ng-container *ngTemplateOutlet="installerCard; context: { $implicit: installer }"></ng-container>
-    </li>
-  </ul>
+    </ng-container>
+  </div>
 
   <div class="installer-section__groups" *ngIf="groupedInstallers.length">
     <ng-container *ngFor="let group of groupedInstallers; trackBy: trackByGroupPath">
@@ -21,79 +23,113 @@
   <section class="installer-section__group" [attr.data-path]="group.path.join('/')">
     <header class="installer-section__group-header">
       <h3 class="installer-section__group-title">{{ group.name }}</h3>
+      <span class="installer-section__group-path">{{ group.path.join(' / ') }}</span>
     </header>
 
-    <ul
-      class="installer-section__list installer-section__list--nested"
-      *ngIf="group.installers.length"
-    >
-      <li
-        class="installer-section__item"
-        *ngFor="let installer of group.installers; trackBy: trackByPath"
-      >
-        <ng-container
-          *ngTemplateOutlet="installerCard; context: { $implicit: installer }"
-        ></ng-container>
-      </li>
-    </ul>
+    <div class="installer-section__grid installer-section__grid--nested" *ngIf="group.installers.length">
+      <ng-container *ngFor="let installer of group.installers; trackBy: trackByPath">
+        <ng-container *ngTemplateOutlet="installerCard; context: { $implicit: installer }"></ng-container>
+      </ng-container>
+    </div>
 
-    <div
-      class="installer-section__group-children"
-      *ngIf="group.children.length"
-    >
-      <ng-container
-        *ngFor="let child of group.children; trackBy: trackByGroupPath"
-      >
-        <ng-container
-          *ngTemplateOutlet="groupTemplate; context: { $implicit: child }"
-        ></ng-container>
+    <div class="installer-section__group-children" *ngIf="group.children.length">
+      <ng-container *ngFor="let child of group.children; trackBy: trackByGroupPath">
+        <ng-container *ngTemplateOutlet="groupTemplate; context: { $implicit: child }"></ng-container>
       </ng-container>
     </div>
   </section>
 </ng-template>
 
 <ng-template #installerCard let-installer>
-  <div class="installer-section__header">
-    <div class="installer-section__name-group">
-      <span class="installer-section__name">{{ getDisplayName(installer) }}</span>
-      <span class="installer-section__platform">{{ installer.platform }}</span>
-      <span class="installer-section__path" *ngIf="installer.directories?.length">
-        {{ installer.relativePath }}
-      </span>
+  <article class="installer-card" [attr.data-platform]="installer.platform | lowercase">
+    <header class="installer-card__header">
+      <div class="installer-card__title-group">
+        <span class="installer-card__name">{{ getDisplayName(installer) }}</span>
+        <span class="installer-card__platform">{{ installer.platform }}</span>
+      </div>
+      <a
+        class="installer-card__download btn btn-primary"
+        [href]="installer.downloadUrl"
+        target="_blank"
+        rel="noopener"
+        [attr.download]="installer.filename"
+      >
+        <span>Download</span>
+      </a>
+    </header>
+
+    <div class="installer-card__path" *ngIf="installer.directories?.length">
+      <span>{{ installer.relativePath }}</span>
     </div>
-    <a
-      class="installer-section__download"
-      [href]="installer.downloadUrl"
-      target="_blank"
-      rel="noopener"
-      [attr.download]="installer.filename"
-    >
-      Download
-    </a>
-  </div>
-  <p class="installer-section__description" *ngIf="installer.metadata?.description">
-    {{ installer.metadata?.description }}
-  </p>
-  <dl class="installer-section__meta">
-    <div *ngIf="installer.size" class="installer-section__meta-item">
-      <dt>Size</dt>
-      <dd>{{ installer.size | number }} bytes</dd>
-    </div>
-    <div *ngIf="installer.metadata?.checksum" class="installer-section__meta-item">
-      <dt>Checksum</dt>
-      <dd>{{ installer.metadata?.checksum }}</dd>
-    </div>
-    <div *ngIf="installer.metadata?.releaseNotesUrl" class="installer-section__meta-item">
-      <dt>Release notes</dt>
-      <dd>
+
+    <p class="installer-card__description" *ngIf="installer.metadata?.description">
+      {{ installer.metadata?.description }}
+    </p>
+
+    <div class="installer-card__meta">
+      <ng-container *ngIf="formatSize(installer.size) as sizeLabel">
+        <div class="installer-card__meta-item">
+          <span class="installer-card__meta-label">Dimensione</span>
+          <span class="installer-card__meta-value">{{ sizeLabel }}</span>
+        </div>
+      </ng-container>
+
+      <ng-container *ngIf="getLicense(installer) as license">
+        <div class="installer-card__meta-item">
+          <span class="installer-card__meta-label">Licenza</span>
+          <ng-container *ngIf="license.url; else plainLicense">
+            <a
+              class="installer-card__meta-value installer-card__link"
+              [href]="license.url"
+              target="_blank"
+              rel="noopener"
+            >
+              {{ license.text }}
+            </a>
+          </ng-container>
+          <ng-template #plainLicense>
+            <span class="installer-card__meta-value">{{ license.text }}</span>
+          </ng-template>
+        </div>
+      </ng-container>
+
+      <ng-container *ngIf="getMaintainer(installer) as maintainer">
+        <div class="installer-card__meta-item">
+          <span class="installer-card__meta-label">Maintainer</span>
+          <span class="installer-card__meta-value">{{ maintainer }}</span>
+        </div>
+      </ng-container>
+
+      <div class="installer-card__meta-item" *ngIf="installer.metadata?.checksum">
+        <span class="installer-card__meta-label">Checksum</span>
+        <code class="installer-card__code">{{ installer.metadata?.checksum }}</code>
+      </div>
+
+      <div class="installer-card__meta-item" *ngIf="installer.metadata?.releaseNotesUrl">
+        <span class="installer-card__meta-label">Note di rilascio</span>
         <a
+          class="installer-card__meta-value installer-card__link"
           [href]="installer.metadata?.releaseNotesUrl"
           target="_blank"
           rel="noopener"
         >
-          View
+          Apri
         </a>
-      </dd>
+      </div>
+
+      <ng-container *ngIf="getHomepage(installer) as homepage">
+        <div class="installer-card__meta-item">
+          <span class="installer-card__meta-label">Sorgente</span>
+          <a
+            class="installer-card__meta-value installer-card__link"
+            [href]="homepage"
+            target="_blank"
+            rel="noopener"
+          >
+            {{ homepage }}
+          </a>
+        </div>
+      </ng-container>
     </div>
-  </dl>
+  </article>
 </ng-template>

--- a/src/app/components/installer-section/installer-section.component.scss
+++ b/src/app/components/installer-section/installer-section.component.scss
@@ -1,153 +1,241 @@
 .installer-section {
-  margin: 3rem auto;
-  max-width: 960px;
-  padding: 0 1.5rem;
+  margin: clamp(3.5rem, 8vw, 5.5rem) auto;
+  width: min(1100px, 100% - 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 4vw, 3.5rem);
+
+  &__intro {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 0.9rem;
+  }
 
   &__title {
-    font-size: 2rem;
-    margin-bottom: 1.5rem;
-    text-align: center;
-  }
-
-  &__list {
-    list-style: none;
     margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-
-    &--nested {
-      margin-top: 1rem;
-      margin-left: 1.5rem;
-    }
-  }
-
-  &__item {
-    background: #ffffff;
-    border-radius: 12px;
-    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
-    padding: 1.5rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-
-  &__header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 1rem;
-    flex-wrap: wrap;
-  }
-
-  &__name-group {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-  }
-
-  &__name {
-    font-size: 1.25rem;
-    font-weight: 600;
-  }
-
-  &__platform {
-    font-size: 0.95rem;
-    font-weight: 500;
-    color: #555;
+    font-size: clamp(2.15rem, 4.5vw, 2.8rem);
+    letter-spacing: 0.04em;
     text-transform: uppercase;
-    letter-spacing: 0.06em;
+    background: linear-gradient(120deg, rgba(226, 232, 240, 0.95), var(--accent));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
   }
 
-  &__path {
-    font-size: 0.85rem;
-    color: #777;
-    word-break: break-all;
+  &__subtitle {
+    margin: 0 auto;
+    max-width: 720px;
+    color: rgba(148, 163, 184, 0.85);
+    font-size: 1rem;
+    line-height: 1.7;
   }
 
-  &__download {
-    background: #0078d7;
-    color: #fff;
-    padding: 0.5rem 1.25rem;
-    border-radius: 999px;
-    text-decoration: none;
-    font-weight: 600;
-    transition: background 0.2s ease-in-out;
-
-    &:hover,
-    &:focus {
-      background: #005fa3;
-    }
-  }
-
-  &__description {
-    margin: 0;
-    color: #333;
-    line-height: 1.5;
-  }
-
-  &__meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1.5rem;
-    margin: 0;
-  }
-
-  &__meta-item {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-
-    dt {
-      font-weight: 600;
-      color: #444;
-    }
-
-    dd {
-      margin: 0;
-      color: #222;
-      word-break: break-all;
-    }
-
-    a {
-      color: #0078d7;
-      text-decoration: none;
-
-      &:hover,
-      &:focus {
-        text-decoration: underline;
-      }
-    }
+  &__grid {
+    display: grid;
+    gap: clamp(1.5rem, 3vw, 2.25rem);
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   }
 
   &__groups {
     display: flex;
     flex-direction: column;
-    gap: 2rem;
+    gap: clamp(2rem, 4vw, 3rem);
   }
 
   &__group {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 1.5rem;
+    padding: clamp(1.5rem, 3vw, 2rem);
+    border-radius: 28px;
+    background: linear-gradient(170deg, rgba(8, 15, 31, 0.92), rgba(15, 23, 42, 0.65));
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    box-shadow: var(--shadow-soft);
+    backdrop-filter: blur(18px);
   }
 
   &__group-header {
-    border-left: 4px solid #0078d7;
-    padding-left: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    align-items: flex-start;
   }
 
   &__group-title {
-    font-size: 1.5rem;
-    font-weight: 600;
     margin: 0;
+    font-size: clamp(1.35rem, 3vw, 1.6rem);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  &__group-path {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(56, 189, 248, 0.08);
+    border: 1px solid rgba(56, 189, 248, 0.2);
+    color: rgba(148, 163, 184, 0.85);
+    font-size: 0.75rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+  }
+
+  &__grid--nested {
+    margin-top: 0.5rem;
   }
 
   &__group-children {
     display: flex;
     flex-direction: column;
-    gap: 1.5rem;
-    margin-left: 1.5rem;
+    gap: clamp(1.25rem, 3vw, 2rem);
+    padding-left: clamp(0.5rem, 2vw, 1.5rem);
+    border-left: 1px dashed rgba(56, 189, 248, 0.25);
+  }
+}
+
+.installer-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: clamp(1.6rem, 3vw, 2rem);
+  border-radius: 26px;
+  background: linear-gradient(180deg, rgba(6, 12, 28, 0.92), rgba(11, 18, 35, 0.78));
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 28px 60px rgba(2, 8, 23, 0.45);
+  overflow: hidden;
+  isolation: isolate;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.28), transparent 60%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+  }
+
+  &:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 45px 85px rgba(3, 7, 18, 0.55);
+
+    &::before {
+      opacity: 1;
+    }
+  }
+
+  &__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  &__title-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+  }
+
+  &__name {
+    font-size: clamp(1.3rem, 3vw, 1.55rem);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+  }
+
+  &__platform {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.35rem 0.9rem;
+    border-radius: 999px;
+    background: rgba(56, 189, 248, 0.12);
+    border: 1px solid rgba(56, 189, 248, 0.3);
+    color: var(--accent);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+  }
+
+  &__download {
+    padding-inline: 1.45rem;
+  }
+
+  &__path {
+    font-size: 0.8rem;
+    color: rgba(148, 163, 184, 0.75);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    word-break: break-all;
+  }
+
+  &__description {
+    margin: 0;
+    color: rgba(226, 232, 240, 0.78);
+    line-height: 1.7;
+  }
+
+  &__meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: clamp(1rem, 2vw, 1.5rem);
+  }
+
+  &__meta-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  &__meta-label {
+    font-size: 0.75rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgba(148, 163, 184, 0.72);
+  }
+
+  &__meta-value {
+    font-size: 0.95rem;
+    color: rgba(226, 232, 240, 0.88);
+    word-break: break-word;
+  }
+
+  &__link {
+    color: var(--accent);
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+  }
+
+  &__code {
+    font-size: 0.85rem;
+    word-break: break-all;
+  }
+}
+
+@media (max-width: 768px) {
+  .installer-section {
+    width: min(100%, 100% - 2.5rem);
+  }
+
+  .installer-card {
+    &__header {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    &__download {
+      width: 100%;
+      justify-content: center;
+    }
   }
 }

--- a/src/app/services/bot.service.ts
+++ b/src/app/services/bot.service.ts
@@ -1227,7 +1227,62 @@ export interface InstallerMetadata {
   checksum?: string;
   releaseNotesUrl?: string;
   downloadUrl?: string;
+  license?: string | InstallerLicenseMetadata;
+  licence?: string | InstallerLicenseMetadata;
+  licenseUrl?: string;
+  licenceUrl?: string;
+  licenseId?: string;
+  licenseText?: string;
+  licenseName?: string;
+  projectUrl?: string | InstallerRepositoryInfo;
+  projectURL?: string | InstallerRepositoryInfo;
+  sourceUrl?: string | InstallerRepositoryInfo;
+  source?: string | InstallerRepositoryInfo;
+  repositoryUrl?: string | InstallerRepositoryInfo;
+  repository?: string | InstallerRepositoryInfo;
+  homepage?: string | InstallerRepositoryInfo;
+  homePage?: string | InstallerRepositoryInfo;
+  maintainer?: InstallerContactValue;
+  maintainers?: InstallerContactValue;
+  publisher?: InstallerContactValue;
+  author?: InstallerContactValue;
+  owner?: InstallerContactValue;
+  vendor?: InstallerContactValue;
   [key: string]: any;
+}
+
+export type InstallerContactValue = string | InstallerContact | InstallerContact[];
+
+export interface InstallerContact {
+  name?: string;
+  displayName?: string;
+  fullName?: string;
+  login?: string;
+  username?: string;
+  email?: string;
+  url?: string;
+  html_url?: string;
+  [key: string]: unknown;
+}
+
+export interface InstallerRepositoryInfo {
+  url?: string;
+  html_url?: string;
+  href?: string;
+  link?: string;
+  [key: string]: unknown;
+}
+
+export interface InstallerLicenseMetadata {
+  name?: string;
+  title?: string;
+  spdx_id?: string;
+  spdxId?: string;
+  key?: string;
+  id?: string;
+  url?: string;
+  html_url?: string;
+  [key: string]: unknown;
 }
 
 export interface InstallerAsset {


### PR DESCRIPTION
## Summary
- restyle the installers view with card layout, license/maintainer details, and size values in MB
- extend installer metadata handling to surface license, maintainer, and source information in the UI
- refresh the footer with legal guidance plus links to the developer portfolio and GitHub profile

## Testing
- npm run build -- --progress=false

------
https://chatgpt.com/codex/tasks/task_e_68f487b22de0832b84ddf99e76ee4767