### PR TITLE
Refine navigation menu in title bars

### DIFF
--- a/lib/frontend/widgets/components/navigation_menu.dart
+++ b/lib/frontend/widgets/components/navigation_menu.dart
@@ -2,19 +2,19 @@ import 'package:flutter/material.dart';
 
 @immutable
 class NavigationMenuEntry {
-  const NavigationMenuEntry({
+  NavigationMenuEntry({
     required this.label,
     this.route,
-    this.children = const <NavigationMenuEntry>[],
-  });
+    List<NavigationMenuEntry> children = const <NavigationMenuEntry>[],
+  })  : children = List.unmodifiable(children),
+        assert(route != null || children.isNotEmpty,
+            'A menu entry must have either a route or children.');
 
   final String label;
   final String? route;
   final List<NavigationMenuEntry> children;
 
   Widget toMenuWidget(BuildContext context) {
-    assert(route != null || children.isNotEmpty,
-        'A menu entry must have either a route or children.');
     final TextStyle? textStyle = Theme.of(context).textTheme.bodyMedium;
     const EdgeInsets menuPadding = EdgeInsets.symmetric(
       horizontal: 16,
@@ -53,7 +53,8 @@ class NavigationMenuEntry {
   }
 }
 
-const List<NavigationMenuEntry> appNavigationEntries = <NavigationMenuEntry>[
+final List<NavigationMenuEntry> appNavigationEntries =
+    List<NavigationMenuEntry>.unmodifiable(<NavigationMenuEntry>[
   NavigationMenuEntry(label: 'Home', route: '/home'),
   NavigationMenuEntry(label: 'Bots', route: '/bots'),
   NavigationMenuEntry(label: 'Tutorial', route: '/tutorial'),
@@ -66,7 +67,7 @@ const List<NavigationMenuEntry> appNavigationEntries = <NavigationMenuEntry>[
     ],
   ),
   NavigationMenuEntry(label: 'Settings', route: '/settings'),
-];
+]);
 
 List<Widget> buildNavigationMenuChildren(
   BuildContext context,

--- a/lib/frontend/widgets/components/navigation_menu.dart
+++ b/lib/frontend/widgets/components/navigation_menu.dart
@@ -6,14 +6,15 @@ class NavigationMenuEntry {
     required this.label,
     this.route,
     this.children = const <NavigationMenuEntry>[],
-  }) : assert(route != null || children.isNotEmpty,
-            'A menu entry must have either a route or children.');
+  });
 
   final String label;
   final String? route;
   final List<NavigationMenuEntry> children;
 
