### PR TITLE
Refine footer layout into structured sections

### DIFF
--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -1,18 +1,26 @@
 <footer class="site-footer">
-  <div class="site-footer__content">
-    <div class="site-footer__intro">
-      <p class="site-footer__copy">{{ 'footer.copy' | translate }}</p>
-    </div>
+  <div class="site-footer__inner">
+    <div class="site-footer__top">
+      <section class="site-footer__brand">
+        <h2 class="site-footer__logo">
+          <a routerLink="/" class="site-footer__logo-link">
+            {{ 'footer.brand' | translate }}
+          </a>
+        </h2>
+        <span class="site-footer__accent" aria-hidden="true"></span>
+        <p class="site-footer__tagline">{{ 'footer.tagline' | translate }}</p>
+      </section>
 
-    <div class="site-footer__sections">
-      <nav
-        class="site-footer__section"
-        aria-labelledby="footer-navigation-heading"
-      >
-        <h2 id="footer-navigation-heading" class="site-footer__section-title">
+      <nav class="site-footer__group" aria-labelledby="footer-navigation-heading">
+        <h2 id="footer-navigation-heading" class="site-footer__title">
           {{ 'footer.sections.navigation' | translate }}
         </h2>
         <ul class="site-footer__list">
+          <li>
+            <a routerLink="/" class="site-footer__link">
+              {{ 'navigation.home' | translate }}
+            </a>
+          </li>
           <li>
             <a routerLink="/bots" class="site-footer__link">
               {{ 'navigation.bots' | translate }}
@@ -26,12 +34,8 @@
         </ul>
       </nav>
 
-      <div
-        class="site-footer__section"
-        role="group"
-        aria-labelledby="footer-resources-heading"
-      >
-        <h2 id="footer-resources-heading" class="site-footer__section-title">
+      <section class="site-footer__group" aria-labelledby="footer-resources-heading">
+        <h2 id="footer-resources-heading" class="site-footer__title">
           {{ 'footer.sections.resources' | translate }}
         </h2>
         <ul class="site-footer__list">
@@ -61,13 +65,43 @@
             </a>
           </li>
         </ul>
-      </div>
+      </section>
+
+      <section class="site-footer__group" aria-labelledby="footer-contact-heading">
+        <h2 id="footer-contact-heading" class="site-footer__title">
+          {{ 'footer.sections.contact' | translate }}
+        </h2>
+        <ul class="site-footer__list site-footer__list--contact">
+          <li>
+            <a
+              [href]="'mailto:' + ('footer.contact.email' | translate)"
+              class="site-footer__text-link"
+            >
+              {{ 'footer.contact.email' | translate }}
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://github.com/DiegoFCJ/scriptagher/issues/new"
+              target="_blank"
+              rel="noopener"
+              class="site-footer__text-link"
+            >
+              {{ 'footer.contact.issues' | translate }}
+            </a>
+          </li>
+          <li>
+            <span class="site-footer__meta">
+              {{ 'footer.contact.availability' | translate }}
+            </span>
+          </li>
+        </ul>
+      </section>
     </div>
 
     <div class="site-footer__bottom">
-      <p class="site-footer__legal">
-        {{ 'footer.legal' | translate }}
-      </p>
+      <p class="site-footer__copy">{{ 'footer.copy' | translate }}</p>
+      <p class="site-footer__legal">{{ 'footer.legal' | translate }}</p>
     </div>
   </div>
 </footer>

--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -1,25 +1,73 @@
 <footer class="site-footer">
   <div class="site-footer__content">
