### PR TITLE
Refine header logo spacing and layout

### DIFF
--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -1,27 +1,34 @@
 <header [class.pdf-page]="isPdfToTxtPage">
   <div class="header-content">
     <div class="header-toolbar">
-      <nav class="header-nav" aria-label="Primary navigation">
-        <a
-          routerLink="/"
-          routerLinkActive="is-active"
-          [routerLinkActiveOptions]="{ exact: true }"
-        >
-          {{ 'navigation.home' | translate }}
-        </a>
-        <a routerLink="/bots" routerLinkActive="is-active">
-          {{ 'navigation.bots' | translate }}
-        </a>
-        <a routerLink="/installers" routerLinkActive="is-active">
-          {{ 'navigation.installers' | translate }}
-        </a>
-      </nav>
-      <app-language-switcher></app-language-switcher>
+      <a class="header-logo" routerLink="/">
+        <img src="assets/branding/logo.svg" alt="{{ 'app.name' | translate }}" />
+      </a>
+      <div class="header-controls">
+        <nav class="header-nav" aria-label="Primary navigation">
+          <a
+            routerLink="/"
+            routerLinkActive="is-active"
+            [routerLinkActiveOptions]="{ exact: true }"
+          >
+            {{ 'navigation.home' | translate }}
+          </a>
+          <a routerLink="/bots" routerLinkActive="is-active">
+            {{ 'navigation.bots' | translate }}
+          </a>
+          <a routerLink="/installers" routerLinkActive="is-active">
+            {{ 'navigation.installers' | translate }}
+          </a>
+        </nav>
+        <app-language-switcher></app-language-switcher>
+      </div>
     </div>
 
     <div *ngIf="isPdfToTxtPage; else normalHeader" class="pdf-header">
       <div class="pdf-copy">
-        <span class="app-name">{{ 'app.name' | translate }}</span>
+        <span class="pdf-logo">
+          <img src="assets/branding/logo.svg" alt="{{ 'app.name' | translate }}" />
+        </span>
         <span class="current-page">{{ 'header.pdf.currentPage' | translate }}</span>
       </div>
       <button class="btn btn-secondary" (click)="navigateHome()">

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -56,6 +56,27 @@ header {
     justify-content: space-between;
     align-items: center;
     gap: 1.5rem;
+    flex-wrap: wrap;
+  }
+
+  .header-logo {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    margin-right: 1.5rem;
+
+    img {
+      display: block;
+      width: clamp(150px, 22vw, 220px);
+      max-width: 100%;
+      height: auto;
+    }
+  }
+
+  .header-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: 1.5rem;
   }
 
   .header-nav {
@@ -105,9 +126,17 @@ header {
       flex-direction: column;
       gap: 0.35rem;
 
-      .app-name {
-        font-weight: 600;
-        font-size: 1.35rem;
+      .pdf-logo {
+        display: inline-flex;
+        align-items: center;
+        padding: 0.35rem 0;
+
+        img {
+          display: block;
+          width: clamp(140px, 24vw, 200px);
+          max-width: 100%;
+          height: auto;
+        }
       }
 
       .current-page {
@@ -190,10 +219,24 @@ header {
     .header-toolbar {
       flex-direction: column;
       align-items: stretch;
+      gap: 1.25rem;
+    }
+
+    .header-logo {
+      justify-content: center;
+      width: 100%;
+      margin-right: 0;
+    }
+
+    .header-controls {
+      flex-direction: column;
+      align-items: center;
       gap: 1rem;
+      width: 100%;
     }
 
     .header-nav {
+      width: 100%;
       justify-content: center;
     }
   }

--- a/src/assets/branding/logo.svg
+++ b/src/assets/branding/logo.svg
@@ -1,0 +1,35 @@
+<svg width="180" height="48" viewBox="0 0 180 48" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="scriptagherLogoTitle">
+  <title id="scriptagherLogoTitle">Scriptagher</title>
+  <defs>
+    <linearGradient id="scriptagherOrb" x1="6" y1="6" x2="42" y2="42" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#38BDF8" />
+      <stop offset="0.5" stop-color="#818CF8" />
+      <stop offset="1" stop-color="#C084FC" />
+    </linearGradient>
+    <linearGradient id="scriptagherTrail" x1="15" y1="12" x2="33" y2="36" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0EA5E9" stop-opacity="0.95" />
+      <stop offset="1" stop-color="#A855F7" stop-opacity="0.95" />
+    </linearGradient>
+    <filter id="logoGlow" x="0" y="0" width="54" height="48" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="1.4" result="blur" />
+    </filter>
+  </defs>
+  <g filter="url(#logoGlow)">
+    <circle cx="24" cy="24" r="20" fill="url(#scriptagherOrb)" opacity="0.82" />
+  </g>
+  <path
+    d="M15.8 18.3c1.5-3.6 4.9-5.8 8.9-5.8 5.8 0 10.4 4.4 10.4 10.3 0 4.5-2.6 7.7-6.7 9.3l4.6 3.4-2.8 3.8-10.9-8.1c-2.5-1.9-4-4.3-4-7.2 0-2.9 1.3-5.3 3.4-6.7l2.7 3.2c-0.9 0.6-1.5 1.6-1.5 2.9 0 1.6 0.9 2.9 2.3 3.9l4.7 3.3c2.7-0.8 4.4-2.6 4.4-5.2 0-3-2.4-5.1-5.2-5.1-2 0-3.6 1-4.5 2.7l-3.2-2z"
+    fill="url(#scriptagherTrail)"
+  />
+  <path
+    d="M25.4 34.8c1 0 2-0.2 2.9-0.7l4.6 3.3-2.5 3.4-6.9-5.1c0.6 0 1.2 0.1 1.9 0.1z"
+    fill="#1D2B53"
+    opacity="0.18"
+  />
+  <text x="56" y="30" fill="#E2E8F0" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="600" font-size="21">
+    Scriptagher
+  </text>
+  <text x="56" y="47" fill="#94A3B8" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="400" font-size="10.5" letter-spacing="0.32em">
+    BOT LIBRARY
+  </text>
+</svg>


### PR DESCRIPTION
## Summary
- group the navigation with the language switcher so the toolbar spacing matches the previous layout while keeping the logo at the left
- simplify the logo styling and rely on translated alternative text to avoid duplicated announcements
- tweak the SVG tagline spacing and reuse the logo within the PDF header

## Testing
- npm run build -- --progress false *(fails: ng: not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f79b5cfde4832ba08bc89007b9ecb6