### PR TITLE
Add bot deletion endpoint and UI action

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ Il file `Bot.json` contiene i metadati (nome, descrizione, versione), l'entrypoi
 
 Il server backend Shelf esposto su `http://localhost:8080` gestisce automaticamente le richieste `OPTIONS` e applica gli header CORS `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods` e `Access-Control-Allow-Headers` a tutte le risposte, inclusi gli stream SSE. Assicurati che qualsiasi client personalizzato invii le richieste con gli header previsti (ad esempio `Content-Type` o `Authorization`) per sfruttare correttamente il supporto CORS fornito dal backend.
 
+#### Endpoint REST principali
+
+| Metodo | Percorso | Descrizione |
+| ------ | -------- | ----------- |
+| `GET` | `/bots` | Restituisce l'elenco dei bot disponibili nel marketplace remoto. |
+| `GET` | `/bots/{language}/{botName}` | Scarica e installa in locale il bot specificato. |
+| `DELETE` | `/bots/{language}/{botName}` | Rimuove un bot scaricato, cancellando record locali e directory nel filesystem. |
+| `GET` | `/bots/downloaded` | Elenca i bot scaricati presenti nel database locale. |
+| `GET` | `/localbots` | Elenca i bot trovati nel filesystem locale. |
+| `POST` | `/bots/{language}/{botName}/start` | Avvia l'esecuzione del bot. |
+| `POST` | `/bots/{language}/{botName}/stop` | Richiede l'arresto ordinato del bot. |
+| `POST` | `/bots/{language}/{botName}/kill` | Termina forzatamente il processo del bot. |
+| `POST` | `/bots/upload` | Carica un archivio ZIP contenente un bot locale. |
+
 ## Struttura del Progetto
 La struttura di base di un'app Flutter è la seguente:
 

--- a/lib/backend/server/db/bot_database.dart
+++ b/lib/backend/server/db/bot_database.dart
@@ -205,6 +205,15 @@ class BotDatabase {
     logger.info('BotDatabase', 'Bot with id $id deleted.');
   }
 
+  Future<void> deleteLocalBot(String language, String botName) async {
+    final db = await database;
+    await db.delete('local_bots',
+        where: 'bot_name = ? AND language = ?',
+        whereArgs: [botName, language]);
+    logger.info('BotDatabase',
+        'Local bot $language/$botName deleted from local_bots table.');
+  }
+
   /// Controlla se la tabella 'bots' esiste
   Future<void> checkIfTableExists() async {
     final db = await database;

--- a/lib/backend/server/routes.dart
+++ b/lib/backend/server/routes.dart
@@ -39,6 +39,11 @@ class BotRoutes {
         (Request request, String language, String botName) =>
             botController.killBot(request, language, botName));
 
+    router.delete(
+        '/bots/<language>/<botName>',
+        (Request request, String language, String botName) =>
+            botController.deleteBot(request, language, botName));
+
     return router;
   }
 }

--- a/lib/backend/server/server.dart
+++ b/lib/backend/server/server.dart
@@ -36,9 +36,8 @@ Future<void> startServer() async {
   final botUploadService = BotUploadService(botDatabase);
   final executionLogManager = ExecutionLogManager();
   final executionService = ExecutionService(botDatabase, executionLogManager);
-  final botController =
-      BotController(botDownloadService, botGetService, botUploadService,
-          executionService);
+  final botController = BotController(botDownloadService, botGetService,
+      botUploadService, executionService, botDatabase);
 
   // Ottieni il router con le rotte definite
   final botRoutes = BotRoutes(botController);

--- a/lib/frontend/services/bot_download_service.dart
+++ b/lib/frontend/services/bot_download_service.dart
@@ -23,18 +23,20 @@ class BotDownloadService {
       return Bot.fromJson(data);
     }
 
+    String? backendMessage;
     try {
       final Map<String, dynamic> error =
           jsonDecode(response.body) as Map<String, dynamic>;
       final message = error['message']?.toString();
       if (message != null && message.isNotEmpty) {
-        throw Exception(message);
+        backendMessage = message;
       }
     } catch (_) {
       // ignore decoding errors and throw generic one below
     }
 
-    throw Exception('Download fallito (codice ${response.statusCode}).');
+    throw Exception(
+        backendMessage ?? 'Download fallito (codice ${response.statusCode}).');
   }
 
   Future<void> deleteBot(String language, String botName) async {
@@ -47,17 +49,19 @@ class BotDownloadService {
       return;
     }
 
+    String? backendMessage;
     try {
       final Map<String, dynamic> error =
           jsonDecode(response.body) as Map<String, dynamic>;
       final message = error['message']?.toString();
       if (message != null && message.isNotEmpty) {
-        throw Exception(message);
+        backendMessage = message;
       }
     } catch (_) {
       // ignore decoding errors and throw generic one below
     }
 
-    throw Exception('Eliminazione fallita (codice ${response.statusCode}).');
+    throw Exception(backendMessage ??
+        'Eliminazione fallita (codice ${response.statusCode}).');
   }
 }

