### PR TITLE
fix: import router module in license component

### DIFF
--- a/src/app/components/legal/license/license.component.ts
+++ b/src/app/components/legal/license/license.component.ts
@@ -2,13 +2,14 @@ import { CommonModule, DOCUMENT } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { Component, Inject, OnInit } from '@angular/core';
 import { finalize } from 'rxjs/operators';
+import { RouterModule } from '@angular/router';
 
 import { TranslatePipe } from '../../../core/i18n/translate.pipe';
 
 @Component({
   selector: 'app-license',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [CommonModule, TranslatePipe, RouterModule],
   templateUrl: './license.component.html',
   styleUrls: ['./license.component.scss']
 })


### PR DESCRIPTION
## Summary
- import RouterModule in the license component so the routerLink binding is available

## Testing
- npm test -- --watch=false *(fails: Chrome browser binary not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f5c16dceb8832b88f5b8a2cc4dbd49