### PR TITLE
Add botlist packaging workflow

### DIFF
--- a/.github/workflows/deploy-botlist.yml
+++ b/.github/workflows/deploy-botlist.yml
@@ -1,0 +1,43 @@
+name: Deploy botlist
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate bot artifacts
+        run: |
+          bash tool/package_bots.sh bot-sources build/botlist
+
+      - name: Upload bot artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: botlist
+          path: build/botlist
+          if-no-files-found: warn
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: build/botlist
+          publish_branch: gh-pages
+          keep_files: true
+          force_orphan: false
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Il file `Bot.json` contiene i metadati (nome, descrizione, versione), l'entrypoi
 Il repository include il workflow [`deploy-botlist`](.github/workflows/deploy-botlist.yml) che, ad ogni push sul branch `main` o al tag di una release, comprime i bot disponibili e pubblica i file risultanti su `gh-pages`.
 
 1. **Aggiungi o modifica un bot** nella directory `bot-sources/<piattaforma>/<nome-bot>/` assicurandoti che contenga un file `Bot.json` valido secondo la guida.
-2. **Esegui lo script di packaging in locale** (opzionale) con `bash tool/package_bots.sh bot-sources build/botlist` per verificare che vengano generati gli archivi `.zip` e i manifest aggiornati.
+2. **Esegui lo script di packaging in locale** (opzionale) con `bash tool/package_bots.sh bot-sources build/botlist` per verificare che vengano generati gli archivi `.zip` e i manifest aggiornati. Assicurati che `zip` e `jq` siano installati nel tuo ambiente locale, poiché lo script li usa per comprimere i bot e aggiornare i metadati.
 3. **Apri una pull request o esegui un push su `main`**: il workflow eseguirà automaticamente lo script, aggiornerà `botlist.json` aggregando i metadati e pubblicherà la cartella `build/botlist/` sul branch `gh-pages` tramite `peaceiris/actions-gh-pages`, mantenendo la cronologia e i file esistenti.
 4. **Recupera la botlist pubblicata** dal branch `gh-pages` (`bots/<piattaforma>/<nome>.zip`, `bots/<piattaforma>/<nome>.json` e `botlist.json`) per distribuirla via CDN o per l'app Scriptagher.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ Il file `Bot.json` contiene i metadati (nome, descrizione, versione), l'entrypoi
 
 > **Sicurezza:** sviluppa bot in ambienti isolati, dichiara solo le permission indispensabili e controlla l'origine dei pacchetti. Altri suggerimenti sono disponibili nella guida dedicata.
 
+### Aggiornare la botlist con la pipeline GitHub Actions
+
+Il repository include il workflow [`deploy-botlist`](.github/workflows/deploy-botlist.yml) che, ad ogni push sul branch `main` o al tag di una release, comprime i bot disponibili e pubblica i file risultanti su `gh-pages`.
+
+1. **Aggiungi o modifica un bot** nella directory `bot-sources/<piattaforma>/<nome-bot>/` assicurandoti che contenga un file `Bot.json` valido secondo la guida.
+2. **Esegui lo script di packaging in locale** (opzionale) con `bash tool/package_bots.sh bot-sources build/botlist` per verificare che vengano generati gli archivi `.zip` e i manifest aggiornati.
+3. **Apri una pull request o esegui un push su `main`**: il workflow eseguirà automaticamente lo script, aggiornerà `botlist.json` aggregando i metadati e pubblicherà la cartella `build/botlist/` sul branch `gh-pages` tramite `peaceiris/actions-gh-pages`, mantenendo la cronologia e i file esistenti.
+4. **Recupera la botlist pubblicata** dal branch `gh-pages` (`bots/<piattaforma>/<nome>.zip`, `bots/<piattaforma>/<nome>.json` e `botlist.json`) per distribuirla via CDN o per l'app Scriptagher.
+
+Se la directory `bot-sources/` è vuota il workflow pubblicherà comunque un `botlist.json` valido con un array di bot vuoto, preservando la cache dei client.
+
 ### Backend API e CORS
 
 Il server backend Shelf esposto su `http://localhost:8080` gestisce automaticamente le richieste `OPTIONS` e applica gli header CORS `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods` e `Access-Control-Allow-Headers` a tutte le risposte, inclusi gli stream SSE. Assicurati che qualsiasi client personalizzato invii le richieste con gli header previsti (ad esempio `Content-Type` o `Authorization`) per sfruttare correttamente il supporto CORS fornito dal backend.

