### PR TITLE
Fix license URL resolution

### DIFF
--- a/src/app/components/legal/license/license.component.ts
+++ b/src/app/components/legal/license/license.component.ts
@@ -1,6 +1,6 @@
-import { CommonModule } from '@angular/common';
+import { CommonModule, DOCUMENT } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
-import { Component, OnInit } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { finalize } from 'rxjs/operators';
 
 import { TranslatePipe } from '../../../core/i18n/translate.pipe';
@@ -17,11 +17,21 @@ export class LicenseComponent implements OnInit {
   protected isLoading = true;
   protected hasError = false;
 
-  constructor(private readonly http: HttpClient) {}
+  private readonly baseHref: string;
+
+  constructor(
+    private readonly http: HttpClient,
+    @Inject(DOCUMENT) private readonly document: Document
+  ) {
+    const baseElement = this.document?.querySelector?.('base');
+    this.baseHref = baseElement?.href ?? this.document?.baseURI ?? '/';
+  }
 
   ngOnInit(): void {
+    const licenseUrl = new URL('LICENSE', this.baseHref).toString();
+
     this.http
-      .get('/LICENSE', { responseType: 'text' })
+      .get(licenseUrl, { responseType: 'text' })
       .pipe(
         finalize(() => {
           this.isLoading = false;


### PR DESCRIPTION
## Summary
- inject the Angular DOCUMENT into the license component to capture the runtime base href
- build the license request URL relative to the detected base instead of relying on a root-relative path

## Testing
- npm test -- --watch=false *(fails: Chrome browser binary not available in container)*


------
https://chatgpt.com/codex/tasks/task_e_68f5bae1f808832ba0a123318b7f3b6c