### PR TITLE
Guard bot execution based on compatibility

### DIFF
--- a/lib/frontend/utils/execution_compatibility.dart
+++ b/lib/frontend/utils/execution_compatibility.dart
@@ -1,0 +1,128 @@
+import '../models/bot.dart';
+
+class ExecutionCompatibilityResult {
+  final bool isSupported;
+  final String? reason;
+
+  const ExecutionCompatibilityResult({
+    required this.isSupported,
+    this.reason,
+  });
+}
+
+ExecutionCompatibilityResult computeExecutionCompatibility({
+  required Bot bot,
+  required bool isWebPlatform,
+  required bool isDesktopPlatform,
+  required bool isMobilePlatform,
+  required bool shouldUseBrowserRunner,
+}) {
+  final compat = bot.compat;
+
+  if (isWebPlatform) {
+    if (shouldUseBrowserRunner) {
+      return const ExecutionCompatibilityResult(isSupported: true);
+    }
+
+    final reason = compat.browserReason?.isNotEmpty == true
+        ? compat.browserReason!
+        : compat.browserSupported == false
+            ? 'Questo bot non è compatibile con l\'esecuzione nel browser.'
+            : 'Esecuzione nel browser non supportata su questa piattaforma.';
+    return ExecutionCompatibilityResult(isSupported: false, reason: reason);
+  }
+
+  if (isDesktopPlatform) {
+    if (compat.isDesktopRunnerMissing) {
+      final missing = compat.missingDesktopRuntimes.join(', ');
+      final missingLabel = missing.isNotEmpty
+          ? 'Runtime mancanti: $missing.'
+          : 'Runtime desktop richiesti mancanti.';
+      return ExecutionCompatibilityResult(
+        isSupported: false,
+        reason: missingLabel,
+      );
+    }
+
+    if (!compat.isDesktopCompatible && compat.desktopRuntimes.isNotEmpty) {
+      return const ExecutionCompatibilityResult(
+        isSupported: false,
+        reason: 'Questo bot non è compatibile con il runner desktop.',
+      );
+    }
+
+    return const ExecutionCompatibilityResult(isSupported: true);
+  }
+
+  if (isMobilePlatform) {
+    final result = _parseMobileMetadata(compat.browserPayloads.metadata['mobile']);
+    if (result != null) {
+      return result;
+    }
+
+    return const ExecutionCompatibilityResult(
+      isSupported: false,
+      reason: 'Questo bot non è compatibile con i dispositivi mobili.',
+    );
+  }
+
+  return const ExecutionCompatibilityResult(isSupported: true);
+}
+
+ExecutionCompatibilityResult? _parseMobileMetadata(dynamic metadata) {
+  if (metadata == null) {
+    return null;
+  }
+
+  bool? supported;
+  String? reason;
+
+  if (metadata is Map<String, dynamic>) {
+    final supportedValue = metadata['supported'];
+    if (supportedValue is bool) {
+      supported = supportedValue;
+    }
+
+    final statusValue = metadata['status'];
+    if (statusValue is String) {
+      final normalizedStatus = statusValue.toLowerCase();
+      if (supported == null) {
+        if (normalizedStatus == 'supported' || normalizedStatus == 'compatible') {
+          supported = true;
+        } else if (normalizedStatus == 'unsupported' ||
+            normalizedStatus == 'incompatible') {
+          supported = false;
+        }
+      }
+    }
+
+    final reasonValue = metadata['reason'];
+    if (reasonValue is String && reasonValue.isNotEmpty) {
+      reason = reasonValue;
+    }
+  } else if (metadata is bool) {
+    supported = metadata;
+  } else if (metadata is String) {
+    final normalizedValue = metadata.toLowerCase();
+    if (normalizedValue == 'supported' || normalizedValue == 'compatible') {
+      supported = true;
+    } else if (normalizedValue == 'unsupported' ||
+        normalizedValue == 'incompatible' ||
+        normalizedValue == 'not_supported') {
+      supported = false;
+    }
+  }
+
+  if (supported == true) {
+    return const ExecutionCompatibilityResult(isSupported: true);
+  }
+
+  if (supported == false) {
+    return ExecutionCompatibilityResult(
+      isSupported: false,
+      reason: reason ?? 'Questo bot non è compatibile con i dispositivi mobili.',
+    );
+  }
+
+  return null;
+}

