### PR TITLE
Add Python badge translations to language dictionaries

### DIFF
--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -26,6 +26,10 @@
     "es": {
       "label": "Spanisch",
       "short": "ES"
+    },
+    "python": {
+      "label": "Python",
+      "short": "PY"
     }
   },
   "languageSwitcher": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -26,6 +26,10 @@
     "es": {
       "label": "Spanish",
       "short": "ES"
+    },
+    "python": {
+      "label": "Python",
+      "short": "PY"
     }
   },
   "languageSwitcher": {

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -26,6 +26,10 @@
     "es": {
       "label": "Español",
       "short": "ES"
+    },
+    "python": {
+      "label": "Python",
+      "short": "PY"
     }
   },
   "languageSwitcher": {

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -26,6 +26,10 @@
     "es": {
       "label": "Spagnolo",
       "short": "ES"
+    },
+    "python": {
+      "label": "Python",
+      "short": "PY"
     }
   },
   "languageSwitcher": {

--- a/src/assets/i18n/no.json
+++ b/src/assets/i18n/no.json
@@ -26,6 +26,10 @@
     "es": {
       "label": "Spansk",
       "short": "ES"
+    },
+    "python": {
+      "label": "Python",
+      "short": "PY"
     }
   },
   "languageSwitcher": {

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -26,6 +26,10 @@
     "es": {
       "label": "Испанский",
       "short": "ES"
+    },
+    "python": {
+      "label": "Python",
+      "short": "PY"
     }
   },
   "languageSwitcher": {


### PR DESCRIPTION
## Summary
- add Python label and short code entries to each localized `languages` dictionary so bot badges resolve correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f5bae44eb4832bb1abd526e3db7ce6