--- a/lib/backend/server/services/execution_service.dart
+++ b/lib/backend/server/services/execution_service.dart
@@ -18,6 +18,7 @@ class ExecutionService {
   final BotDatabase _botDatabase;
   final ExecutionLogManager _logManager;
   final CustomLogger _logger = CustomLogger();
+  static const Utf8Decoder _lossyUtf8Decoder = Utf8Decoder(allowMalformed: true);
   final Map<String, _ManagedProcess> _runningProcesses = {};
   final Map<String, _CompletedProcess> _completedProcesses = {};
   final List<String> _completedOrder = [];
@@ -75,7 +76,7 @@ class ExecutionService {
       final process = await _spawnProcess(bot);
 
       final stdoutSub = process.stdout
-          .transform(utf8.decoder)
+          .transform(_lossyUtf8Decoder)
           .transform(const LineSplitter())
           .listen((line) {
         _handleLine(session, line,
@@ -91,7 +92,7 @@ class ExecutionService {
       });
 
       final stderrSub = process.stderr
-          .transform(utf8.decoder)
+          .transform(_lossyUtf8Decoder)
           .transform(const LineSplitter())
           .listen((line) {
         _handleLine(session, line,
@@ -272,7 +273,7 @@ class ExecutionService {
         process = await _spawnProcess(bot);
 
         stdoutSub = process!.stdout
-            .transform(utf8.decoder)
+            .transform(_lossyUtf8Decoder)
             .transform(const LineSplitter())
             .listen((line) {
           _handleLine(session, line,
@@ -280,7 +281,7 @@ class ExecutionService {
         });
 
         stderrSub = process!.stderr
-            .transform(utf8.decoder)
+            .transform(_lossyUtf8Decoder)
             .transform(const LineSplitter())
             .listen((line) {
           _handleLine(session, line,

--- a/tool/package_bots.sh
+++ b/tool/package_bots.sh
@@ -4,6 +4,16 @@ set -euo pipefail
 SOURCE_DIR=${1:-bot-sources}
 OUTPUT_DIR=${2:-build/botlist}
 
+# Verify dependencies up-front to fail fast on missing tools.
+required_commands=(jq zip)
+for cmd in "${required_commands[@]}"; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "[botlist] Errore: comando richiesto '$cmd' non trovato nel PATH." >&2
+    echo "          Installa '$cmd' e riprova." >&2
+    exit 1
+  fi
+done
+
 # Prepare output directory structure
 rm -rf "$OUTPUT_DIR"
 mkdir -p "$OUTPUT_DIR/bots"

--- a/tool/package_bots.sh
+++ b/tool/package_bots.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_DIR=${1:-bot-sources}
+OUTPUT_DIR=${2:-build/botlist}
+
+# Prepare output directory structure
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR/bots"
+
+metadata_file=$(mktemp)
+: > "$metadata_file"
+
+if [ ! -d "$SOURCE_DIR" ]; then
+  echo "[botlist] Nessuna directory sorgente trovata in '$SOURCE_DIR'. Verrà generata una botlist vuota." >&2
+else
+  for platform_dir in "$SOURCE_DIR"/*; do
+    [ -d "$platform_dir" ] || continue
+    platform="$(basename "$platform_dir")"
+
+    for bot_dir in "$platform_dir"/*; do
+      [ -d "$bot_dir" ] || continue
+      bot_name="$(basename "$bot_dir")"
+      manifest_path="$bot_dir/Bot.json"
+
+      if [ ! -f "$manifest_path" ]; then
+        echo "[botlist] Avviso: nessun Bot.json trovato per $platform/$bot_name, salto." >&2
+        continue
+      fi
+
+      zip_rel_path="bots/$platform/$bot_name.zip"
+      manifest_rel_path="bots/$platform/$bot_name.json"
+      zip_out_path="$OUTPUT_DIR/$zip_rel_path"
+      manifest_out_path="$OUTPUT_DIR/$manifest_rel_path"
+
+      mkdir -p "$(dirname "$zip_out_path")"
+
+      tmp_dir=$(mktemp -d)
+      cp -R "$bot_dir" "$tmp_dir/$bot_name"
+      (cd "$tmp_dir" && zip -qr "$zip_out_path" "$bot_name")
+      rm -rf "$tmp_dir"
+
+      if command -v sha256sum >/dev/null 2>&1; then
+        archive_sha=$(sha256sum "$zip_out_path" | awk '{print $1}')
+      else
+        archive_sha=$(shasum -a 256 "$zip_out_path" | awk '{print $1}')
+      fi
+      if archive_size=$(stat -c%s "$zip_out_path" 2>/dev/null); then
+        :
+      else
+        archive_size=$(stat -f%z "$zip_out_path")
+      fi
+
+      mkdir -p "$(dirname "$manifest_out_path")"
+      jq --arg sha "$archive_sha" \
+         --arg url "$zip_rel_path" \
+         --argjson size "$archive_size" \
+         '.archiveSha256 = $sha
+          | .archiveUrl = $url
+          | .archiveSize = $size' "$manifest_path" > "$manifest_out_path"
+
+      echo "$platform|$bot_name|$zip_rel_path|$manifest_rel_path|$archive_sha|$archive_size" >> "$metadata_file"
+    done
+  done
+fi
+
+bots_json="[]"
+
+while IFS='|' read -r platform bot_name zip_rel manifest_rel archive_sha archive_size; do
+  [ -n "${platform:-}" ] || continue
+  manifest_out_path="$OUTPUT_DIR/$manifest_rel"
+  bots_json=$(jq \
+    --arg platform "$platform" \
+    --arg name "$bot_name" \
+    --arg zip "$zip_rel" \
+    --arg manifest "$manifest_rel" \
+    --arg sha "$archive_sha" \
+    --arg size "$archive_size" \
+    --slurpfile manifestJson "$manifest_out_path" \
+    '. + [{
+      platform: $platform,
+      name: $name,
+      archiveUrl: $zip,
+      manifestUrl: $manifest,
+      archiveSha256: $sha,
+      archiveSize: ($size | tonumber),
+      manifest: $manifestJson[0]
+    }]' <<< "$bots_json")
+done < "$metadata_file"
+
+rm -f "$metadata_file"
+
+jq -n \
+  --arg generatedAt "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  --argjson bots "$bots_json" \
+  '{generatedAt: $generatedAt, bots: $bots}' > "$OUTPUT_DIR/botlist.json"
+
+printf '[botlist] Generazione completata in %s\n' "$OUTPUT_DIR" >&2


### PR DESCRIPTION
## Summary
- add a deploy-botlist workflow that packages bots on pushes and publishes the artifacts to gh-pages
- provide a reusable script to zip bots, refresh manifests, and build the aggregated botlist
- document how to update and publish the botlist through the new automation

## Testing
- `./tool/package_bots.sh`


------
https://chatgpt.com/codex/tasks/task_e_68f48e9325a0832b91cf73300028ee48