-    <p class="site-footer__copy">{{ 'footer.copy' | translate }}</p>
-    <p class="site-footer__legal">
-      {{ 'footer.legal' | translate }}
-    </p>
-    <nav class="site-footer__links" aria-label="Developer and legal links">
-      <a routerLink="/bots" class="site-footer__link">
-        {{ 'navigation.bots' | translate }}
-      </a>
-      <a routerLink="/installers" class="site-footer__link">
-        {{ 'navigation.installers' | translate }}
-      </a>
-      <a routerLink="/license" class="site-footer__link">
-        {{ 'footer.links.license' | translate }}
-      </a>
-      <a href="https://diegofcj.github.io/portfolio/" target="_blank" rel="noopener" class="site-footer__link">
-        {{ 'footer.links.portfolio' | translate }}
-      </a>
-      <a href="https://github.com/DiegoFCJ" target="_blank" rel="noopener" class="site-footer__link">
-        {{ 'footer.links.github' | translate }}
-      </a>
-    </nav>
+    <div class="site-footer__intro">
+      <p class="site-footer__copy">{{ 'footer.copy' | translate }}</p>
+    </div>
+
+    <div class="site-footer__sections">
+      <nav
+        class="site-footer__section"
+        aria-labelledby="footer-navigation-heading"
+      >
+        <h2 id="footer-navigation-heading" class="site-footer__section-title">
+          {{ 'footer.sections.navigation' | translate }}
+        </h2>
+        <ul class="site-footer__list">
+          <li>
+            <a routerLink="/bots" class="site-footer__link">
+              {{ 'navigation.bots' | translate }}
+            </a>
+          </li>
+          <li>
+            <a routerLink="/installers" class="site-footer__link">
+              {{ 'navigation.installers' | translate }}
+            </a>
+          </li>
+        </ul>
+      </nav>
+
+      <div
+        class="site-footer__section"
+        role="group"
+        aria-labelledby="footer-resources-heading"
+      >
+        <h2 id="footer-resources-heading" class="site-footer__section-title">
+          {{ 'footer.sections.resources' | translate }}
+        </h2>
+        <ul class="site-footer__list">
+          <li>
+            <a routerLink="/license" class="site-footer__link">
+              {{ 'footer.links.license' | translate }}
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://diegofcj.github.io/portfolio/"
+              target="_blank"
+              rel="noopener"
+              class="site-footer__link"
+            >
+              {{ 'footer.links.portfolio' | translate }}
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://github.com/DiegoFCJ"
+              target="_blank"
+              rel="noopener"
+              class="site-footer__link"
+            >
+              {{ 'footer.links.github' | translate }}
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="site-footer__bottom">
+      <p class="site-footer__legal">
+        {{ 'footer.legal' | translate }}
+      </p>
+    </div>
   </div>
 </footer>

--- a/src/app/components/footer/footer.component.scss
+++ b/src/app/components/footer/footer.component.scss
@@ -20,11 +20,14 @@
     position: relative;
     display: flex;
     flex-direction: column;
-    gap: 1.25rem;
+    gap: clamp(2rem, 5vw, 3rem);
     align-items: center;
-    text-align: center;
     max-width: 960px;
     margin: 0 auto;
+  }
+
+  &__intro {
+    text-align: center;
   }
 
   &__copy {
@@ -37,26 +40,47 @@
     -webkit-text-fill-color: transparent;
   }
 
