### PR TITLE
Add shared API base URL resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ Il server backend Shelf esposto su `http://localhost:8080` gestisce automaticame
 | `POST` | `/bots/{language}/{botName}/kill` | Termina forzatamente il processo del bot. |
 | `POST` | `/bots/upload` | Carica un archivio ZIP contenente un bot locale. |
 
+### Configurare un endpoint API remoto
+
+Per le build non desktop (ad esempio Chrome o dispositivi mobili) l'app utilizza una variabile di compilazione `API_BASE_URL` per determinare l'endpoint dell'API. Se non viene fornita, viene usato automaticamente l'`origin` della pagina web oppure `http://localhost:8080` sulle piattaforme desktop. Per puntare a un backend remoto, passa il valore desiderato tramite `--dart-define` al momento dell'esecuzione:
+
+```sh
+flutter run -d chrome --dart-define=API_BASE_URL=https://your-host.example
+```
+
+Il valore viene letto all'avvio dall'helper condiviso `ApiBaseUrl.resolve()`, garantendo URL coerenti per download, log e upload.
+
 ## Struttura del Progetto
 La struttura di base di un'app Flutter è la seguente:
 

--- a/lib/frontend/services/bot_download_service.dart
+++ b/lib/frontend/services/bot_download_service.dart
@@ -1,13 +1,14 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import 'package:scriptagher/shared/config/api_base_url.dart';
 
 import '../models/bot.dart';
 
 class BotDownloadService {
-  BotDownloadService(
-      {this.baseUrl = 'http://localhost:8080', http.Client? httpClient})
-      : _httpClient = httpClient ?? http.Client();
+  BotDownloadService({String? baseUrl, http.Client? httpClient})
+      : baseUrl = baseUrl ?? ApiBaseUrl.resolve(),
+        _httpClient = httpClient ?? http.Client();
 
   final String baseUrl;
   final http.Client _httpClient;

--- a/lib/frontend/services/bot_get_service.dart
+++ b/lib/frontend/services/bot_get_service.dart
@@ -1,12 +1,15 @@
-import 'package:http/http.dart' as http;
 import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:scriptagher/shared/config/api_base_url.dart';
+
 import '../models/bot.dart';
 import '../models/bot_filter.dart';
 
 class BotGetService {
   final String baseUrl;
 
-  BotGetService({this.baseUrl = 'http://localhost:8080'});
+  BotGetService({String? baseUrl}) : baseUrl = baseUrl ?? ApiBaseUrl.resolve();
 
   Future<Map<String, List<Bot>>> fetchBots(
           {bool forceRefresh = false, BotFilter? filter}) =>

--- a/lib/frontend/services/bot_upload_service.dart
+++ b/lib/frontend/services/bot_upload_service.dart
@@ -1,10 +1,13 @@
 import 'dart:convert';
+
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
+import 'package:scriptagher/shared/config/api_base_url.dart';
 import '../models/bot.dart';
 
 class BotUploadService {
-  BotUploadService({this.baseUrl = 'http://localhost:8080'});
+  BotUploadService({String? baseUrl})
+      : baseUrl = baseUrl ?? ApiBaseUrl.resolve();
 
   final String baseUrl;
 

--- a/lib/frontend/widgets/pages/bot_detail_view.dart
+++ b/lib/frontend/widgets/pages/bot_detail_view.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
+import 'package:scriptagher/shared/config/api_base_url.dart';
 
 import '../../models/bot.dart';
 import '../../models/execution_log.dart';
@@ -19,12 +20,12 @@ class BotDetailView extends StatefulWidget {
   const BotDetailView(
       {super.key,
       required this.bot,
-      this.baseUrl = 'http://localhost:8080',
+      this.baseUrl,
       this.botGetService,
       this.botDownloadService});
 
   final Bot bot;
-  final String baseUrl;
+  final String? baseUrl;
   final BotGetService? botGetService;
   final BotDownloadService? botDownloadService;
 
@@ -38,6 +39,7 @@ class _BotDetailViewState extends State<BotDetailView> {
   final List<ExecutionLog> _logHistory = [];
   static const ValueKey<String> _runButtonKey =
       ValueKey<String>('bot-detail-run-button');
+  late final String _baseUrl;
   late final BotGetService _botGetService;
   late final BotDownloadService _botDownloadService;
   Bot? _downloadedBot;
@@ -81,10 +83,11 @@ class _BotDetailViewState extends State<BotDetailView> {
   @override
   void initState() {
     super.initState();
+    _baseUrl = widget.baseUrl ?? ApiBaseUrl.resolve();
     _botGetService =
-        widget.botGetService ?? BotGetService(baseUrl: widget.baseUrl);
-    _botDownloadService = widget.botDownloadService ??
-        BotDownloadService(baseUrl: widget.baseUrl);
+        widget.botGetService ?? BotGetService(baseUrl: _baseUrl);
+    _botDownloadService =
+        widget.botDownloadService ?? BotDownloadService(baseUrl: _baseUrl);
     if (!widget.bot.isDownloaded && !widget.bot.isLocal) {
       _remoteBot = widget.bot;
     }
@@ -372,7 +375,7 @@ class _BotDetailViewState extends State<BotDetailView> {
     });
 
     final uri = Uri.parse(
-        '${widget.baseUrl}/bots/${Uri.encodeComponent(widget.bot.language)}/${Uri.encodeComponent(widget.bot.botName)}/logs');
+        '${_baseUrl}/bots/${Uri.encodeComponent(widget.bot.language)}/${Uri.encodeComponent(widget.bot.botName)}/logs');
 
     try {
       final response = await http.get(uri);
@@ -452,7 +455,7 @@ class _BotDetailViewState extends State<BotDetailView> {
     });
 
     final baseUri = Uri.parse(
-        '${widget.baseUrl}/bots/${Uri.encodeComponent(widget.bot.language)}/${Uri.encodeComponent(widget.bot.botName)}/start');
+        '${_baseUrl}/bots/${Uri.encodeComponent(widget.bot.language)}/${Uri.encodeComponent(widget.bot.botName)}/start');
     final uri = (grantedPermissions != null && grantedPermissions.isNotEmpty)
         ? baseUri.replace(queryParameters: {
             ...baseUri.queryParameters,
@@ -554,7 +557,7 @@ class _BotDetailViewState extends State<BotDetailView> {
     _client = client;
 
     final baseUri = Uri.parse(
-        '${widget.baseUrl}/bots/${Uri.encodeComponent(widget.bot.language)}/${Uri.encodeComponent(widget.bot.botName)}/stream');
+        '${_baseUrl}/bots/${Uri.encodeComponent(widget.bot.language)}/${Uri.encodeComponent(widget.bot.botName)}/stream');
     final uri = (grantedPermissions != null && grantedPermissions.isNotEmpty)
         ? baseUri.replace(queryParameters: {
             ...baseUri.queryParameters,
@@ -697,7 +700,7 @@ class _BotDetailViewState extends State<BotDetailView> {
     });
 
     final uri = Uri.parse(
-            '${widget.baseUrl}/bots/${Uri.encodeComponent(widget.bot.language)}/${Uri.encodeComponent(widget.bot.botName)}/$action')
+            '${_baseUrl}/bots/${Uri.encodeComponent(widget.bot.language)}/${Uri.encodeComponent(widget.bot.botName)}/$action')
         .replace(queryParameters: {'processId': processId});
 
     try {
@@ -860,7 +863,7 @@ class _BotDetailViewState extends State<BotDetailView> {
     try {
       final session = await _browserRunner!.start(
         _primaryBot,
-        baseUrl: widget.baseUrl,
+        baseUrl: _baseUrl,
       );
       _browserSession = session;
       _browserSubscription = session.stream.listen((event) {
@@ -1003,7 +1006,7 @@ class _BotDetailViewState extends State<BotDetailView> {
 
   Future<void> _openLog(ExecutionLog log) async {
     final uri = Uri.parse(
-        '${widget.baseUrl}/bots/${Uri.encodeComponent(widget.bot.language)}/${Uri.encodeComponent(widget.bot.botName)}/logs/${Uri.encodeComponent(log.runId)}');
+        '${_baseUrl}/bots/${Uri.encodeComponent(widget.bot.language)}/${Uri.encodeComponent(widget.bot.botName)}/logs/${Uri.encodeComponent(log.runId)}');
     try {
       final response = await http.get(uri);
       if (response.statusCode == 200) {
@@ -1040,7 +1043,7 @@ class _BotDetailViewState extends State<BotDetailView> {
 
   Future<void> _exportLog(ExecutionLog log) async {
     final uri = Uri.parse(
-        '${widget.baseUrl}/bots/${Uri.encodeComponent(widget.bot.language)}/${Uri.encodeComponent(widget.bot.botName)}/logs/${Uri.encodeComponent(log.runId)}');
+        '${_baseUrl}/bots/${Uri.encodeComponent(widget.bot.language)}/${Uri.encodeComponent(widget.bot.botName)}/logs/${Uri.encodeComponent(log.runId)}');
     try {
       final response = await http.get(uri);
       if (response.statusCode != 200) {

--- a/lib/shared/config/api_base_url.dart
+++ b/lib/shared/config/api_base_url.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/foundation.dart';
+
+/// Utility to resolve the base URL for API calls across platforms.
+class ApiBaseUrl {
+  const ApiBaseUrl._();
+
+  static const _envKey = 'API_BASE_URL';
+
+  /// Returns the API base URL following the priority:
+  /// 1. Compile-time override via [String.fromEnvironment] using [_envKey].
+  /// 2. The current browser origin when running on the web.
+  /// 3. The local development endpoint for desktop and tests.
+  static String resolve() {
+    const override = String.fromEnvironment(_envKey);
+    if (override.isNotEmpty) {
+      return override;
+    }
+
+    if (kIsWeb) {
+      final origin = Uri.base.origin;
+      if (origin.isNotEmpty) {
+        return origin;
+      }
+    }
+
+    return 'http://localhost:8080';
+  }
+}

--- a/test/frontend/services/bot_filter_test.dart
+++ b/test/frontend/services/bot_filter_test.dart
@@ -54,7 +54,7 @@ void main() {
 
   group('BotGetService.applyFilter', () {
     test('returns filtered groups respecting metadata filters', () {
-      final service = BotGetService();
+      final service = BotGetService(baseUrl: 'http://localhost:8080');
       final botPython = Bot(
         botName: 'UtilityBot',
         description: 'A helpful utility bot for files',
@@ -91,7 +91,7 @@ void main() {
     });
 
     test('returns original map when filter is empty', () {
-      final service = BotGetService();
+      final service = BotGetService(baseUrl: 'http://localhost:8080');
       final bot = Bot(
         botName: 'UtilityBot',
         description: 'A helpful utility bot for files',


### PR DESCRIPTION
## Summary
- add an ApiBaseUrl helper to centralize how the client resolves the backend endpoint
- update bot services and the bot detail view to accept optional overrides and reuse the shared resolver
- document how to define API_BASE_URL at build time and keep service tests deterministic with explicit base URLs

## Testing
- not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f75a00e19c832bb1543d3b14a8194e