--- a/lib/frontend/widgets/pages/bot_detail_view.dart
+++ b/lib/frontend/widgets/pages/bot_detail_view.dart
@@ -1324,11 +1324,12 @@ class _BotDetailViewState extends State<BotDetailView> {
                 : 'Scarica';
 
     final compatibility = executionCompatibility;
+    final bool canExecute = _canExecuteBot;
     final bool isBusy = _isRunning || _isTerminating || _activeProcessId != null;
     String? executeTooltip;
     if (!_isDownloaded) {
       executeTooltip = 'Scarica il bot prima di eseguirlo.';
-    } else if (!compatibility.isSupported) {
+    } else if (!canExecute) {
       executeTooltip = compatibility.reason ??
           'Questo bot non è compatibile con la piattaforma corrente.';
     }

--- a/test/frontend/utils/execution_compatibility_test.dart
+++ b/test/frontend/utils/execution_compatibility_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scriptagher/frontend/models/bot.dart';
+import 'package:scriptagher/frontend/utils/execution_compatibility.dart';
+
+Bot _createBot(BotCompat compat) {
+  return Bot(
+    botName: 'Test Bot',
+    description: 'desc',
+    startCommand: 'run',
+    sourcePath: '/data/remote/test',
+    language: 'python',
+    compat: compat,
+  );
+}
+
+void main() {
+  test('web execution is blocked when browser runner is unavailable', () {
+    const compat = BotCompat(
+      browserSupported: false,
+      browserReason: 'No browser',
+    );
+    final bot = _createBot(compat);
+
+    final result = computeExecutionCompatibility(
+      bot: bot,
+      isWebPlatform: true,
+      isDesktopPlatform: false,
+      isMobilePlatform: false,
+      shouldUseBrowserRunner: false,
+    );
+
+    expect(result.isSupported, isFalse);
+    expect(result.reason, contains('browser'));
+  });
+
+  test('mobile execution uses metadata to determine support', () {
+    final compat = BotCompat(
+      browserPayloads: const BrowserPayloads(
+        metadata: {
+          'mobile': {
+            'supported': false,
+            'reason': 'Non disponibile su mobile',
+          },
+        },
+      ),
+    );
+    final bot = _createBot(compat);
+
+    final result = computeExecutionCompatibility(
+      bot: bot,
+      isWebPlatform: false,
+      isDesktopPlatform: false,
+      isMobilePlatform: true,
+      shouldUseBrowserRunner: false,
+    );
+
+    expect(result.isSupported, isFalse);
+    expect(result.reason, contains('mobile'));
+  });
+}

--- a/test/frontend/widgets/bot_detail_view_test.dart
+++ b/test/frontend/widgets/bot_detail_view_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:scriptagher/frontend/models/bot.dart';
+import 'package:scriptagher/frontend/widgets/pages/bot_detail_view.dart';
+
+void main() {
+  Bot createBot({BotCompat compat = const BotCompat(), String? sourcePath}) {
+    return Bot(
+      botName: 'Test Bot',
+      description: 'desc',
+      startCommand: 'run',
+      sourcePath: sourcePath ?? '/data/remote/test',
+      language: 'python',
+      compat: compat,
+    );
+  }
+
+  Future<State> pumpDetailView(WidgetTester tester, Bot bot) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: BotDetailView(bot: bot),
+        ),
+      ),
+    );
+    await tester.pump();
+    return tester.state<StatefulElement>(find.byType(BotDetailView));
+  }
+
+  testWidgets('execute button is disabled when bot is not downloaded',
+      (tester) async {
+    final bot = createBot();
+    final state = await pumpDetailView(tester, bot) as dynamic;
+
+    state.debugConfigureForTesting(
+      remoteBot: bot,
+      updateRemoteBot: true,
+      downloadedBot: null,
+      updateDownloadedBot: true,
+      isDownloaded: false,
+      updateActiveProcessId: true,
+      activeProcessId: null,
+    );
+    await tester.pump();
+
+    final executeFinder = find.widgetWithText(ElevatedButton, 'Esegui');
+    expect(executeFinder, findsOneWidget);
+    final ElevatedButton executeButton = tester.widget(executeFinder);
+    expect(executeButton.onPressed, isNull);
+
+    final tooltipFinder =
+        find.ancestor(of: executeFinder, matching: find.byType(Tooltip));
+    expect(tooltipFinder, findsOneWidget);
+    final Tooltip tooltip = tester.widget(tooltipFinder);
+    expect(tooltip.message, contains('Scarica il bot'));
+  });
+
+  testWidgets(
+      'execute button is disabled when required desktop runtimes are missing',
+      (tester) async {
+    const compat = BotCompat(
+      desktopRuntimes: ['python'],
+      missingDesktopRuntimes: ['python'],
+    );
+    final bot = createBot(compat: compat, sourcePath: '/data/remote/test');
+    final state = await pumpDetailView(tester, bot) as dynamic;
+
+    state.debugConfigureForTesting(
+      remoteBot: bot,
+      updateRemoteBot: true,
+      downloadedBot: bot,
+      updateDownloadedBot: true,
+      isDownloaded: true,
+      updateActiveProcessId: true,
+      activeProcessId: null,
+    );
+    await tester.pump();
+
+    final executeFinder = find.widgetWithText(ElevatedButton, 'Esegui');
+    expect(executeFinder, findsOneWidget);
+    final ElevatedButton executeButton = tester.widget(executeFinder);
+    expect(executeButton.onPressed, isNull);
+
+    final tooltipFinder =
+        find.ancestor(of: executeFinder, matching: find.byType(Tooltip));
+    expect(tooltipFinder, findsOneWidget);
+    final Tooltip tooltip = tester.widget(tooltipFinder);
+    expect(tooltip.message, contains('Runtime mancanti'));
+  });
+}

