### PR TITLE
Add GitHub repo visibility guard for bot source links

### DIFF
--- a/src/app/components/bot-card/bot-card.component.spec.ts
+++ b/src/app/components/bot-card/bot-card.component.spec.ts
@@ -1,0 +1,63 @@
+import { DestroyRef } from '@angular/core';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
+
+import { BotCardComponent } from './bot-card.component';
+import { BotService, LocalizedBotDetails } from '../../services/bot.service';
+import { TranslationService } from '../../core/i18n/translation.service';
+
+describe('BotCardComponent', () => {
+  class MockDestroyRef implements DestroyRef {
+    private callbacks: Array<() => void> = [];
+
+    onDestroy(callback: () => void): () => void {
+      this.callbacks.push(callback);
+      return () => {
+        this.callbacks = this.callbacks.filter((stored) => stored !== callback);
+      };
+    }
+
+    destroy(): void {
+      this.callbacks.forEach((callback) => callback());
+      this.callbacks = [];
+    }
+  }
+
+  function createComponent(isRepoPublic: boolean): BotCardComponent {
+    const router = jasmine.createSpyObj<Router>('Router', ['navigate']);
+    const botService = {
+      isSourceRepoPublic$: of(isRepoPublic),
+      openBot: jasmine.createSpy('openBot')
+    } as unknown as BotService;
+    const translation = jasmine.createSpyObj('TranslationService', ['translate']) as unknown as TranslationService;
+    const destroyRef = new MockDestroyRef();
+
+    return new BotCardComponent(router, botService, translation, destroyRef);
+  }
+
+  function buildBotDetails(): LocalizedBotDetails {
+    return {
+      botName: 'TestBot',
+      language: 'en',
+      displayName: 'Test Bot',
+      shortDescription: 'A test bot',
+      actions: {},
+      translations: {},
+      sourceUrl: 'https://example.com/repo'
+    } as LocalizedBotDetails;
+  }
+
+  it('allows viewing the source when the repository is public', () => {
+    const component = createComponent(true);
+    component.bot = buildBotDetails();
+
+    expect(component.canViewSource).toBeTrue();
+  });
+
+  it('hides the source when the repository is private', () => {
+    const component = createComponent(false);
+    component.bot = buildBotDetails();
+
+    expect(component.canViewSource).toBeFalse();
+  });
+});

--- a/src/app/components/bot-card/bot-card.component.ts
+++ b/src/app/components/bot-card/bot-card.component.ts
@@ -1,9 +1,10 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, DestroyRef } from '@angular/core';
 import { Router } from '@angular/router';
 import { BotService, LocalizedBotDetails } from '../../services/bot.service';
 import { TranslatePipe } from '../../core/i18n/translate.pipe';
 import { TranslationService } from '../../core/i18n/translation.service';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-bot-card',
@@ -16,15 +17,23 @@ export class BotCardComponent {
   @Input() bot!: LocalizedBotDetails;
   @Input() language: string = '';
   @Output() download = new EventEmitter<void>();
+  private isSourceRepoPublic = true;
 
   constructor(
     private router: Router,
     private botService: BotService,
-    private translation: TranslationService
-  ) {}
+    private translation: TranslationService,
+    destroyRef: DestroyRef
+  ) {
+    this.botService.isSourceRepoPublic$
+      .pipe(takeUntilDestroyed(destroyRef))
+      .subscribe((isPublic) => {
+        this.isSourceRepoPublic = isPublic;
+      });
+  }
 
   get canViewSource(): boolean {
-    return !!this.bot?.sourceUrl;
+    return !!this.bot?.sourceUrl && this.isSourceRepoPublic;
   }
 
   openBot() {


### PR DESCRIPTION
## Summary
- query the GitHub repository metadata once and expose an `isSourceRepoPublic$` flag
- clear bot source URLs when the repository is private and update `BotCardComponent` to respect the flag
- cover public and private repository cases with new unit tests for the service and component

## Testing
- npm test -- --watch=false *(fails: Chrome binary not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f5c16e3e58832b81ec5de0ca7d0a0f