### PR TITLE
feat: localize bot listings

### DIFF
--- a/public/bots/bots.json
+++ b/public/bots/bots.json
@@ -1,12 +1,26 @@
 {
-    "python": [
-        {
-            "botName": "Zipper",
-            "path": "Zipper.zip"
+  "sections": {
+    "python": {
+      "translations": {
+        "it": {
+          "title": "Bot Python",
+          "summary": "Automazioni scritte in Python per semplificare attività ripetitive."
         },
-        {
-            "botName": "facebook-images-remover",
-            "path": "facebook-images-remover.zip"
+        "en": {
+          "title": "Python Bots",
+          "summary": "Python-powered automations to streamline repetitive tasks."
         }
-    ]
+      }
+    }
+  },
+  "python": [
+    {
+      "botName": "Zipper",
+      "path": "Zipper.zip"
+    },
+    {
+      "botName": "facebook-images-remover",
+      "path": "facebook-images-remover.zip"
+    }
+  ]
 }

--- a/public/bots/python/Zipper/Bot.json
+++ b/public/bots/python/Zipper/Bot.json
@@ -1,6 +1,18 @@
 {
-    "botName": "Zipper",
-    "startCommand": "python3 bots/python/Zipper/Zipper.py",
-    "description": "This bot zips a folder into a ZIP archive.",
-    "language": "python"
+  "botName": "Zipper",
+  "startCommand": "python3 bots/python/Zipper/Zipper.py",
+  "description": "This bot zips a folder into a ZIP archive.",
+  "language": "python",
+  "translations": {
+    "it": {
+      "displayName": "Zipper",
+      "shortDescription": "Comprimi rapidamente una cartella in un archivio ZIP.",
+      "description": "Questo bot comprime una cartella in un archivio ZIP pronto per il download."
+    },
+    "en": {
+      "displayName": "Zipper",
+      "shortDescription": "Quickly compress a folder into a ZIP archive.",
+      "description": "This bot zips a folder into a downloadable ZIP archive."
+    }
+  }
 }

--- a/public/bots/python/facebook-images-remover/Bot.json
+++ b/public/bots/python/facebook-images-remover/Bot.json
@@ -1,6 +1,18 @@
 {
-    "botName": "facebook-images-remover",
-    "startCommand": "./image-remover.sh",
-    "description": "A Python bot that automates the process of deleting Facebook photos by interacting with the web interface using Selenium.",
-    "language": "Python"
+  "botName": "facebook-images-remover",
+  "startCommand": "./image-remover.sh",
+  "description": "A Python bot that automates the process of deleting Facebook photos by interacting with the web interface using Selenium.",
+  "language": "Python",
+  "translations": {
+    "it": {
+      "displayName": "Facebook Images Remover",
+      "shortDescription": "Elimina automaticamente le foto di Facebook tramite Selenium.",
+      "description": "Un bot Python che automatizza l'eliminazione delle foto su Facebook interagendo con l'interfaccia web tramite Selenium."
+    },
+    "en": {
+      "displayName": "Facebook Images Remover",
+      "shortDescription": "Automatically delete Facebook photos using Selenium.",
+      "description": "A Python bot that automates the removal of Facebook photos by controlling the web interface through Selenium."
+    }
+  }
 }

--- a/src/app/components/bot-card/bot-card.component.html
+++ b/src/app/components/bot-card/bot-card.component.html
@@ -1,21 +1,21 @@
 <div class="bot">
     <div class="bot-surface">
         <div class="bot-header">
-            <h3>{{ bot.botName }}</h3>
-            <span class="bot-language">{{ language | uppercase }}</span>
+            <h3>{{ displayName }}</h3>
+            <span class="bot-language">{{ (language || bot?.language || '') | uppercase }}</span>
         </div>
-        <p class="bot-description">{{ bot.description || 'No description available' }}</p>
+        <p class="bot-description">{{ description }}</p>
         <div class="bot-command">
-            <span>Start command</span>
-            <code>{{ bot.startCommand || 'No start commands provided' }}</code>
+            <span>{{ uiText.startCommandLabel }}</span>
+            <code>{{ startCommand }}</code>
         </div>
 
         <div class="bot-actions">
             <button *ngIf="bot.botName === 'pdf-to-txt'" class="btn btn-secondary" (click)="navigateToPdfToTxt()">
-                Vai al converter PDF to Txt
+                {{ uiText.pdfCtaLabel }}
             </button>
-            <button class="btn btn-secondary" (click)="openBot()">View source</button>
-            <button class="btn btn-primary" (click)="downloadBot()">Download</button>
+            <button class="btn btn-secondary" (click)="openBot()">{{ uiText.viewSourceLabel }}</button>
+            <button class="btn btn-primary" (click)="downloadBot()">{{ uiText.downloadLabel }}</button>
         </div>
     </div>
 </div>

--- a/src/app/components/bot-card/bot-card.component.ts
+++ b/src/app/components/bot-card/bot-card.component.ts
@@ -1,7 +1,9 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import { BotService } from '../../services/bot.service';
+import { I18nService, UiStrings } from '../../services/i18n.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-bot-card',
@@ -10,12 +12,43 @@ import { BotService } from '../../services/bot.service';
   templateUrl: './bot-card.component.html',
   styleUrls: ['./bot-card.component.scss']
 })
