### PR TITLE
Handle malformed UTF-8 output in execution service

### DIFF
--- a/lib/backend/server/services/execution_service.dart
+++ b/lib/backend/server/services/execution_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 import 'package:scriptagher/shared/constants/LOGS.dart';
 import 'package:scriptagher/shared/custom_logger.dart';
@@ -21,6 +22,10 @@ class ExecutionService {
   final Map<String, _ManagedProcess> _runningProcesses = {};
   final Map<String, _CompletedProcess> _completedProcesses = {};
   final List<String> _completedOrder = [];
+
+  @visibleForTesting
+  static const Utf8Decoder lossyUtf8Decoder =
+      Utf8Decoder(allowMalformed: true);
 
   Future<Response> startBot(
       Request request, String language, String botName) async {
@@ -75,7 +80,7 @@ class ExecutionService {
       final process = await _spawnProcess(bot);
 
       final stdoutSub = process.stdout
-          .transform(utf8.decoder)
+          .transform(lossyUtf8Decoder)
           .transform(const LineSplitter())
           .listen((line) {
         _handleLine(session, line,
@@ -91,7 +96,7 @@ class ExecutionService {
       });
 
       final stderrSub = process.stderr
-          .transform(utf8.decoder)
+          .transform(lossyUtf8Decoder)
           .transform(const LineSplitter())
           .listen((line) {
         _handleLine(session, line,
@@ -272,7 +277,7 @@ class ExecutionService {
         process = await _spawnProcess(bot);
 
         stdoutSub = process!.stdout
-            .transform(utf8.decoder)
+            .transform(lossyUtf8Decoder)
             .transform(const LineSplitter())
             .listen((line) {
           _handleLine(session, line,
@@ -280,7 +285,7 @@ class ExecutionService {
         });
 
         stderrSub = process!.stderr
-            .transform(utf8.decoder)
+            .transform(lossyUtf8Decoder)
             .transform(const LineSplitter())
             .listen((line) {
           _handleLine(session, line,

--- a/test/backend/server/execution_service_test.dart
+++ b/test/backend/server/execution_service_test.dart
@@ -35,9 +35,11 @@ void main() {
           .transform(const LineSplitter())
           .toList();
 
-      controller.add(<int>[0x61, 0x62, 0x63, 0xFF]);
-      controller.add(<int>[0x64, 0x65, 0x66, 0x0A]);
-      await controller.close();
+      unawaited(Future<void>(() async {
+        controller.add(<int>[0x61, 0x62, 0x63, 0xFF]);
+        controller.add(<int>[0x64, 0x65, 0x66, 0x0A]);
+        await controller.close();
+      }));
 
       final lines = await linesFuture;
 

--- a/test/backend/server/execution_service_test.dart
+++ b/test/backend/server/execution_service_test.dart
@@ -1,0 +1,51 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:scriptagher/backend/server/services/execution_service.dart';
+
+void main() {
+  group('ExecutionService lossy UTF-8 decoding', () {
+    test('decodes malformed stdout bytes without throwing', () async {
+      final malformedOutput = <List<int>>[
+        <int>[102, 111, 111, 0xFF, 98, 97, 114, 10],
+      ];
+      final buffer = StringBuffer();
+
+      await expectLater(
+        Stream<List<int>>.fromIterable(malformedOutput)
+            .transform(ExecutionService.lossyUtf8Decoder)
+            .transform(const LineSplitter())
+            .map((line) {
+          buffer.writeln(line);
+          return line;
+        }).drain<void>(),
+        completes,
+      );
+
+      expect(buffer.toString(), contains('�'));
+    });
+
+    test('decodes malformed bytes in SSE stream without throwing', () async {
+      final controller = StreamController<List<int>>();
+      final buffer = StringBuffer();
+      final errors = <Object>[];
+
+      final subscription = controller.stream
+          .transform(ExecutionService.lossyUtf8Decoder)
+          .transform(const LineSplitter())
+          .listen((line) {
+        buffer.writeln(line);
+      }, onError: errors.add);
+
+      controller.add(<int>[0x61, 0x62, 0x63, 0xFF]);
+      controller.add(<int>[0x64, 0x65, 0x66, 0x0A]);
+      await controller.close();
+      await subscription.asFuture<void>();
+
+      expect(errors, isEmpty);
+      expect(buffer.toString(), contains('�'));
+    });
+  });
+}

--- a/test/backend/server/execution_service_test.dart
+++ b/test/backend/server/execution_service_test.dart
@@ -29,23 +29,20 @@ void main() {
 
     test('decodes malformed bytes in SSE stream without throwing', () async {
       final controller = StreamController<List<int>>();
-      final buffer = StringBuffer();
-      final errors = <Object>[];
 
-      final subscription = controller.stream
+      final linesFuture = controller.stream
           .transform(ExecutionService.lossyUtf8Decoder)
           .transform(const LineSplitter())
-          .listen((line) {
-        buffer.writeln(line);
-      }, onError: errors.add);
+          .toList();
 
       controller.add(<int>[0x61, 0x62, 0x63, 0xFF]);
       controller.add(<int>[0x64, 0x65, 0x66, 0x0A]);
       await controller.close();
-      await subscription.asFuture<void>();
 
-      expect(errors, isEmpty);
-      expect(buffer.toString(), contains('�'));
+      final lines = await linesFuture;
+
+      expect(lines, isNotEmpty);
+      expect(lines.join('\n'), contains('�'));
     });
   });
 }


### PR DESCRIPTION
## Summary
- allow the execution service to decode malformed UTF-8 output with a lossy decoder for both synchronous and SSE streams
- add unit coverage that simulates binary output and ensures it is logged without throwing

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f48e94b1dc832b911252656b983425