### PR TITLE
Update bot source links and repository config

### DIFF
--- a/public/bots/python/Zipper/Bot.json
+++ b/public/bots/python/Zipper/Bot.json
@@ -3,7 +3,7 @@
   "startCommand": "python3 bots/python/Zipper/Zipper.py",
   "description": "This bot zips a folder into a ZIP archive.",
   "language": "python",
-  "sourceUrl": "https://github.com/scriptagle/scriptagher/tree/main/public/bots/python/Zipper",
+  "sourceUrl": "https://github.com/DiegoFCJ/scriptagher/tree/gh-pages/bots/python/Zipper",
   "translations": {
     "it": {
       "displayName": "Zipper",

--- a/public/bots/python/facebook-images-remover/Bot.json
+++ b/public/bots/python/facebook-images-remover/Bot.json
@@ -3,7 +3,7 @@
   "startCommand": "./image-remover.sh",
   "description": "Use the helper shell script to prepare dependencies and launch the Selenium automation that deletes Facebook photos.",
   "language": "Python",
-  "sourceUrl": "https://github.com/scriptagle/scriptagher/tree/main/public/bots/python/facebook-images-remover",
+  "sourceUrl": "https://github.com/DiegoFCJ/scriptagher/tree/gh-pages/bots/python/facebook-images-remover",
   "translations": {
     "it": {
       "displayName": "Facebook Images Remover",

--- a/src/app/services/bot-config.ts
+++ b/src/app/services/bot-config.ts
@@ -8,6 +8,10 @@ export interface BotRuntimeConfig {
    * Absolute URL to the public installers directory published via GitHub Pages.
    */
   publicInstallersBaseUrl?: string;
+  /**
+   * Absolute URL to the base directory that hosts the bot sources (e.g. GitHub tree).
+   */
+  botsRepositoryBaseUrl?: string;
 }
 
 export const BOT_CONFIG = new InjectionToken<BotRuntimeConfig>('BOT_CONFIG', {
@@ -37,11 +41,18 @@ function createBotRuntimeConfig(overrides: Partial<BotRuntimeConfig> = {}): BotR
     readEnvironmentValue('INSTALLERS_BASE_URL') ??
     (owner && repo ? `https://${owner}.github.io/${repo}/installers/` : undefined);
 
+  const botsRepositoryBaseUrl =
+    overrides.botsRepositoryBaseUrl ??
+    readEnvironmentValue('NG_APP_BOTS_REPOSITORY_BASE_URL') ??
+    readEnvironmentValue('BOTS_REPOSITORY_BASE_URL') ??
+    (owner && repo ? `https://github.com/${owner}/${repo}/tree/${branch}/bots/` : undefined);
+
   return {
     githubRepoOwner: owner,
     githubRepoName: repo,
     githubInstallersBranch: branch,
     publicInstallersBaseUrl: installersBaseUrl,
+    botsRepositoryBaseUrl,
   };
 }
 


### PR DESCRIPTION
## Summary
- point bot metadata sourceUrl entries to the gh-pages GitHub tree
- add a configurable botsRepositoryBaseUrl so future links share a single base
- prefer the repository base when normalising relative source URLs in the bot service

## Testing
- CI=1 npm run build -- --progress false

------
https://chatgpt.com/codex/tasks/task_e_68f5c16f6fe4832babf6f7ef467eb0a1