### PR TITLE
Add outline mini droid icon asset

### DIFF
--- a/assets/icons/scriptagher_mini_droid.svg
+++ b/assets/icons/scriptagher_mini_droid.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <g stroke="#F8FAFC" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="18" y="12" width="28" height="20" rx="6"/>
+    <path d="M28 18h-2.2c-1.8 0-3.3 1.3-3.3 3v1.3c0 1-0.6 1.8-1.5 2.2 0.9 0.4 1.5 1.2 1.5 2.2v1.3c0 1.7 1.5 3 3.3 3H28"/>
+    <path d="M36 18h2.2c1.8 0 3.3 1.3 3.3 3v1.3c0 1 0.6 1.8 1.5 2.2-0.9 0.4-1.5 1.2-1.5 2.2v1.3c0 1.7-1.5 3-3.3 3H36"/>
+    <path d="M32 8v4"/>
+    <circle cx="32" cy="8" r="3" fill="#F8FAFC" stroke="none"/>
+    <path d="M24 32h16v16c0 4.4-3.6 8-8 8s-8-3.6-8-8V32z"/>
+    <path d="M40 38h4.5c2.2 0 4 1.8 4 4s-1.8 4-4 4h-1.3"/>
+  </g>
+</svg>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,3 +32,4 @@ flutter:
   uses-material-design: true
   assets:
     - assets/icons/scriptagher_logo.svg
+    - assets/icons/scriptagher_mini_droid.svg


### PR DESCRIPTION
## Summary
- add the outline version of the mini droid icon with monochrome strokes and simplified geometry
- register the new asset in the Flutter configuration for use in the app

## Testing
- not run (Flutter SDK unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68f62929ae74832b9c6c12d7941dca2d