--- a/test/frontend/widgets/bot_detail_view_test.dart
+++ b/test/frontend/widgets/bot_detail_view_test.dart
@@ -15,7 +15,8 @@ void main() {
     );
   }
 
-  Future<State> pumpDetailView(WidgetTester tester, Bot bot) async {
+  Future<State<StatefulWidget>> pumpDetailView(
+      WidgetTester tester, Bot bot) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -24,7 +25,8 @@ void main() {
       ),
     );
     await tester.pump();
-    return tester.state<StatefulElement>(find.byType(BotDetailView));
+    final element = tester.element(find.byType(BotDetailView));
+    return (element as StatefulElement).state;
   }
 
   testWidgets('execute button is disabled when bot is not downloaded',

--- a/test/frontend/widgets/bot_detail_view_test.dart
+++ b/test/frontend/widgets/bot_detail_view_test.dart
@@ -25,8 +25,7 @@ void main() {
       ),
     );
     await tester.pump();
-    final element = tester.element(find.byType(BotDetailView));
-    return (element as StatefulElement).state;
+    return tester.state<State<StatefulWidget>>(find.byType(BotDetailView));
   }
 
   testWidgets('execute button is disabled when bot is not downloaded',


### PR DESCRIPTION
## Summary
- disable the Execute action when the bot is not downloaded or incompatible and show an explanatory tooltip
- add compatibility evaluation helpers and guard execution start to prevent running unsupported or remote bots
- add widget and unit tests covering the disabled button scenarios and compatibility logic

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f48e942cf8832b8a754cdf4790edc8