-export class BotCardComponent {
+export class BotCardComponent implements OnDestroy {
   @Input() bot: any;
   @Input() language: string = '';
   @Output() download = new EventEmitter<void>();
 
-  constructor(private router: Router, private botService: BotService) {}
+  uiText: UiStrings;
+  private languageSubscription?: Subscription;
+
+  constructor(
+    private router: Router,
+    private botService: BotService,
+    private readonly i18nService: I18nService
+  ) {
+    this.uiText = this.i18nService.getUiStrings();
+    this.languageSubscription = this.i18nService.language$.subscribe(() => {
+      this.uiText = this.i18nService.getUiStrings();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.languageSubscription?.unsubscribe();
+  }
+
+  get displayName(): string {
+    return this.bot?.displayName ?? this.bot?.botName ?? this.uiText.missingValueFallback;
+  }
+
+  get description(): string {
+    return this.bot?.shortDescription ?? this.bot?.description ?? this.uiText.noDescriptionFallback;
+  }
+
+  get startCommand(): string {
+    if (typeof this.bot?.startCommand === 'string' && this.bot.startCommand.trim()) {
+      return this.bot.startCommand;
+    }
+    return this.uiText.noStartCommandFallback;
+  }
 
   openBot() {
     this.bot.language = this.language;

--- a/src/app/components/bot-list/bot-list.component.html
+++ b/src/app/components/bot-list/bot-list.component.html
@@ -5,13 +5,17 @@
 ></app-installer-section>
 
 <main class="bot-list" id="bots" *ngIf="botSections.length; else errorTemplate">
-  <app-bot-section *ngFor="let section of botSections" [language]="section.language"
+  <app-bot-section *ngFor="let section of botSections"
+    [language]="section.language"
+    [languageLabel]="section.languageLabel"
+    [title]="section.title"
+    [summary]="section.summary"
     [bots]="section.botDetails"></app-bot-section>
 </main>
 <ng-template #errorTemplate>
   <div class="error-state">
-    <h2>Ops, qualcosa è andato storto.</h2>
-    <p>{{ errorMessage || 'No bots available.' }}</p>
+    <h2>{{ uiText.genericErrorTitle }}</h2>
+    <p>{{ errorMessage || uiText.genericErrorMessage }}</p>
   </div>
 </ng-template>
 <app-footer></app-footer>

--- a/src/app/components/bot-list/bot-list.component.ts
+++ b/src/app/components/bot-list/bot-list.component.ts
@@ -15,6 +15,14 @@ import { InstallerSectionComponent } from '../installer-section/installer-sectio
 import { Subscription, firstValueFrom, forkJoin } from 'rxjs';
 import { I18nService, UiStrings } from '../../services/i18n.service';
 
+interface BotSectionView {
+  language: string;
+  languageLabel: string;
+  title: string;
+  summary?: string;
+  botDetails: BotDetails[];
+}
+
 @Component({
   selector: 'app-bot-list',
   templateUrl: './bot-list.component.html',
@@ -28,14 +36,6 @@ import { I18nService, UiStrings } from '../../services/i18n.service';
     FooterComponent
   ]
 })
-interface BotSectionView {
-  language: string;
-  languageLabel: string;
-  title: string;
-  summary?: string;
-  botDetails: BotDetails[];
-}
-
 export class BotListComponent implements OnInit, OnDestroy {
   botSections: BotSectionView[] = [];
   errorMessage: string = '';

--- a/src/app/components/bot-list/bot-list.component.ts
+++ b/src/app/components/bot-list/bot-list.component.ts
@@ -1,11 +1,19 @@
-import { Component, OnInit } from '@angular/core';
-import { BotService, InstallerAsset } from '../../services/bot.service';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import {
+  BotService,
+  BotDetails,
+  BotSummary,
+  BotsConfiguration,
+  InstallerAsset,
+  SectionTranslation
+} from '../../services/bot.service';
 import { CommonModule } from '@angular/common';
 import { BotSectionComponent } from '../bot-section/bot-section.component';
 import { HeaderComponent } from '../header/header.component';
 import { FooterComponent } from '../footer/footer.component';
 import { InstallerSectionComponent } from '../installer-section/installer-section.component';
-import { forkJoin } from 'rxjs';
+import { Subscription, firstValueFrom, forkJoin } from 'rxjs';
+import { I18nService, UiStrings } from '../../services/i18n.service';
 
 @Component({
   selector: 'app-bot-list',
@@ -20,15 +28,45 @@ import { forkJoin } from 'rxjs';
     FooterComponent
   ]
 })
-export class BotListComponent implements OnInit {
-  botSections: any[] = [];
+interface BotSectionView {
+  language: string;
+  languageLabel: string;
+  title: string;
+  summary?: string;
+  botDetails: BotDetails[];
+}
+
+export class BotListComponent implements OnInit, OnDestroy {
+  botSections: BotSectionView[] = [];
   errorMessage: string = '';
   installerAssets: InstallerAsset[] = [];
+  uiText: UiStrings;
 
-  constructor(private botService: BotService) {}
+  private botsConfiguration?: BotsConfiguration;
+  private languageSubscription?: Subscription;
+
+  constructor(private botService: BotService, private readonly i18nService: I18nService) {
+    this.uiText = this.i18nService.getUiStrings();
+  }
 
   ngOnInit() {
+    this.languageSubscription = this.i18nService.language$.subscribe(() => {
+      this.uiText = this.i18nService.getUiStrings();
+      if (this.errorMessage) {
+        this.errorMessage = this.uiText.genericErrorMessage;
+      }
+      if (this.botsConfiguration) {
+        this.rebuildBotSections().catch((error) =>
+          console.error('Error rebuilding bot sections after language change', error)
+        );
+      }
+    });
+
     this.populateBotList();
+  }
+
+  ngOnDestroy(): void {
+    this.languageSubscription?.unsubscribe();
   }
 
   populateBotList() {
@@ -36,32 +74,109 @@ export class BotListComponent implements OnInit {
       botsConfig: this.botService.getBotsConfig(),
       installers: this.botService.listInstallerAssets()
     }).subscribe({
-      next: async ({ botsConfig, installers }) => {
+      next: ({ botsConfig, installers }) => {
         this.botSections = [];
+        this.botsConfiguration = botsConfig;
         this.installerAssets = installers ?? [];
-        for (const language in botsConfig) {
-          const bots = botsConfig[language];
-          if (!bots || bots.length === 0) continue;
-          const botDetails = await Promise.all(
-            bots.map(async (bot: any) => {
-              try {
-                bot.language = language;
-                return await this.botService.getBotDetails(bot).toPromise();
-              } catch {
-                return { botName: bot.botName, description: 'Error loading details' };
-              }
-            })
-          );
-          this.botSections.push({
-            language,
-            botDetails,
-          });
-        }
+        this.rebuildBotSections().catch((error) =>
+          console.error('Error building bot sections', error)
+        );
       },
       error: (err) => {
         console.error('Error fetching bots configuration:', err);
-        this.errorMessage = 'Failed to load the bot list.';
+        this.errorMessage = this.uiText.genericErrorMessage;
       },
     });
+  }
+
+  private async rebuildBotSections(): Promise<void> {
+    if (!this.botsConfiguration) {
+      this.botSections = [];
+      return;
+    }
+
+    const sections: BotSectionView[] = [];
+    const botsByLanguage = this.botsConfiguration.bots ?? {};
+    const fallbackChain = this.i18nService.getFallbackLanguages();
+
+    for (const language of Object.keys(botsByLanguage)) {
+      const bots = botsByLanguage[language];
+      if (!Array.isArray(bots) || bots.length === 0) {
+        continue;
+      }
+
+      const translation = this.pickSectionTranslation(
+        this.botsConfiguration.sections?.[language]?.translations,
+        fallbackChain
+      );
+
+      const title = translation?.title ?? this.buildDefaultSectionTitle(language);
+      const summary = translation?.summary;
+
+      const botDetails = await Promise.all(
+        bots.map(async (bot: BotSummary) => {
+          try {
+            const details = await firstValueFrom(
+              this.botService.getBotDetails({ ...bot, language })
+            );
+            details.language = language;
+            details.path = details.path ?? bot.path;
+            return details;
+          } catch (error) {
+            console.error(`Error loading details for bot ${bot?.botName}`, error);
+            return this.createFallbackBot(language, bot);
+          }
+        })
+      );
+
+      sections.push({
+        language,
+        languageLabel: language.toUpperCase(),
+        title,
+        summary,
+        botDetails
+      });
+    }
+
+    this.botSections = sections;
+  }
+
+  private pickSectionTranslation(
+    translations: Record<string, SectionTranslation> | undefined,
+    fallbackChain: string[]
+  ): SectionTranslation | undefined {
+    if (!translations) {
+      return undefined;
+    }
+    for (const language of fallbackChain) {
+      const translation = translations[language];
+      if (translation) {
+        return translation;
+      }
+    }
+    return undefined;
+  }
+
+  private buildDefaultSectionTitle(language: string): string {
+    if (!language) {
+      return this.uiText.botsLabel;
+    }
+    const capitalized = language.charAt(0).toUpperCase() + language.slice(1);
+    return `${capitalized} ${this.uiText.botsLabel}`.trim();
+  }
+
+  private createFallbackBot(language: string, bot: BotSummary): BotDetails {
+    const uiText = this.uiText;
+    const botName = bot?.botName ?? uiText.missingValueFallback;
+    const description = bot?.description ?? uiText.noDescriptionFallback;
+    return {
+      ...bot,
+      language,
+      botName,
+      displayName: botName,
+      description,
+      shortDescription: bot?.shortDescription ?? description,
+      startCommand: bot?.startCommand ?? '',
+    };
   }
 }

--- a/src/app/components/bot-section/bot-section.component.html
+++ b/src/app/components/bot-section/bot-section.component.html
@@ -1,7 +1,10 @@
 <section class="bot-section">
     <div class="section-header">
-        <span class="section-language">{{ language | uppercase }}</span>
-        <h2>{{ capitalize(language) }} Bots</h2>
+        <span class="section-language">{{ resolvedLanguageLabel }}</span>
+        <div class="section-text">
+            <h2>{{ resolvedTitle }}</h2>
+            <p *ngIf="summary" class="section-summary">{{ summary }}</p>
+        </div>
     </div>
     <div class="bot-container">
         <app-bot-card *ngFor="let bot of bots" [bot]="bot" [language]="language"

--- a/src/app/components/bot-section/bot-section.component.scss
+++ b/src/app/components/bot-section/bot-section.component.scss
@@ -37,6 +37,12 @@
     justify-content: space-between;
     flex-wrap: wrap;
     gap: 1rem;
+
+    .section-text {
+      display: flex;
+      flex-direction: column;
+      gap: 0.45rem;
+    }
   }
 
   .section-language {
@@ -63,6 +69,13 @@
     background: linear-gradient(120deg, #38bdf8 0%, #818cf8 50%, #c084fc 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
+  }
+
+  .section-summary {
+    margin: 0;
+    font-size: 0.95rem;
+    color: rgba(226, 232, 240, 0.85);
+    max-width: 640px;
   }
 
   .bot-container {

--- a/src/app/services/bot.service.spec.ts
+++ b/src/app/services/bot.service.spec.ts
@@ -1,0 +1,138 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { BotDetails, BotService, BotsConfiguration } from './bot.service';
+import { APP_BASE_HREF } from '@angular/common';
+import { I18nService } from './i18n.service';
+
+describe('BotService', () => {
+  let service: BotService;
+  let httpMock: HttpTestingController;
+  let i18n: I18nService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [{ provide: APP_BASE_HREF, useValue: '/' }]
+    });
+
+    service = TestBed.inject(BotService);
+    httpMock = TestBed.inject(HttpTestingController);
+    i18n = TestBed.inject(I18nService);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should normalize bots configuration with section translations', () => {
+    let config: BotsConfiguration | undefined;
+
+    service.getBotsConfig().subscribe((value) => {
+      config = value;
+    });
+
+    const request = httpMock.expectOne((req) => req.url.includes('bots.json'));
+    request.flush({
+      sections: {
+        python: {
+          translations: {
+            EN: {
+              title: 'Python Bots',
+              summary: 'Summary'
+            }
+          }
+        }
+      },
+      python: [
+        { botName: 'Zipper', path: 'Zipper.zip' }
+      ]
+    });
+
+    expect(config).toBeDefined();
+    expect(config?.sections['python'].translations['en'].title).toBe('Python Bots');
+    expect(config?.bots['python']?.[0].botName).toBe('Zipper');
+  });
+
+  it('should merge english translations when available', () => {
+    i18n.setLanguage('en');
+
+    let details: BotDetails | undefined;
+    service.getBotDetails({ botName: 'Zipper', language: 'python' }).subscribe((value) => {
+      details = value;
+    });
+
+    const request = httpMock.expectOne((req) => req.url.includes('bots/python/Zipper/Bot.json'));
+    request.flush({
+      botName: 'Zipper',
+      startCommand: 'run zipper',
+      description: 'Base description',
+      translations: {
+        en: {
+          displayName: 'Zipper EN',
+          shortDescription: 'English short description',
+          description: 'English description'
+        },
+        it: {
+          displayName: 'Zipper IT',
+          shortDescription: 'Italiana'
+        }
+      }
+    });
+
+    expect(details).toBeDefined();
+    expect(details?.displayName).toBe('Zipper EN');
+    expect(details?.shortDescription).toBe('English short description');
+    expect(details?.description).toBe('English description');
+  });
+
+  it('should fallback to italian translation when requested language is missing', () => {
+    i18n.setLanguage('fr');
+
+    let details: BotDetails | undefined;
+    service.getBotDetails({ botName: 'Zipper', language: 'python' }).subscribe((value) => {
+      details = value;
+    });
+
+    const request = httpMock.expectOne((req) => req.url.includes('bots/python/Zipper/Bot.json'));
+    request.flush({
+      botName: 'Zipper',
+      startCommand: 'run zipper',
+      description: 'Base description',
+      translations: {
+        it: {
+          displayName: 'Zipper IT',
+          shortDescription: 'Descrizione breve'
+        }
+      }
+    });
+
+    expect(details).toBeDefined();
+    expect(details?.displayName).toBe('Zipper IT');
+    expect(details?.shortDescription).toBe('Descrizione breve');
+    expect(details?.description).toBe('Base description');
+  });
+
+  it('should provide safe fallbacks when translations are missing', () => {
+    i18n.setLanguage('fr');
+
+    let details: BotDetails | undefined;
+    service.getBotDetails({ botName: 'Unknown', language: 'python' }).subscribe((value) => {
+      details = value;
+    });
+
+    const request = httpMock.expectOne((req) => req.url.includes('bots/python/Unknown/Bot.json'));
+    request.flush({
+      botName: 'Unknown',
+      startCommand: '',
+      description: '',
+      translations: {}
+    });
+
+    const uiStrings = i18n.getUiStrings();
+    expect(details).toBeDefined();
+    expect(details?.displayName).toBe('Unknown');
+    expect(details?.shortDescription).toBe(uiStrings.noDescriptionFallback);
+    expect(details?.description).toBe(uiStrings.noDescriptionFallback);
+    expect(details?.startCommand).toBe('');
+  });
+});

--- a/src/app/services/i18n.service.ts
+++ b/src/app/services/i18n.service.ts
@@ -1,0 +1,113 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export interface UiStrings {
+  viewSourceLabel: string;
+  downloadLabel: string;
+  startCommandLabel: string;
+  noDescriptionFallback: string;
+  noStartCommandFallback: string;
+  pdfCtaLabel: string;
+  botsLabel: string;
+  genericErrorTitle: string;
+  genericErrorMessage: string;
+  missingValueFallback: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class I18nService {
+  private readonly defaultLanguage = 'it';
+  private readonly fallbackLanguages = ['it', 'en'];
+  private readonly language$Subject = new BehaviorSubject<string>(this.defaultLanguage);
+
+  readonly language$ = this.language$Subject.asObservable();
+
+  private readonly uiTranslations: Record<string, Partial<UiStrings>> = {
+    it: {
+      viewSourceLabel: 'Vedi sorgente',
+      downloadLabel: 'Scarica',
+      startCommandLabel: 'Comando di avvio',
+      noDescriptionFallback: 'Descrizione non disponibile',
+      noStartCommandFallback: 'Nessun comando disponibile',
+      pdfCtaLabel: 'Vai al convertitore PDF in TXT',
+      botsLabel: 'Bot',
+      genericErrorTitle: 'Ops, qualcosa è andato storto.',
+      genericErrorMessage: 'Nessun bot disponibile.',
+      missingValueFallback: '—'
+    },
+    en: {
+      viewSourceLabel: 'View source',
+      downloadLabel: 'Download',
+      startCommandLabel: 'Start command',
+      noDescriptionFallback: 'No description available',
+      noStartCommandFallback: 'No start commands provided',
+      pdfCtaLabel: 'Go to the PDF to TXT converter',
+      botsLabel: 'Bots',
+      genericErrorTitle: 'Oops, something went wrong.',
+      genericErrorMessage: 'No bots available.',
+      missingValueFallback: '—'
+    }
+  };
+
+  setLanguage(language: string): void {
+    const normalized = this.normalizeLanguage(language);
+    if (normalized && normalized !== this.language$Subject.value) {
+      this.language$Subject.next(normalized);
+    }
+  }
+
+  getCurrentLanguage(): string {
+    return this.language$Subject.value;
+  }
+
+  getFallbackLanguages(preferred?: string): string[] {
+    const normalized = this.normalizeLanguage(preferred ?? this.getCurrentLanguage());
+    const chain = [normalized, ...this.fallbackLanguages];
+    const unique: string[] = [];
+    for (const lang of chain) {
+      if (!lang) {
+        continue;
+      }
+      if (!unique.includes(lang)) {
+        unique.push(lang);
+      }
+    }
+    return unique;
+  }
+
+  getUiStrings(language?: string): UiStrings {
+    const defaults: UiStrings = {
+      viewSourceLabel: 'View source',
+      downloadLabel: 'Download',
+      startCommandLabel: 'Start command',
+      noDescriptionFallback: 'No description available',
+      noStartCommandFallback: 'No start commands provided',
+      pdfCtaLabel: 'Go to the PDF to TXT converter',
+      botsLabel: 'Bots',
+      genericErrorTitle: 'Oops, something went wrong.',
+      genericErrorMessage: 'No bots available.',
+      missingValueFallback: '—'
+    };
+
+    const chain = this.getFallbackLanguages(language);
+    for (let i = chain.length - 1; i >= 0; i--) {
+      const lang = chain[i];
+      const translations = this.uiTranslations[lang];
+      if (!translations) {
+        continue;
+      }
+      Object.assign(defaults, translations);
+    }
+
+    return defaults;
+  }
+
+  private normalizeLanguage(language: string | undefined | null): string {
+    if (!language) {
+      return this.defaultLanguage;
+    }
+    return language.toLowerCase().split('-')[0] || this.defaultLanguage;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce section-level translations in the bots catalog while keeping legacy arrays intact
- add per-bot translation metadata and update services/components to surface localized text with fallbacks
- cover translation merging behaviour with new BotService unit tests

## Testing
- npm test -- --watch=false *(fails: Chrome browser binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f4c58ef5a0832bb92d42256a6cf9a4