### PR TITLE
Refactor navigation into left sidebar

### DIFF
--- a/lib/frontend/widgets/components/navigation_sidebar.dart
+++ b/lib/frontend/widgets/components/navigation_sidebar.dart
@@ -1,0 +1,352 @@
+import 'package:flutter/material.dart';
+import 'package:scriptagher/shared/theme/theme_controller.dart';
+
+import 'navigation_menu.dart';
+
+class NavigationSidebar extends StatelessWidget {
+  const NavigationSidebar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final themeController = ThemeController();
+
+    return Container(
+      width: 280,
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        boxShadow: [
+          BoxShadow(
+            color: colorScheme.shadow.withOpacity(0.12),
+            blurRadius: 24,
+            offset: const Offset(0, 8),
+          ),
+        ],
+      ),
+      child: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 24, 24, 12),
+              child: Text(
+                'Navigazione',
+                style: textTheme.titleMedium?.copyWith(
+                  color: colorScheme.onSurface,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: 0.2,
+                ),
+              ),
+            ),
+            const Divider(height: 1),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.symmetric(vertical: 12),
+                children: _buildNavigationItems(context),
+              ),
+            ),
+            const Divider(height: 1),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 20, 24, 24),
+              child: AnimatedBuilder(
+                animation: themeController,
+                builder: (context, _) {
+                  final currentTheme = themeController.currentTheme;
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Tema',
+                        style: textTheme.titleSmall?.copyWith(
+                          color: colorScheme.onSurface,
+                          fontWeight: FontWeight.w600,
+                          letterSpacing: 0.1,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      DecoratedBox(
+                        decoration: BoxDecoration(
+                          color: colorScheme.surfaceVariant.withOpacity(0.6),
+                          borderRadius: BorderRadius.circular(14),
+                          border: Border.all(
+                            color: colorScheme.outlineVariant.withOpacity(0.5),
+                          ),
+                        ),
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 12),
+                          child: DropdownButton<AppTheme>(
+                            value: currentTheme,
+                            isExpanded: true,
+                            borderRadius: BorderRadius.circular(14),
+                            icon: Icon(
+                              Icons.keyboard_arrow_down_rounded,
+                              color: colorScheme.onSurfaceVariant,
+                            ),
+                            underline: const SizedBox.shrink(),
+                            dropdownColor: colorScheme.surface,
+                            onChanged: (theme) {
+                              if (theme != null) {
+                                themeController.setTheme(theme);
+                              }
+                            },
+                            items: AppTheme.values
+                                .map(
+                                  (theme) => DropdownMenuItem<AppTheme>(
+                                    value: theme,
+                                    child: Text(
+                                      _labelForTheme(theme),
+                                      style: textTheme.bodyMedium?.copyWith(
+                                        color: colorScheme.onSurface,
+                                      ),
+                                    ),
+                                  ),
+                                )
+                                .toList(),
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildNavigationItems(BuildContext context) {
+    final currentRoute = ModalRoute.of(context)?.settings.name;
+    return appNavigationEntries
+        .map(
+          (entry) => _NavigationTile(
+            entry: entry,
+            currentRoute: currentRoute,
+          ),
+        )
+        .toList(growable: false);
+  }
+}
+
+class _NavigationTile extends StatelessWidget {
+  const _NavigationTile({
+    required this.entry,
+    required this.currentRoute,
+    this.depth = 0,
+  });
+
+  final NavigationMenuEntry entry;
+  final String? currentRoute;
+  final int depth;
+
+  @override
+  Widget build(BuildContext context) {
+    if (entry.children.isEmpty) {
+      return _NavigationLeafTile(
+        entry: entry,
+        isSelected: entry.route != null && entry.route == currentRoute,
+        depth: depth,
+      );
+    }
+
+    return _NavigationBranchTile(
+      entry: entry,
+      currentRoute: currentRoute,
+      depth: depth,
+    );
+  }
+}
+
+class _NavigationLeafTile extends StatelessWidget {
+  const _NavigationLeafTile({
+    required this.entry,
+    required this.isSelected,
+    required this.depth,
+  });
+
+  final NavigationMenuEntry entry;
+  final bool isSelected;
+  final int depth;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Padding(
+      padding: EdgeInsets.only(left: 12 + depth * 16.0, right: 12, bottom: 4),
+      child: Material(
+        color: isSelected
+            ? colorScheme.primary.withOpacity(0.12)
+            : Colors.transparent,
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          hoverColor: colorScheme.primary.withOpacity(0.08),
+          splashColor: colorScheme.primary.withOpacity(0.12),
+          onTap: entry.route == null
+              ? null
+              : () => Navigator.of(context).pushNamed(entry.route!),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Text(
+              entry.label,
+              style: textTheme.bodyLarge?.copyWith(
+                color: isSelected
+                    ? colorScheme.primary
+                    : colorScheme.onSurface,
+                fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
+                letterSpacing: 0.1,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NavigationBranchTile extends StatelessWidget {
+  const _NavigationBranchTile({
+    required this.entry,
+    required this.currentRoute,
+    required this.depth,
+  });
+
+  final NavigationMenuEntry entry;
+  final String? currentRoute;
+  final int depth;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    final childTiles = entry.children
+        .map(
+          (child) => _NavigationTile(
+            entry: child,
+            currentRoute: currentRoute,
+            depth: depth + 1,
+          ),
+        )
+        .toList(growable: false);
+
+    final hasActiveRoute =
+        currentRoute != null && _entryContainsRoute(entry, currentRoute!);
+    final initiallyExpanded = hasActiveRoute && entry.children.isNotEmpty;
+
+    return _ExpandableSection(
+      label: entry.label,
+      depth: depth,
+      initiallyExpanded: initiallyExpanded,
+      children: childTiles,
+      colorScheme: colorScheme,
+      textTheme: textTheme,
+      isActive: hasActiveRoute,
+    );
+  }
+}
+
+class _ExpandableSection extends StatefulWidget {
+  const _ExpandableSection({
+    required this.label,
+    required this.children,
+    required this.depth,
+    required this.colorScheme,
+    required this.textTheme,
+    required this.isActive,
+    this.initiallyExpanded = false,
+  });
+
+  final String label;
+  final List<Widget> children;
+  final int depth;
+  final ColorScheme colorScheme;
+  final TextTheme textTheme;
+  final bool isActive;
+  final bool initiallyExpanded;
+
+  @override
+  State<_ExpandableSection> createState() => _ExpandableSectionState();
+}
+
+class _ExpandableSectionState extends State<_ExpandableSection> {
+  late bool _expanded;
+
+  @override
+  void initState() {
+    super.initState();
+    _expanded = widget.initiallyExpanded;
+  }
+
+  @override
+  void didUpdateWidget(covariant _ExpandableSection oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.initiallyExpanded != oldWidget.initiallyExpanded) {
+      setState(() {
+        _expanded = widget.initiallyExpanded;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(left: 12 + widget.depth * 16.0, right: 12),
+      child: Material(
+        color: Colors.transparent,
+        child: ExpansionTile(
+          initiallyExpanded: _expanded,
+          onExpansionChanged: (value) => setState(() => _expanded = value),
+          tilePadding: const EdgeInsets.symmetric(horizontal: 4, vertical: 0),
+          childrenPadding: EdgeInsets.zero,
+          iconColor: widget.isActive
+              ? widget.colorScheme.primary
+              : widget.colorScheme.onSurfaceVariant,
+          collapsedIconColor: widget.isActive
+              ? widget.colorScheme.primary
+              : widget.colorScheme.onSurfaceVariant,
+          title: Text(
+            widget.label,
+            style: widget.textTheme.bodyLarge?.copyWith(
+              color: widget.isActive
+                  ? widget.colorScheme.primary
+                  : widget.colorScheme.onSurface,
+              fontWeight: widget.isActive ? FontWeight.w700 : FontWeight.w600,
+              letterSpacing: 0.2,
+            ),
+          ),
+          children: widget.children,
+        ),
+      ),
+    );
+  }
+}
+
+String _labelForTheme(AppTheme theme) {
+  switch (theme) {
+    case AppTheme.light:
+      return 'Tema chiaro';
+    case AppTheme.dark:
+      return 'Tema scuro';
+    case AppTheme.highContrast:
+      return 'Alto contrasto';
+  }
+}
+
+bool _entryContainsRoute(NavigationMenuEntry entry, String route) {
+  if (entry.route == route) {
+    return true;
+  }
+
+  for (final child in entry.children) {
+    if (_entryContainsRoute(child, route)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/lib/frontend/widgets/components/window_title_bar_desktop.dart
+++ b/lib/frontend/widgets/components/window_title_bar_desktop.dart
@@ -3,9 +3,6 @@ import 'dart:io' show Platform;
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:bitsdojo_window/bitsdojo_window.dart';
-import 'package:scriptagher/shared/theme/theme_controller.dart';
-
-import 'navigation_menu.dart';
 
 bool get _isDesktop =>
     !kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS);
@@ -25,110 +22,32 @@ class WindowTitleBar extends StatelessWidget {
     }
 
     final colorScheme = Theme.of(context).colorScheme;
-    final themeController = ThemeController();
+    final textTheme = Theme.of(context).textTheme;
 
     return WindowTitleBarBox(
       child: MoveWindow(
         child: Container(
-          color: colorScheme.surface,
+          decoration: BoxDecoration(
+            color: colorScheme.surface,
+            border: Border(
+              bottom: BorderSide(
+                color: colorScheme.outlineVariant.withOpacity(0.4),
+              ),
+            ),
+          ),
           height: 40,
-          padding: const EdgeInsets.symmetric(horizontal: 12),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              MenuAnchor(
-                alignmentOffset: const Offset(0, 8),
-                builder: (context, controller, child) {
-                  final isOpen = controller.isOpen;
-                  final textStyle = Theme.of(context).textTheme.titleMedium?.copyWith(
-                        color: colorScheme.onSurface,
-                        fontWeight: FontWeight.w600,
-                      );
-
-                  return Tooltip(
-                    message: 'Apri la navigazione',
-                    child: Material(
-                      color: colorScheme.surfaceVariant,
-                      borderRadius: BorderRadius.circular(12),
-                      child: InkWell(
-                        borderRadius: BorderRadius.circular(12),
-                        onTap: () => isOpen ? controller.close() : controller.open(),
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 18,
-                            vertical: 10,
-                          ),
-                          child: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Icon(
-                                Icons.menu,
-                                size: 26,
-                                color: colorScheme.onSurface,
-                              ),
-                              const SizedBox(width: 12),
-                              Text('Menu', style: textStyle),
-                              const SizedBox(width: 8),
-                              Icon(
-                                isOpen
-                                    ? Icons.keyboard_arrow_up
-                                    : Icons.keyboard_arrow_down,
-                                size: 20,
-                                color: colorScheme.onSurface,
-                              ),
-                            ],
-                          ),
-                        ),
-                      ),
-                    ),
-                  );
-                },
-                menuChildren: buildNavigationMenuChildren(context),
-              ),
-              Row(
-                children: [
-                  AnimatedBuilder(
-                    animation: themeController,
-                    builder: (context, _) {
-                      final currentTheme = themeController.currentTheme;
-                      return PopupMenuButton<AppTheme>(
-                        tooltip: 'Cambia tema',
-                        initialValue: currentTheme,
-                        icon: Icon(
-                          Icons.brightness_6,
-                          color: colorScheme.onSurface,
-                        ),
-                        onSelected: (theme) => themeController.setTheme(theme),
-                        itemBuilder: (ctx) => AppTheme.values
-                            .map(
-                              (theme) => CheckedPopupMenuItem<AppTheme>(
-                                value: theme,
-                                checked: theme == currentTheme,
-                                child: Text(_labelForTheme(theme)),
-                              ),
-                            )
-                            .toList(),
-                      );
-                    },
-                  ),
-                  const SizedBox(width: 8),
-                ],
-              ),
-            ],
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          alignment: Alignment.centerLeft,
+          child: Text(
+            'Scriptagher',
+            style: textTheme.titleMedium?.copyWith(
+              color: colorScheme.onSurface,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.2,
+            ),
           ),
         ),
       ),
     );
-  }
-}
-
-String _labelForTheme(AppTheme theme) {
-  switch (theme) {
-    case AppTheme.light:
-      return 'Tema chiaro';
-    case AppTheme.dark:
-      return 'Tema scuro';
-    case AppTheme.highContrast:
-      return 'Alto contrasto';
   }
 }

--- a/lib/frontend/widgets/layout/home_shell_desktop.dart
+++ b/lib/frontend/widgets/layout/home_shell_desktop.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:bitsdojo_window/bitsdojo_window.dart';
 
+import '../components/navigation_sidebar.dart';
 import '../components/window_title_bar.dart';
 import '../pages/home_page_view.dart';
 
@@ -20,11 +21,20 @@ class HomeShell extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final content = Column(
-      children: const [
-        WindowTitleBar(),
-        Expanded(
+    const pageContent = Row(
+      children: [
+        NavigationSidebar(),
+        const Expanded(
           child: HomePage(),
+        ),
+      ],
+    );
+
+    const content = Column(
+      children: [
+        WindowTitleBar(),
+        const Expanded(
+          child: pageContent,
         ),
       ],
     );

--- a/lib/frontend/widgets/layout/home_shell_web.dart
+++ b/lib/frontend/widgets/layout/home_shell_web.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../components/window_title_bar.dart';
+import '../components/navigation_sidebar.dart';
 import '../pages/home_page_view.dart';
 
 class HomeShell extends StatelessWidget {
@@ -8,12 +8,15 @@ class HomeShell extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: PreferredSize(
-        preferredSize: const Size.fromHeight(56),
-        child: const WindowTitleBar(),
+    return const Scaffold(
+      body: Row(
+        children: [
+          NavigationSidebar(),
+          Expanded(
+            child: HomePage(),
+          ),
+        ],
       ),
-      body: const HomePage(),
     );
   }
 }


### PR DESCRIPTION
## Summary
- replace the top navigation menu with a persistent `NavigationSidebar` that stays on the left and includes a dropdown for switching theme
- update the desktop and web shells to lay out content beside the new sidebar so the menu no longer disappears
- simplify the desktop window title bar to a compact header that complements the sidebar

## Testing
- not run (flutter command not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f5a0c66324832bad3b7748e4b9dd3b