### PR TITLE
Anchor footer at the bottom of routed pages

### DIFF
--- a/src/app/components/bot-list/bot-list.component.scss
+++ b/src/app/components/bot-list/bot-list.component.scss
@@ -1,8 +1,11 @@
 :host {
-  display: block;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 main.bot-list {
+  flex: 1 0 auto;
   position: relative;
   padding-bottom: clamp(3rem, 8vw, 5rem);
   display: flex;

--- a/src/app/pages/bot-detail/bot-detail-page.component.scss
+++ b/src/app/pages/bot-detail/bot-detail-page.component.scss
@@ -1,4 +1,11 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
 .bot-detail-page {
+  flex: 1 0 auto;
   width: min(960px, 100% - 3rem);
   margin: clamp(2.5rem, 6vw, 4rem) auto clamp(3rem, 7vw, 5rem);
   display: flex;

--- a/src/app/pages/home/home-page.component.scss
+++ b/src/app/pages/home/home-page.component.scss
@@ -1,8 +1,11 @@
 :host {
-  display: block;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 .home-page {
+  flex: 1 0 auto;
   display: flex;
   flex-direction: column;
   gap: clamp(3rem, 8vw, 5rem);

--- a/src/app/pages/installers/installers-page.component.scss
+++ b/src/app/pages/installers/installers-page.component.scss
@@ -1,4 +1,11 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
 .installers-page {
+  flex: 1 0 auto;
   width: min(1100px, 100% - 3rem);
   margin: clamp(2.5rem, 6vw, 3.5rem) auto clamp(3rem, 7vw, 4.5rem);
   display: flex;


### PR DESCRIPTION
## Summary
- switch routed page hosts to flex column layouts with a full viewport height so the footer stays anchored to the bottom
- let the main content areas on the home, bots, installers, and bot detail pages expand to fill the remaining height

## Testing
- Not Run (script missing): npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f753b7c7cc832ba9c7edbc30eaf1b3