### PR TITLE
Handle invalid UTF-8 output in execution logs

### DIFF
--- a/test/backend/server/services/execution_service_test.dart
+++ b/test/backend/server/services/execution_service_test.dart
@@ -1,0 +1,33 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:scriptagher/backend/server/services/execution_service.dart';
+
+void main() {
+  group('ExecutionService.lossyUtf8LineStream', () {
+    test('decodes invalid UTF-8 bytes without throwing', () async {
+      final controller = StreamController<List<int>>();
+      final lines = <String>[];
+      final errors = <Object>[];
+      final completer = Completer<void>();
+
+      ExecutionService.lossyUtf8LineStream(controller.stream).listen(
+        lines.add,
+        onError: errors.add,
+        onDone: () => completer.complete(),
+      );
+
+      controller
+        ..add(<int>[0x61, 0x62])
+        ..add(<int>[0xff, 0x63, 0x0a])
+        ..add(<int>[0x64, 0x65, 0x0a])
+        ..close();
+
+      await completer.future;
+
+      expect(errors, isEmpty);
+      expect(lines, equals(<String>['ab�c', 'de']));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a shared lossyUtf8LineStream helper to tolerate malformed UTF-8 output
- update ExecutionService to reuse the lossy decoder for synchronous and SSE execution logs
- cover malformed output handling with a new unit test

## Testing
- `flutter test test/backend/server/services/execution_service_test.dart` *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f4c67a5b38832bba49ffba7805296c