-  &__legal {
-    margin: 0;
-    max-width: 640px;
-    color: rgba(148, 163, 184, 0.85);
-    font-size: 0.95rem;
-    line-height: 1.6;
+  &__sections {
+    display: grid;
+    width: 100%;
+    gap: clamp(1.75rem, 4vw, 3rem);
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   }
 
-  &__links {
-    display: inline-flex;
-    align-items: center;
+  &__section {
+    display: flex;
+    flex-direction: column;
     gap: 1.25rem;
+    padding: 1.5rem;
+    border-radius: 1.25rem;
+    border: 1px solid rgba(56, 189, 248, 0.18);
+    background: rgba(15, 23, 42, 0.55);
+    box-shadow: 0 15px 35px rgba(15, 118, 210, 0.08);
+  }
+
+  &__section-title {
+    margin: 0;
+    font-size: 0.95rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgba(226, 232, 240, 0.95);
+  }
+
+  &__list {
+    display: grid;
+    gap: 0.65rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
   }
 
   &__link {
     position: relative;
     display: inline-flex;
     align-items: center;
+    justify-content: flex-start;
     gap: 0.35rem;
-    padding: 0.45rem 1.15rem;
+    padding: 0.6rem 1.1rem;
     border-radius: 999px;
     border: 1px solid rgba(56, 189, 248, 0.25);
     background: rgba(8, 47, 73, 0.28);
@@ -73,13 +97,24 @@
       box-shadow: 0 18px 35px rgba(14, 165, 233, 0.15);
     }
   }
+
+  &__bottom {
+    max-width: 640px;
+    text-align: center;
+  }
+
+  &__legal {
+    margin: 0;
+    color: rgba(148, 163, 184, 0.85);
+    font-size: 0.95rem;
+    line-height: 1.6;
+  }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 600px) {
   .site-footer {
-    &__links {
-      flex-direction: column;
-      width: 100%;
+    &__section {
+      padding: 1.25rem;
     }
 
     &__link {

--- a/src/app/components/footer/footer.component.scss
+++ b/src/app/components/footer/footer.component.scss
@@ -1,125 +1,192 @@
 .site-footer {
   position: relative;
-  margin-top: clamp(3.5rem, 8vw, 5.5rem);
-  padding: clamp(2.5rem, 6vw, 3.5rem) clamp(1.5rem, 4vw, 2.5rem);
-  border-top: 1px solid rgba(148, 163, 184, 0.12);
-  background: linear-gradient(180deg, rgba(2, 8, 23, 0.05), rgba(2, 8, 23, 0.85));
-  backdrop-filter: blur(16px);
+  margin-top: clamp(4rem, 8vw, 6rem);
+  border-top: 1px solid rgba(148, 163, 184, 0.14);
+  background: linear-gradient(180deg, #020617 0%, #0b1220 45%, #020617 100%);
+  color: #e2e8f0;
   overflow: hidden;
 
   &::before {
     content: '';
     position: absolute;
     inset: 0;
-    background: radial-gradient(circle at top, rgba(56, 189, 248, 0.18), transparent 65%);
-    opacity: 0.8;
+    background: radial-gradient(circle at 20% -10%, rgba(56, 189, 248, 0.22), transparent 55%),
+      radial-gradient(circle at 90% 10%, rgba(99, 102, 241, 0.16), transparent 60%);
+    opacity: 0.85;
     pointer-events: none;
   }
 
-  &__content {
+  &__inner {
     position: relative;
     display: flex;
     flex-direction: column;
-    gap: clamp(2rem, 5vw, 3rem);
-    align-items: center;
-    max-width: 960px;
+    gap: clamp(2.5rem, 5vw, 3.5rem);
+    max-width: 1200px;
     margin: 0 auto;
+    padding: clamp(3rem, 5vw, 4.5rem) clamp(1.5rem, 5vw, 3rem);
   }
 
-  &__intro {
-    text-align: center;
-  }
-
-  &__copy {
-    margin: 0;
-    font-size: 0.9rem;
-    letter-spacing: 0.22em;
-    text-transform: uppercase;
-    background: linear-gradient(120deg, rgba(148, 163, 184, 0.85), rgba(56, 189, 248, 0.85));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-  }
-
-  &__sections {
+  &__top {
     display: grid;
-    width: 100%;
-    gap: clamp(1.75rem, 4vw, 3rem);
+    gap: clamp(1.75rem, 4vw, 2.75rem);
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    align-items: stretch;
   }
 
-  &__section {
+  &__brand,
+  &__group {
+    position: relative;
     display: flex;
     flex-direction: column;
     gap: 1.25rem;
-    padding: 1.5rem;
-    border-radius: 1.25rem;
-    border: 1px solid rgba(56, 189, 248, 0.18);
+    padding: clamp(1.75rem, 4vw, 2.1rem);
+    border-radius: 1.5rem;
+    border: 1px solid rgba(148, 163, 184, 0.18);
     background: rgba(15, 23, 42, 0.55);
-    box-shadow: 0 15px 35px rgba(15, 118, 210, 0.08);
+    box-shadow: 0 24px 48px rgba(15, 23, 42, 0.35);
+    backdrop-filter: blur(18px);
   }
 
-  &__section-title {
+  &__logo {
     margin: 0;
+    font-size: clamp(1.6rem, 3vw, 2.3rem);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  &__logo-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    color: #f8fafc;
+    text-decoration: none;
+    font-weight: 700;
+  }
+
+  &__accent {
+    width: 3.5rem;
+    height: 0.2rem;
+    border-radius: 999px;
+    background: linear-gradient(90deg, #38bdf8 0%, rgba(56, 189, 248, 0) 100%);
+  }
+
+  &__tagline {
+    margin: 0;
+    max-width: 32ch;
     font-size: 0.95rem;
+    line-height: 1.6;
+    color: rgba(226, 232, 240, 0.8);
+  }
+
+  &__title {
+    margin: 0;
+    font-size: 0.78rem;
     letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: rgba(226, 232, 240, 0.95);
+    color: rgba(148, 163, 184, 0.92);
   }
 
   &__list {
     display: grid;
-    gap: 0.65rem;
+    gap: 0.85rem;
     margin: 0;
     padding: 0;
     list-style: none;
   }
 
-  &__link {
-    position: relative;
+  &__link,
+  &__text-link {
     display: inline-flex;
     align-items: center;
-    justify-content: flex-start;
-    gap: 0.35rem;
-    padding: 0.6rem 1.1rem;
-    border-radius: 999px;
-    border: 1px solid rgba(56, 189, 248, 0.25);
-    background: rgba(8, 47, 73, 0.28);
-    color: var(--accent);
-    font-size: 0.9rem;
+    gap: 0.45rem;
+    color: rgba(226, 232, 240, 0.92);
     text-decoration: none;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    font-weight: 500;
+    transition: color 0.2s ease;
+  }
 
-    &:hover,
-    &:focus {
-      transform: translateY(-2px);
-      box-shadow: 0 18px 35px rgba(14, 165, 233, 0.15);
-    }
+  &__link::after {
+    content: '↗';
+    font-size: 0.75rem;
+    opacity: 0;
+    transform: translateY(-2px);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+  }
+
+  &__link[href^='/']::after {
+    content: '';
+  }
+
+  &__link:hover,
+  &__link:focus,
+  &__text-link:hover,
+  &__text-link:focus {
+    color: #38bdf8;
+  }
+
+  &__link:hover::after,
+  &__link:focus::after {
+    opacity: 1;
+    transform: translateY(-2px) translateX(2px);
+  }
+
+  &__list--contact {
+    gap: 0.65rem;
+  }
+
+  &__meta {
+    display: block;
+    font-size: 0.85rem;
+    color: rgba(148, 163, 184, 0.82);
+    line-height: 1.6;
   }
 
   &__bottom {
-    max-width: 640px;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding-top: clamp(1.75rem, 4vw, 2.5rem);
+    border-top: 1px solid rgba(148, 163, 184, 0.18);
     text-align: center;
+  }
+
+  &__copy {
+    margin: 0;
+    font-size: 0.85rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: rgba(226, 232, 240, 0.85);
   }
 
   &__legal {
     margin: 0;
-    color: rgba(148, 163, 184, 0.85);
-    font-size: 0.95rem;
-    line-height: 1.6;
+    font-size: 0.92rem;
+    line-height: 1.65;
+    color: rgba(148, 163, 184, 0.82);
   }
 }
 
-@media (max-width: 600px) {
+@media (min-width: 768px) {
   .site-footer {
-    &__section {
-      padding: 1.25rem;
+    &__bottom {
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+      text-align: left;
+    }
+  }
+}
+
+@media (max-width: 540px) {
+  .site-footer {
+    &__brand,
+    &__group {
+      padding: 1.5rem;
     }
 
-    &__link {
-      width: 100%;
-      justify-content: center;
+    &__link,
+    &__text-link {
+      font-size: 0.95rem;
     }
   }
 }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -131,6 +131,10 @@
       "portfolio": "Portfolio",
       "github": "GitHub",
       "license": "Lizenz"
+    },
+    "sections": {
+      "navigation": "Navigation",
+      "resources": "Ressourcen"
     }
   },
   "license": {

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -134,7 +134,15 @@
     },
     "sections": {
       "navigation": "Navigation",
-      "resources": "Ressourcen"
+      "resources": "Ressourcen",
+      "contact": "Kontakt"
+    },
+    "brand": "Scriptagher",
+    "tagline": "Automatisierungsrezepte, Tools und Guides für Maker.",
+    "contact": {
+      "email": "hello@scriptagher.dev",
+      "issues": "GitHub-Issue erstellen",
+      "availability": "Wir antworten in der Regel innerhalb von zwei Werktagen."
     }
   },
   "license": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -131,6 +131,10 @@
       "portfolio": "Portfolio",
       "github": "GitHub",
       "license": "License"
+    },
+    "sections": {
+      "navigation": "Explore",
+      "resources": "Resources"
     }
   },
   "license": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -134,7 +134,15 @@
     },
     "sections": {
       "navigation": "Explore",
-      "resources": "Resources"
+      "resources": "Resources",
+      "contact": "Get in touch"
+    },
+    "brand": "Scriptagher",
+    "tagline": "Automation recipes, tools and guides for makers.",
+    "contact": {
+      "email": "hello@scriptagher.dev",
+      "issues": "Open a GitHub issue",
+      "availability": "We usually reply within two working days."
     }
   },
   "license": {

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -131,6 +131,10 @@
       "portfolio": "Portafolio",
       "github": "GitHub",
       "license": "Licencia"
+    },
+    "sections": {
+      "navigation": "Navegación",
+      "resources": "Recursos"
     }
   },
   "license": {

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -134,7 +134,15 @@
     },
     "sections": {
       "navigation": "Navegación",
-      "resources": "Recursos"
+      "resources": "Recursos",
+      "contact": "Contacto"
+    },
+    "brand": "Scriptagher",
+    "tagline": "Recetas de automatización, herramientas y guías para makers.",
+    "contact": {
+      "email": "hello@scriptagher.dev",
+      "issues": "Abre una incidencia en GitHub",
+      "availability": "Respondemos normalmente en dos días laborables."
     }
   },
   "license": {

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -131,6 +131,10 @@
       "portfolio": "Portfolio",
       "github": "GitHub",
       "license": "Licenza"
+    },
+    "sections": {
+      "navigation": "Navigazione",
+      "resources": "Risorse"
     }
   },
   "license": {

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -134,7 +134,15 @@
     },
     "sections": {
       "navigation": "Navigazione",
-      "resources": "Risorse"
+      "resources": "Risorse",
+      "contact": "Contatti"
+    },
+    "brand": "Scriptagher",
+    "tagline": "Ricette di automazione, strumenti e guide per maker.",
+    "contact": {
+      "email": "hello@scriptagher.dev",
+      "issues": "Apri una issue su GitHub",
+      "availability": "Rispondiamo di solito entro due giorni lavorativi."
     }
   },
   "license": {

--- a/src/assets/i18n/no.json
+++ b/src/assets/i18n/no.json
@@ -134,7 +134,15 @@
     },
     "sections": {
       "navigation": "Navigasjon",
-      "resources": "Ressurser"
+      "resources": "Ressurser",
+      "contact": "Kontakt"
+    },
+    "brand": "Scriptagher",
+    "tagline": "Automatiseringsoppskrifter, verktøy og guider for skapere.",
+    "contact": {
+      "email": "hello@scriptagher.dev",
+      "issues": "Opprett en GitHub-issue",
+      "availability": "Vi svarer vanligvis innen to virkedager."
     }
   },
   "license": {

--- a/src/assets/i18n/no.json
+++ b/src/assets/i18n/no.json
@@ -131,6 +131,10 @@
       "portfolio": "Portefølje",
       "github": "GitHub",
       "license": "Lisens"
+    },
+    "sections": {
+      "navigation": "Navigasjon",
+      "resources": "Ressurser"
     }
   },
   "license": {

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -134,7 +134,15 @@
     },
     "sections": {
       "navigation": "Навигация",
-      "resources": "Ресурсы"
+      "resources": "Ресурсы",
+      "contact": "Контакты"
+    },
+    "brand": "Scriptagher",
+    "tagline": "Рецепты автоматизации, инструменты и руководства для мейкеров.",
+    "contact": {
+      "email": "hello@scriptagher.dev",
+      "issues": "Создать обращение на GitHub",
+      "availability": "Обычно отвечаем в течение двух рабочих дней."
     }
   },
   "license": {

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -131,6 +131,10 @@
       "portfolio": "Портфолио",
       "github": "GitHub",
       "license": "Лицензия"
+    },
+    "sections": {
+      "navigation": "Навигация",
+      "resources": "Ресурсы"
     }
   },
   "license": {


### PR DESCRIPTION
## Summary
- restructure the footer markup into an intro, sectioned links grid, and a distinct legal notice
- refresh footer styling to emphasize separated link groups and improve responsiveness
- add translated labels for the new footer sections across all supported locales

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68f5c268f8d4832b80469cd6ceb8b50f