### PR TITLE
Add source URLs for bots and surface them in the UI

### DIFF
--- a/public/bots/python/Zipper/Bot.json
+++ b/public/bots/python/Zipper/Bot.json
@@ -3,6 +3,7 @@
   "startCommand": "python3 bots/python/Zipper/Zipper.py",
   "description": "This bot zips a folder into a ZIP archive.",
   "language": "python",
+  "sourceUrl": "https://github.com/scriptagle/scriptagher/tree/main/public/bots/python/Zipper",
   "translations": {
     "it": {
       "displayName": "Zipper",

--- a/public/bots/python/facebook-images-remover/Bot.json
+++ b/public/bots/python/facebook-images-remover/Bot.json
@@ -3,6 +3,7 @@
   "startCommand": "./image-remover.sh",
   "description": "A Python bot that automates the process of deleting Facebook photos by interacting with the web interface using Selenium.",
   "language": "Python",
+  "sourceUrl": "https://github.com/scriptagle/scriptagher/tree/main/public/bots/python/facebook-images-remover",
   "translations": {
     "it": {
       "displayName": "Facebook Images Remover",

--- a/src/app/components/bot-card/bot-card.component.html
+++ b/src/app/components/bot-card/bot-card.component.html
@@ -18,7 +18,11 @@
       >
         {{ 'botCard.pdfCta' | translate }}
       </button>
-      <button class="btn btn-secondary" (click)="openBot()">
+      <button
+        *ngIf="canViewSource"
+        class="btn btn-secondary"
+        (click)="openBot()"
+      >
         {{ bot.actions['viewSource'] || ('botCard.viewSource' | translate) }}
       </button>
       <button class="btn btn-primary" (click)="downloadBot()">

--- a/src/app/components/bot-card/bot-card.component.ts
+++ b/src/app/components/bot-card/bot-card.component.ts
@@ -23,7 +23,15 @@ export class BotCardComponent {
     private translation: TranslationService
   ) {}
 
+  get canViewSource(): boolean {
+    return !!this.bot?.sourceUrl;
+  }
+
   openBot() {
+    if (!this.canViewSource) {
+      return;
+    }
+
     this.bot.language = this.language;
     this.botService.openBot(this.bot);
   }

--- a/src/app/services/bot.service.spec.ts
+++ b/src/app/services/bot.service.spec.ts
@@ -67,6 +67,7 @@ describe('BotService localization', () => {
     request.flush({
       botName: 'Zipper',
       startCommand: 'python3 bots/python/Zipper/Zipper.py',
+      sourceUrl: 'https://example.com/zipper',
       translations: {
         it: { displayName: 'Zipper IT', shortDescription: 'Descrizione IT' },
         en: { displayName: 'Zipper EN', shortDescription: 'English description' }
@@ -76,12 +77,14 @@ describe('BotService localization', () => {
     tick();
     expect(results[0].displayName).toBe('Zipper IT');
     expect(results[0].shortDescription).toBe('Descrizione IT');
+    expect(results[0].sourceUrl).toBe('https://example.com/zipper');
 
     translations.changeLanguage('en');
     tick();
 
     expect(results[results.length - 1].displayName).toBe('Zipper EN');
     expect(results[results.length - 1].shortDescription).toBe('English description');
+    expect(results[results.length - 1].sourceUrl).toBe('https://example.com/zipper');
 
     subscription.unsubscribe();
   }));
@@ -103,5 +106,6 @@ describe('BotService localization', () => {
 
     expect(value.displayName).toBe('Fallback EN');
     expect(value.shortDescription).toBe('English only description');
+    expect(value.sourceUrl).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- add explicit `sourceUrl` metadata to existing bots and propagate it through the bot service
- prefer readable source links when opening bot details and only render the "View source" button when available
- extend unit tests to cover the new metadata and localisation behaviour

## Testing
- npm test -- --watch=false *(fails: Chrome binary is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f5bae27504832bbcd8656d55214f54