### PR TITLE
Add monochrome mini droid branding icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 ## Descrizione
 Questo progetto è una semplice applicazione mobile/desktop/web sviluppata con Flutter. Flutter è un framework open-source che permette di creare app per dispositivi mobili, desktop e web da una singola base di codice. Questo README include informazioni su come eseguire, configurare, testare e distribuire l'app su diverse piattaforme (Android, iOS, Linux, Windows e altre).
 
+## Risorse grafiche
+
+- `assets/icons/scriptagher_mini_droid.svg`: icona monocromatica del mini droid utilizzata nei componenti `WindowTitleBar` desktop e web per mostrare il marchio dell'app.
+- `web/favicon.svg`: variante solo testa impiegata come favicon tramite `web/index.html` e dichiarata nel `web/manifest.json`.
+
 ## Bot per Scriptagher
 
 Scriptagher consente di scaricare, installare ed eseguire bot provenienti da marketplace, repository locali o filesystem.

--- a/assets/icons/scriptagher_mini_droid.svg
+++ b/assets/icons/scriptagher_mini_droid.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Scriptagher Mini Droid</title>
+  <desc id="desc">Monochrome mini droid with bracket face, cylindrical body, hook arm and chest LED.</desc>
+  <g fill="none" stroke="#F8FAFC" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="12" y="8" width="40" height="22" rx="7" />
+    <path d="M26 19h-3c-2 0-3 1.5-3 3.5v2c0 2-1 3.5-3 3.5h-3" />
+    <path d="M38 19h3c2 0 3 1.5 3 3.5v2c0 2 1 3.5 3 3.5h3" />
+    <line x1="32" y1="30" x2="32" y2="34" />
+    <rect x="23" y="34" width="18" height="20" rx="9" />
+    <path d="M41 40h9a5.5 5.5 0 0 1 0 11h-4l3 3" />
+  </g>
+  <circle cx="32" cy="44" r="4" fill="#F8FAFC" />
+</svg>

--- a/lib/frontend/widgets/components/mini_droid_brand.dart
+++ b/lib/frontend/widgets/components/mini_droid_brand.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+const String _miniDroidAsset = 'assets/icons/scriptagher_mini_droid.svg';
+
+/// Renders the full-body Scriptagher mini droid icon.
+///
+/// This widget centralises the usage of [_miniDroidAsset] so that both the
+/// desktop and web chrome reuse the same branding asset.
+class MiniDroidBrandMark extends StatelessWidget {
+  const MiniDroidBrandMark({super.key, this.size = 28, this.semanticLabel});
+
+  final double size;
+  final String? semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.onSurface;
+    return SvgPicture.asset(
+      _miniDroidAsset,
+      width: size,
+      height: size,
+      colorFilter: ColorFilter.mode(color, BlendMode.srcIn),
+      semanticsLabel: semanticLabel ?? 'Scriptagher mini droid',
+    );
+  }
+}

--- a/lib/frontend/widgets/components/navigation_sidebar.dart
+++ b/lib/frontend/widgets/components/navigation_sidebar.dart
@@ -73,36 +73,39 @@ class NavigationSidebar extends StatelessWidget {
                             color: colorScheme.outlineVariant.withOpacity(0.5),
                           ),
                         ),
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 12),
-                          child: DropdownButton<AppTheme>(
-                            value: currentTheme,
-                            isExpanded: true,
-                            borderRadius: BorderRadius.circular(14),
-                            icon: Icon(
-                              Icons.keyboard_arrow_down_rounded,
-                              color: colorScheme.onSurfaceVariant,
-                            ),
-                            underline: const SizedBox.shrink(),
-                            dropdownColor: colorScheme.surface,
-                            onChanged: (theme) {
-                              if (theme != null) {
-                                themeController.setTheme(theme);
-                              }
-                            },
-                            items: AppTheme.values
-                                .map(
-                                  (theme) => DropdownMenuItem<AppTheme>(
-                                    value: theme,
-                                    child: Text(
-                                      _labelForTheme(theme),
-                                      style: textTheme.bodyMedium?.copyWith(
-                                        color: colorScheme.onSurface,
+                        child: Material(
+                          type: MaterialType.transparency,
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 12),
+                            child: DropdownButton<AppTheme>(
+                              value: currentTheme,
+                              isExpanded: true,
+                              borderRadius: BorderRadius.circular(14),
+                              icon: Icon(
+                                Icons.keyboard_arrow_down_rounded,
+                                color: colorScheme.onSurfaceVariant,
+                              ),
+                              underline: const SizedBox.shrink(),
+                              dropdownColor: colorScheme.surface,
+                              onChanged: (theme) {
+                                if (theme != null) {
+                                  themeController.setTheme(theme);
+                                }
+                              },
+                              items: AppTheme.values
+                                  .map(
+                                    (theme) => DropdownMenuItem<AppTheme>(
+                                      value: theme,
+                                      child: Text(
+                                        _labelForTheme(theme),
+                                        style: textTheme.bodyMedium?.copyWith(
+                                          color: colorScheme.onSurface,
+                                        ),
                                       ),
                                     ),
-                                  ),
-                                )
-                                .toList(),
+                                  )
+                                  .toList(),
+                            ),
                           ),
                         ),
                       ),

