### PR TITLE
Improve language switcher select contrast and arrow styling

### DIFF
--- a/src/app/components/header/language-switcher.component.scss
+++ b/src/app/components/header/language-switcher.component.scss
@@ -14,30 +14,34 @@
 
 .language-switcher__select {
   --language-switcher-accent: var(--accent, #38bdf8);
-  --language-switcher-outline: color-mix(in srgb, var(--language-switcher-accent) 30%, transparent);
-  background-color: #0f172a;
-  background-color: color-mix(in srgb, var(--bg-panel, #0f172a) 88%, #020617 12%);
-  border: 1px solid color-mix(in srgb, currentColor 35%, transparent);
+  --language-switcher-outline: color-mix(in srgb, var(--language-switcher-accent) 32%, transparent);
+  --language-switcher-surface-dark: color-mix(in srgb, #0f172a 82%, #020617 18%);
+  --language-switcher-surface-light: color-mix(in srgb, #ffffff 94%, #e2e8f0 6%);
+  background-color: #111b2f;
+  background-color: var(--language-switcher-surface-dark);
+  border: 1px solid color-mix(in srgb, var(--text-primary, #e2e8f0) 28%, transparent);
   border-radius: 999px;
-  padding: 0.4rem 2.4rem 0.4rem 0.85rem;
-  color: var(--text-primary, #0f172a);
+  padding: 0.45rem 2.35rem 0.45rem 0.95rem;
+  color: var(--text-primary, #e2e8f0);
   font-weight: 500;
-  line-height: 1.3;
+  line-height: 1.35;
   appearance: none;
   -webkit-appearance: none;
-  min-width: 8.5rem;
+  min-width: 8.25rem;
   background-image: linear-gradient(45deg, transparent 50%, currentColor 50%),
-    linear-gradient(135deg, currentColor 50%, transparent 50%);
-  background-position: right 1.05rem center, right 0.65rem center;
-  background-size: 0.55rem 0.55rem;
+    linear-gradient(135deg, currentColor 50%, transparent 50%),
+    linear-gradient(to right, color-mix(in srgb, currentColor 28%, transparent), transparent);
+  background-position: right 1.15rem center, right 0.75rem center, right 2.1rem center;
+  background-size: 0.55rem 0.55rem, 0.55rem 0.55rem, 1px 60%;
   background-repeat: no-repeat;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 2px 6px rgba(2, 8, 23, 0.24);
   transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease,
     color 0.2s ease;
 }
 
 .language-switcher__select:hover {
-  border-color: color-mix(in srgb, var(--language-switcher-accent) 40%, currentColor 60%);
+  border-color: color-mix(in srgb, var(--language-switcher-accent) 50%, currentColor 50%);
+  box-shadow: 0 4px 16px rgba(8, 47, 73, 0.24);
 }
 
 .language-switcher__select:focus-visible {
@@ -52,27 +56,25 @@
 }
 
 .language-switcher__select option {
-  color: #0f172a;
-  background-color: #f8fafc;
+  color: #e2e8f0;
+  background-color: #0b1120;
 }
 
 @media (prefers-color-scheme: light) {
   .language-switcher__select {
-    background-color: color-mix(in srgb, #ffffff 92%, #0f172a 8%);
+    background-color: var(--language-switcher-surface-light);
     color: #0f172a;
-    border-color: rgba(15, 23, 42, 0.3);
+    border-color: rgba(15, 23, 42, 0.24);
+    box-shadow: 0 2px 8px rgba(15, 23, 42, 0.12);
+  }
+
+  .language-switcher__select:hover {
+    box-shadow: 0 4px 18px rgba(15, 23, 42, 0.12);
   }
 
   .language-switcher__select option {
     color: #0f172a;
     background-color: #ffffff;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .language-switcher__select option {
-    color: #e2e8f0;
-    background-color: #020817;
   }
 }
 

--- a/src/app/components/header/language-switcher.component.scss
+++ b/src/app/components/header/language-switcher.component.scss
@@ -13,9 +13,69 @@
 }
 
 .language-switcher__select {
-  background: transparent;
-  border: 1px solid currentColor;
+  --language-switcher-accent: var(--accent, #38bdf8);
+  --language-switcher-outline: color-mix(in srgb, var(--language-switcher-accent) 30%, transparent);
+  background-color: #0f172a;
+  background-color: color-mix(in srgb, var(--bg-panel, #0f172a) 88%, #020617 12%);
+  border: 1px solid color-mix(in srgb, currentColor 35%, transparent);
   border-radius: 999px;
-  padding: 0.25rem 0.75rem;
-  color: inherit;
+  padding: 0.4rem 2.4rem 0.4rem 0.85rem;
+  color: var(--text-primary, #0f172a);
+  font-weight: 500;
+  line-height: 1.3;
+  appearance: none;
+  -webkit-appearance: none;
+  min-width: 8.5rem;
+  background-image: linear-gradient(45deg, transparent 50%, currentColor 50%),
+    linear-gradient(135deg, currentColor 50%, transparent 50%);
+  background-position: right 1.05rem center, right 0.65rem center;
+  background-size: 0.55rem 0.55rem;
+  background-repeat: no-repeat;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.12);
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease,
+    color 0.2s ease;
+}
+
+.language-switcher__select:hover {
+  border-color: color-mix(in srgb, var(--language-switcher-accent) 40%, currentColor 60%);
+}
+
+.language-switcher__select:focus-visible {
+  outline: none;
+  border-color: var(--language-switcher-accent);
+  box-shadow: 0 0 0 3px var(--language-switcher-outline);
+}
+
+.language-switcher__select:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.language-switcher__select option {
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+@media (prefers-color-scheme: light) {
+  .language-switcher__select {
+    background-color: color-mix(in srgb, #ffffff 92%, #0f172a 8%);
+    color: #0f172a;
+    border-color: rgba(15, 23, 42, 0.3);
+  }
+
+  .language-switcher__select option {
+    color: #0f172a;
+    background-color: #ffffff;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .language-switcher__select option {
+    color: #e2e8f0;
+    background-color: #020817;
+  }
+}
+
+.language-switcher__select::-ms-expand {
+  display: none;
 }


### PR DESCRIPTION
## Summary
- restyle the header language switcher select with an opaque surface, themed text color, and custom chevron indicator
- add hover and focus-visible treatments that work across light and dark surfaces
- ensure dropdown options inherit accessible foreground/background colors for both color schemes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f5bae50c60832bbf7a4afb8fd48863