-  Widget toMenuWidget(BuildContext context, MenuController controller) {
+  Widget toMenuWidget(BuildContext context) {
+    assert(route != null || children.isNotEmpty,
+        'A menu entry must have either a route or children.');
     final TextStyle? textStyle = Theme.of(context).textTheme.bodyMedium;
     const EdgeInsets menuPadding = EdgeInsets.symmetric(
       horizontal: 16,
@@ -28,7 +29,7 @@ class NavigationMenuEntry {
           if (route == null) {
             return;
           }
-          controller.close();
+          MenuController.maybeOf(context)?.close();
           Navigator.of(context).pushNamed(route!);
         },
       );
@@ -36,7 +37,7 @@ class NavigationMenuEntry {
 
     return SubmenuButton(
       menuChildren:
-          children.map((child) => child.toMenuWidget(context, controller)).toList(),
+          children.map((child) => child.toMenuWidget(context)).toList(),
       child: Padding(
         padding: menuPadding,
         child: Row(
@@ -69,9 +70,8 @@ const List<NavigationMenuEntry> appNavigationEntries = <NavigationMenuEntry>[
 
 List<Widget> buildNavigationMenuChildren(
   BuildContext context,
-  MenuController controller,
 ) {
   return appNavigationEntries
-      .map((entry) => entry.toMenuWidget(context, controller))
+      .map((entry) => entry.toMenuWidget(context))
       .toList(growable: false);
 }

--- a/lib/frontend/widgets/components/navigation_menu.dart
+++ b/lib/frontend/widgets/components/navigation_menu.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+
+@immutable
+class NavigationMenuEntry {
+  const NavigationMenuEntry({
+    required this.label,
+    this.route,
+    this.children = const <NavigationMenuEntry>[],
+  }) : assert(route != null || children.isNotEmpty,
+            'A menu entry must have either a route or children.');
+
+  final String label;
+  final String? route;
+  final List<NavigationMenuEntry> children;
+
+  Widget toMenuWidget(BuildContext context, MenuController controller) {
+    final TextStyle? textStyle = Theme.of(context).textTheme.bodyMedium;
+    const EdgeInsets menuPadding = EdgeInsets.symmetric(
+      horizontal: 16,
+      vertical: 12,
+    );
+
+    if (children.isEmpty) {
+      return MenuItemButton(
+        style: MenuItemButton.styleFrom(padding: menuPadding),
+        child: Text(label, style: textStyle),
+        onPressed: () {
+          if (route == null) {
+            return;
+          }
+          controller.close();
+          Navigator.of(context).pushNamed(route!);
+        },
+      );
+    }
+
+    return SubmenuButton(
+      menuChildren:
+          children.map((child) => child.toMenuWidget(context, controller)).toList(),
+      child: Padding(
+        padding: menuPadding,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(label, style: textStyle),
+            const SizedBox(width: 8),
+            const Icon(Icons.chevron_right),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+const List<NavigationMenuEntry> appNavigationEntries = <NavigationMenuEntry>[
+  NavigationMenuEntry(label: 'Home', route: '/home'),
+  NavigationMenuEntry(label: 'Bots', route: '/bots'),
+  NavigationMenuEntry(label: 'Tutorial', route: '/tutorial'),
+  NavigationMenuEntry(
+    label: 'Test',
+    children: <NavigationMenuEntry>[
+      NavigationMenuEntry(label: 'Test 1', route: '/test1'),
+      NavigationMenuEntry(label: 'Test 2', route: '/test2'),
+      NavigationMenuEntry(label: 'Test 3', route: '/test3'),
+    ],
+  ),
+  NavigationMenuEntry(label: 'Settings', route: '/settings'),
+];
+
+List<Widget> buildNavigationMenuChildren(
+  BuildContext context,
+  MenuController controller,
+) {
+  return appNavigationEntries
+      .map((entry) => entry.toMenuWidget(context, controller))
+      .toList(growable: false);
+}

--- a/lib/frontend/widgets/components/navigation_menu.dart
+++ b/lib/frontend/widgets/components/navigation_menu.dart
@@ -6,9 +6,12 @@ class NavigationMenuEntry {
     required this.label,
     this.route,
     List<NavigationMenuEntry> children = const <NavigationMenuEntry>[],
-  })  : children = List.unmodifiable(children),
-        assert(route != null || children.isNotEmpty,
-            'A menu entry must have either a route or children.');
+  }) : children = List.unmodifiable(children) {
+    assert(
+      route != null || this.children.isNotEmpty,
+      'A menu entry must have either a route or children.',
+    );
+  }
 
   final String label;
   final String? route;

--- a/lib/frontend/widgets/components/window_title_bar_desktop.dart
+++ b/lib/frontend/widgets/components/window_title_bar_desktop.dart
@@ -83,7 +83,7 @@ class WindowTitleBar extends StatelessWidget {
                     ),
                   );
                 },
-                menuChildren: buildNavigationMenuChildren(context, controller),
+                menuChildren: buildNavigationMenuChildren(context),
               ),
               Row(
                 children: [

--- a/lib/frontend/widgets/components/window_title_bar_desktop.dart
+++ b/lib/frontend/widgets/components/window_title_bar_desktop.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:bitsdojo_window/bitsdojo_window.dart';
 import 'package:scriptagher/shared/theme/theme_controller.dart';
 
+import 'navigation_menu.dart';
+
 bool get _isDesktop =>
     !kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS);
 
@@ -34,15 +36,54 @@ class WindowTitleBar extends StatelessWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              GestureDetector(
-                onTap: () => Navigator.pushNamed(context, '/home'),
-                child: Text(
-                  'Scriptagher',
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+              MenuAnchor(
+                alignmentOffset: const Offset(0, 8),
+                builder: (context, controller, child) {
+                  final isOpen = controller.isOpen;
+                  final textStyle = Theme.of(context).textTheme.titleMedium?.copyWith(
                         color: colorScheme.onSurface,
                         fontWeight: FontWeight.w600,
+                      );
+
+                  return Tooltip(
+                    message: 'Apri la navigazione',
+                    child: Material(
+                      color: colorScheme.surfaceVariant,
+                      borderRadius: BorderRadius.circular(12),
+                      child: InkWell(
+                        borderRadius: BorderRadius.circular(12),
+                        onTap: () => isOpen ? controller.close() : controller.open(),
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 18,
+                            vertical: 10,
+                          ),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(
+                                Icons.menu,
+                                size: 26,
+                                color: colorScheme.onSurface,
+                              ),
+                              const SizedBox(width: 12),
+                              Text('Menu', style: textStyle),
+                              const SizedBox(width: 8),
+                              Icon(
+                                isOpen
+                                    ? Icons.keyboard_arrow_up
+                                    : Icons.keyboard_arrow_down,
+                                size: 20,
+                                color: colorScheme.onSurface,
+                              ),
+                            ],
+                          ),
+                        ),
                       ),
-                ),
+                    ),
+                  );
+                },
+                menuChildren: buildNavigationMenuChildren(context, controller),
               ),
               Row(
                 children: [
@@ -71,39 +112,6 @@ class WindowTitleBar extends StatelessWidget {
                     },
                   ),
                   const SizedBox(width: 8),
-                  PopupMenuButton<_MenuOption>(
-                    icon: Icon(Icons.menu, color: colorScheme.onSurface),
-                    onSelected: (opt) {
-                      switch (opt) {
-                        case _MenuOption.portfolio:
-                          Navigator.pushNamed(context, '/portfolio');
-                          break;
-                        case _MenuOption.botsList:
-                          Navigator.pushNamed(context, '/bots');
-                          break;
-                      }
-                    },
-                    itemBuilder: (ctx) => const [
-                      PopupMenuItem<_MenuOption>(
-                        enabled: false,
-                        child: Text(
-                          'Prima Sezione',
-                          style: TextStyle(
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ),
-                      PopupMenuDivider(),
-                      PopupMenuItem<_MenuOption>(
-                        value: _MenuOption.portfolio,
-                        child: Text('Portfolio'),
-                      ),
-                      PopupMenuItem<_MenuOption>(
-                        value: _MenuOption.botsList,
-                        child: Text('Bots List'),
-                      ),
-                    ],
-                  ),
                 ],
               ),
             ],
@@ -113,8 +121,6 @@ class WindowTitleBar extends StatelessWidget {
     );
   }
 }
-
-enum _MenuOption { portfolio, botsList }
 
 String _labelForTheme(AppTheme theme) {
   switch (theme) {

--- a/lib/frontend/widgets/components/window_title_bar_web.dart
+++ b/lib/frontend/widgets/components/window_title_bar_web.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:scriptagher/shared/theme/theme_controller.dart';
 
+import 'navigation_menu.dart';
+
 class WindowTitleBar extends StatelessWidget {
   const WindowTitleBar({super.key});
 
@@ -14,15 +16,54 @@ class WindowTitleBar extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       child: Row(
         children: [
-          GestureDetector(
-            onTap: () => Navigator.pushNamed(context, '/home'),
-            child: Text(
-              'Scriptagher',
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+          MenuAnchor(
+            alignmentOffset: const Offset(0, 8),
+            builder: (context, controller, child) {
+              final isOpen = controller.isOpen;
+              final textStyle = Theme.of(context).textTheme.titleMedium?.copyWith(
                     color: colorScheme.onSurface,
                     fontWeight: FontWeight.w600,
+                  );
+
+              return Tooltip(
+                message: 'Apri la navigazione',
+                child: Material(
+                  color: colorScheme.surfaceVariant,
+                  borderRadius: BorderRadius.circular(12),
+                  child: InkWell(
+                    borderRadius: BorderRadius.circular(12),
+                    onTap: () => isOpen ? controller.close() : controller.open(),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 18,
+                        vertical: 10,
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            Icons.menu,
+                            size: 26,
+                            color: colorScheme.onSurface,
+                          ),
+                          const SizedBox(width: 12),
+                          Text('Menu', style: textStyle),
+                          const SizedBox(width: 8),
+                          Icon(
+                            isOpen
+                                ? Icons.keyboard_arrow_up
+                                : Icons.keyboard_arrow_down,
+                            size: 20,
+                            color: colorScheme.onSurface,
+                          ),
+                        ],
+                      ),
+                    ),
                   ),
-            ),
+                ),
+              );
+            },
+            menuChildren: buildNavigationMenuChildren(context, controller),
           ),
           const Spacer(),
           AnimatedBuilder(
@@ -47,36 +88,11 @@ class WindowTitleBar extends StatelessWidget {
             },
           ),
           const SizedBox(width: 8),
-          PopupMenuButton<_MenuOption>(
-            icon: Icon(Icons.menu, color: colorScheme.onSurface),
-            onSelected: (opt) {
-              switch (opt) {
-                case _MenuOption.portfolio:
-                  Navigator.pushNamed(context, '/portfolio');
-                  break;
-                case _MenuOption.botsList:
-                  Navigator.pushNamed(context, '/bots');
-                  break;
-              }
-            },
-            itemBuilder: (ctx) => const [
-              PopupMenuItem<_MenuOption>(
-                value: _MenuOption.portfolio,
-                child: Text('Portfolio'),
-              ),
-              PopupMenuItem<_MenuOption>(
-                value: _MenuOption.botsList,
-                child: Text('Bots List'),
-              ),
-            ],
-          ),
         ],
       ),
     );
   }
 }
-
-enum _MenuOption { portfolio, botsList }
 
 String _labelForTheme(AppTheme theme) {
   switch (theme) {

--- a/lib/frontend/widgets/components/window_title_bar_web.dart
+++ b/lib/frontend/widgets/components/window_title_bar_web.dart
@@ -63,7 +63,7 @@ class WindowTitleBar extends StatelessWidget {
                 ),
               );
             },
-            menuChildren: buildNavigationMenuChildren(context, controller),
+            menuChildren: buildNavigationMenuChildren(context),
           ),
           const Spacer(),
           AnimatedBuilder(


### PR DESCRIPTION
## Summary
- replace the static title in the web and desktop title bars with a reusable MenuAnchor-based navigation trigger
- add a shared navigation menu definition that lists the available routes (excluding Portfolio) and supports nested entries
- style the menu button with larger hit area and richer affordances for improved accessibility

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f48e959808832b9670cea60c7928d9