--- a/lib/frontend/widgets/components/window_title_bar_desktop.dart
+++ b/lib/frontend/widgets/components/window_title_bar_desktop.dart
@@ -3,6 +3,7 @@ import 'dart:io' show Platform;
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:bitsdojo_window/bitsdojo_window.dart';
+import 'mini_droid_brand.dart';
 
 bool get _isDesktop =>
     !kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS);
@@ -38,13 +39,20 @@ class WindowTitleBar extends StatelessWidget {
           height: 40,
           padding: const EdgeInsets.symmetric(horizontal: 16),
           alignment: Alignment.centerLeft,
-          child: Text(
-            'Scriptagher',
-            style: textTheme.titleMedium?.copyWith(
-              color: colorScheme.onSurface,
-              fontWeight: FontWeight.w600,
-              letterSpacing: 0.2,
-            ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              MiniDroidBrandMark(size: 24, semanticLabel: 'Scriptagher mini droid icon'),
+              const SizedBox(width: 12),
+              Text(
+                'Scriptagher',
+                style: textTheme.titleMedium?.copyWith(
+                  color: colorScheme.onSurface,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: 0.2,
+                ),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/frontend/widgets/components/window_title_bar_web.dart
+++ b/lib/frontend/widgets/components/window_title_bar_web.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:scriptagher/shared/theme/theme_controller.dart';
 
+import 'mini_droid_brand.dart';
 import 'navigation_menu.dart';
 
 class WindowTitleBar extends StatelessWidget {
@@ -10,12 +11,24 @@ class WindowTitleBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final themeController = ThemeController();
+    final textTheme = Theme.of(context).textTheme;
 
     return Container(
       color: colorScheme.surface,
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       child: Row(
         children: [
+          MiniDroidBrandMark(size: 24),
+          const SizedBox(width: 12),
+          Text(
+            'Scriptagher',
+            style: textTheme.titleMedium?.copyWith(
+              color: colorScheme.onSurface,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.2,
+            ),
+          ),
+          const SizedBox(width: 20),
           MenuAnchor(
             alignmentOffset: const Offset(0, 8),
             builder: (context, controller, child) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_svg: ^2.0.9
   sqflite: ^2.4.2
   sqflite_common_ffi: ^2.3.5
   logging: ^1.3.0
@@ -31,4 +32,6 @@ dev_dependencies:
 flutter:
   uses-material-design: true
   assets:
+    # Full-body mini droid icon used in navigation chrome and tooltips.
+    - assets/icons/scriptagher_mini_droid.svg
     - assets/icons/scriptagher_logo.svg

--- a/web/favicon.svg
+++ b/web/favicon.svg
@@ -1,16 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
-  <title id="title">Scriptagher Favicon</title>
-  <desc id="desc">Gradient tile with stylised S</desc>
-  <defs>
-    <linearGradient id="fav-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0F172A" />
-      <stop offset="50%" stop-color="#1E3A8A" />
-      <stop offset="100%" stop-color="#0EA5E9" />
-    </linearGradient>
-  </defs>
-  <rect width="64" height="64" rx="14" fill="url(#fav-gradient)" />
-  <path
-    fill="#F8FAFC"
-    d="M19 19c6-7 17-9 26-7 7 2 12 6 14 11 3 9-3 16-16 19-11 3-14 6-12 10 1 4 7 6 13 6 6 0 11-2 14-6l8 7c-6 7-13 11-23 12-16 1-30-8-31-22-1-9 5-16 17-19 10-3 14-6 12-10s-7-5-11-4c-5 1-9 4-12 8z"
-  />
+  <title id="title">Scriptagher Mini Droid Head</title>
+  <desc id="desc">Rounded rectangular droid head with centered braces and a glowing LED.</desc>
+  <g fill="none" stroke="#F8FAFC" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="8" y="10" width="48" height="32" rx="11" />
+    <path d="M30 22h-5c-3 0-4 2-4 4.5v2c0 2.5-1 4.5-4 4.5h-5" />
+    <path d="M34 22h5c3 0 4 2 4 4.5v2c0 2.5 1 4.5 4 4.5h5" />
+  </g>
+  <circle cx="32" cy="44" r="5" fill="#F8FAFC" />
 </svg>

--- a/web/index.html
+++ b/web/index.html
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Scriptagher</title>
     <link rel="manifest" href="manifest.json">
+    <!-- Head-only mini droid favicon variant -->
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <meta name="theme-color" content="#0175C2">
   </head>


### PR DESCRIPTION
## Summary
- add a monochrome mini droid SVG asset and update the favicon with the head-only variant
- integrate the mini droid brand mark into the desktop and web window title bars and document asset usage
- add flutter_svg to render the SVG asset inside the app shell

## Testing
- not run (environment lacks Flutter/Dart SDK)


------
https://chatgpt.com/codex/tasks/task_e_68f6c782ae6c832b9dec8bbbbb79fa90