--- a/lib/frontend/services/bot_download_service.dart
+++ b/lib/frontend/services/bot_download_service.dart
@@ -5,15 +5,18 @@ import 'package:http/http.dart' as http;
 import '../models/bot.dart';
 
 class BotDownloadService {
-  BotDownloadService({this.baseUrl = 'http://localhost:8080'});
+  BotDownloadService(
+      {this.baseUrl = 'http://localhost:8080', http.Client? httpClient})
+      : _httpClient = httpClient ?? http.Client();
 
   final String baseUrl;
+  final http.Client _httpClient;
 
   Future<Bot> downloadBot(String language, String botName) async {
     final uri = Uri.parse(
         '$baseUrl/bots/${Uri.encodeComponent(language)}/${Uri.encodeComponent(botName)}');
 
-    final response = await http.get(uri);
+    final response = await _httpClient.get(uri);
     if (response.statusCode == 200) {
       final Map<String, dynamic> data =
           jsonDecode(response.body) as Map<String, dynamic>;
@@ -32,5 +35,29 @@ class BotDownloadService {
     }
 
     throw Exception('Download fallito (codice ${response.statusCode}).');
+  }
+
+  Future<void> deleteBot(String language, String botName) async {
+    final uri = Uri.parse(
+        '$baseUrl/bots/${Uri.encodeComponent(language)}/${Uri.encodeComponent(botName)}');
+
+    final response = await _httpClient.delete(uri);
+
+    if (response.statusCode == 200 || response.statusCode == 204) {
+      return;
+    }
+
+    try {
+      final Map<String, dynamic> error =
+          jsonDecode(response.body) as Map<String, dynamic>;
+      final message = error['message']?.toString();
+      if (message != null && message.isNotEmpty) {
+        throw Exception(message);
+      }
+    } catch (_) {
+      // ignore decoding errors and throw generic one below
+    }
+
+    throw Exception('Eliminazione fallita (codice ${response.statusCode}).');
   }
 }

--- a/lib/frontend/widgets/pages/bot_detail_view.dart
+++ b/lib/frontend/widgets/pages/bot_detail_view.dart
@@ -35,6 +35,7 @@ class _BotDetailViewState extends State<BotDetailView> {
   Bot? _remoteBot;
   bool _isStatusLoading = false;
   bool _isDownloadingBot = false;
+  bool _isDeletingBot = false;
   bool _isDownloaded = false;
   bool _hasUpdateAvailable = false;
 
@@ -57,7 +58,8 @@ class _BotDetailViewState extends State<BotDetailView> {
   Bot? get _installedBot => _downloadedBot;
   bool get _isDesktopPlatform => !kIsWeb &&
       (Platform.isLinux || Platform.isMacOS || Platform.isWindows);
-  bool get _canOpenFolderAction => _isDesktopPlatform && _isDownloaded;
+  bool get _canOpenFolderAction =>
+      _isDesktopPlatform && _isDownloaded && !_isDeletingBot;
 
   void _openTutorial() {
     Navigator.pushNamed(context, '/tutorial');
@@ -211,6 +213,76 @@ class _BotDetailViewState extends State<BotDetailView> {
     if (completed && mounted) {
       await _refreshBotStatus();
     }
+  }
+
+  Future<void> _confirmAndDeleteBot() async {
+    if (!_isDownloaded || _isDeletingBot) {
+      return;
+    }
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        final theme = Theme.of(dialogContext);
+        return AlertDialog(
+          title: const Text('Elimina bot'),
+          content: Text(
+              'Vuoi eliminare definitivamente ${widget.bot.botName}? Verranno rimossi i file locali.'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: const Text('Annulla'),
+            ),
+            FilledButton(
+              style: FilledButton.styleFrom(
+                backgroundColor: theme.colorScheme.error,
+                foregroundColor: theme.colorScheme.onError,
+              ),
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: const Text('Elimina'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (confirmed != true) {
+      return;
+    }
+
+    setState(() {
+      _isDeletingBot = true;
+    });
+
+    var deleted = false;
+    try {
+      await _botDownloadService.deleteBot(
+          widget.bot.language, widget.bot.botName);
+      deleted = true;
+    } catch (e) {
+      if (mounted) {
+        _showSnackBar('Errore durante l\'eliminazione: $e');
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isDeletingBot = false;
+        });
+      }
+    }
+
+    if (!mounted || !deleted) {
+      return;
+    }
+
+    setState(() {
+      _downloadedBot = null;
+      _isDownloaded = false;
+      _hasUpdateAvailable = false;
+    });
+    _showSnackBar('Bot eliminato correttamente.');
+
+    await _refreshBotStatus();
   }
 
   Future<void> _openBotFolder() async {
@@ -1246,8 +1318,9 @@ class _BotDetailViewState extends State<BotDetailView> {
   }
 
   Widget _buildPrimaryActions(BuildContext context) {
-    final bool enableDownload =
-        !_isDownloadingBot && (!_isDownloaded || _hasUpdateAvailable);
+    final bool enableDownload = !_isDownloadingBot &&
+        !_isDeletingBot &&
+        (!_isDownloaded || _hasUpdateAvailable);
     final bool showSpinner = _isDownloadingBot;
     final Widget downloadIcon = showSpinner
         ? const SizedBox(
@@ -1263,6 +1336,17 @@ class _BotDetailViewState extends State<BotDetailView> {
             : _isDownloaded
                 ? 'Scaricato'
                 : 'Scarica';
+    final bool showDelete = _isDownloaded;
+    final bool deleteSpinner = _isDeletingBot;
+    final Widget deleteIcon = deleteSpinner
+        ? const SizedBox(
+            width: 18,
+            height: 18,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          )
+        : const Icon(Icons.delete);
+    final String deleteLabel =
+        deleteSpinner ? 'Eliminazione...' : 'Elimina';
 
     return Wrap(
       spacing: 12,
@@ -1291,6 +1375,16 @@ class _BotDetailViewState extends State<BotDetailView> {
                       ? 'Processo attivo'
                       : 'Esegui'),
         ),
+        if (showDelete)
+          ElevatedButton.icon(
+            onPressed: deleteSpinner ? null : _confirmAndDeleteBot,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.error,
+              foregroundColor: Theme.of(context).colorScheme.onError,
+            ),
+            icon: deleteIcon,
+            label: Text(deleteLabel),
+          ),
       ],
     );
   }

--- a/test/frontend/services/bot_download_service_test.dart
+++ b/test/frontend/services/bot_download_service_test.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:scriptagher/frontend/models/bot.dart';
+import 'package:scriptagher/frontend/services/bot_download_service.dart';
+
+void main() {
+  group('BotDownloadService', () {
+    test('deleteBot calls DELETE endpoint successfully', () async {
+      late http.Request capturedRequest;
+      final client = MockClient((request) async {
+        capturedRequest = request;
+        return http.Response('', 204);
+      });
+
+      final service = BotDownloadService(
+        baseUrl: 'http://localhost:8080',
+        httpClient: client,
+      );
+
+      await service.deleteBot('python', 'SampleBot');
+
+      expect(capturedRequest.method, equals('DELETE'));
+      expect(capturedRequest.url.path,
+          equals('/bots/python/SampleBot'));
+    });
+
+    test('deleteBot throws with backend message on error', () async {
+      final client = MockClient((request) async {
+        return http.Response(jsonEncode({'message': 'Errore personalizzato'}), 400);
+      });
+
+      final service = BotDownloadService(
+        baseUrl: 'http://localhost:8080',
+        httpClient: client,
+      );
+
+      expect(
+        () => service.deleteBot('python', 'BrokenBot'),
+        throwsA(isA<Exception>().having(
+            (e) => e.toString(), 'message', contains('Errore personalizzato'))),
+      );
+    });
+
+    test('downloadBot parses successful response', () async {
+      final client = MockClient((request) async {
+        final payload = {
+          'id': 1,
+          'bot_name': 'SampleBot',
+          'description': 'Desc',
+          'start_command': 'run.sh',
+          'source_path': 'data/remote/python/SampleBot/Bot.json',
+          'language': 'python',
+          'compat': const BotCompat().toJson(),
+          'permissions': const <String>[],
+          'archive_sha256': 'abc',
+          'version': '1.0.0',
+          'author': 'Author',
+          'tags': const <String>[],
+        };
+        return http.Response(jsonEncode(payload), 200);
+      });
+
+      final service = BotDownloadService(
+        baseUrl: 'http://localhost:8080',
+        httpClient: client,
+      );
+
+      final bot = await service.downloadBot('python', 'SampleBot');
+
+      expect(bot.botName, equals('SampleBot'));
+      expect(bot.language, equals('python'));
+      expect(bot.isDownloaded, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a DELETE /bots/{language}/{botName} endpoint that removes downloaded bots from storage and the local database
- expose the new backend route, document it, and surface a delete action with confirmation in the bot detail UI
- extend the frontend download service with deletion support and add unit tests covering the new API call

## Testing
- flutter test *(fails: Flutter SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f48e93d200832b90897a6e5d63b7b5