### PR TITLE
Add feedback banner helper and request storage permissions

### DIFF
--- a/lib/frontend/widgets/components/feedback_banner.dart
+++ b/lib/frontend/widgets/components/feedback_banner.dart
@@ -1,0 +1,107 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+/// Displays feedback messages using a top-anchored material banner on
+/// Android/iOS and falls back to traditional snackbars on other platforms.
+class FeedbackBanner {
+  FeedbackBanner._();
+
+  static Timer? _activeTimer;
+
+  static bool get _isMobilePlatform =>
+      !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.android ||
+          defaultTargetPlatform == TargetPlatform.iOS);
+
+  /// Shows a feedback message that adapts to the current platform.
+  static void show(
+    BuildContext context, {
+    required String message,
+    bool isError = false,
+    Duration duration = const Duration(seconds: 4),
+    IconData? icon,
+    String? dismissLabel,
+  }) {
+    if (context is! Element || !(context as Element).mounted) {
+      return;
+    }
+
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) {
+      return;
+    }
+
+    messenger.hideCurrentSnackBar();
+
+    if (_isMobilePlatform) {
+      _showMaterialBanner(
+        context,
+        messenger,
+        message,
+        isError: isError,
+        duration: duration,
+        icon: icon,
+        dismissLabel: dismissLabel,
+      );
+    } else {
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(message),
+          backgroundColor:
+              isError ? Theme.of(context).colorScheme.error : null,
+        ),
+      );
+    }
+  }
+
+  static void _showMaterialBanner(
+    BuildContext context,
+    ScaffoldMessengerState messenger,
+    String message, {
+    required bool isError,
+    required Duration duration,
+    IconData? icon,
+    String? dismissLabel,
+  }) {
+    messenger.clearMaterialBanners();
+    _activeTimer?.cancel();
+
+    final colorScheme = Theme.of(context).colorScheme;
+    final backgroundColor =
+        isError ? colorScheme.errorContainer : colorScheme.secondaryContainer;
+    final foregroundColor =
+        isError ? colorScheme.onErrorContainer : colorScheme.onSecondaryContainer;
+    final effectiveIcon =
+        icon ?? (isError ? Icons.error_outline_rounded : Icons.info_outline_rounded);
+    final effectiveDismissLabel = (dismissLabel ?? 'Chiudi').toUpperCase();
+
+    messenger.showMaterialBanner(
+      MaterialBanner(
+        backgroundColor: backgroundColor,
+        content: Text(
+          message,
+          style: TextStyle(color: foregroundColor),
+        ),
+        leading: Icon(effectiveIcon, color: foregroundColor),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        actions: [
+          TextButton(
+            onPressed: messenger.hideCurrentMaterialBanner,
+            style: TextButton.styleFrom(
+              foregroundColor: foregroundColor,
+            ),
+            child: Text(effectiveDismissLabel),
+          ),
+        ],
+      ),
+    );
+
+    _activeTimer = Timer(duration, () {
+      if (messenger.mounted) {
+        messenger.hideCurrentMaterialBanner();
+      }
+    });
+  }
+}

--- a/lib/frontend/widgets/pages/bot_detail_view.dart
+++ b/lib/frontend/widgets/pages/bot_detail_view.dart
@@ -6,6 +6,7 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'package:permission_handler/permission_handler.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:scriptagher/shared/config/api_base_url.dart';
 
@@ -15,6 +16,7 @@ import '../../services/bot_download_service.dart';
 import '../../services/bot_get_service.dart';
 import '../../services/browser_runner/browser_bot_runner.dart';
 import '../../services/browser_runner/browser_runner_models.dart';
+import '../components/feedback_banner.dart';
 
 class BotDetailView extends StatefulWidget {
   const BotDetailView(
@@ -115,7 +117,8 @@ class _BotDetailViewState extends State<BotDetailView> {
       downloaded = await _fetchDownloadedBot();
     } catch (e) {
       if (mounted) {
-        _showSnackBar('Errore durante il controllo dei bot scaricati: $e');
+        _showSnackBar('Errore durante il controllo dei bot scaricati: $e',
+            isError: true);
       }
     }
 
@@ -124,7 +127,8 @@ class _BotDetailViewState extends State<BotDetailView> {
         remote = await _fetchRemoteBot();
       } catch (e) {
         if (mounted) {
-          _showSnackBar('Errore durante il recupero dei metadati remoti: $e');
+          _showSnackBar('Errore durante il recupero dei metadati remoti: $e',
+              isError: true);
         }
       }
     }
@@ -218,7 +222,7 @@ class _BotDetailViewState extends State<BotDetailView> {
       _showSnackBar('Bot scaricato correttamente.');
     } catch (e) {
       if (mounted) {
-        _showSnackBar('Errore durante il download: $e');
+        _showSnackBar('Errore durante il download: $e', isError: true);
       }
     } finally {
       if (mounted) {
@@ -279,7 +283,8 @@ class _BotDetailViewState extends State<BotDetailView> {
       deleted = true;
     } catch (e) {
       if (mounted) {
-        _showSnackBar('Errore durante l\'eliminazione: $e');
+        _showSnackBar('Errore durante l\'eliminazione: $e',
+            isError: true);
       }
     } finally {
       if (mounted) {
@@ -317,7 +322,8 @@ class _BotDetailViewState extends State<BotDetailView> {
 
     final sourcePath = bot.sourcePath;
     if (sourcePath.isEmpty) {
-      _showSnackBar('Percorso della cartella non disponibile.');
+      _showSnackBar('Percorso della cartella non disponibile.',
+          isError: true);
       return;
     }
 
@@ -330,7 +336,8 @@ class _BotDetailViewState extends State<BotDetailView> {
     }
 
     if (!await directory.exists()) {
-      _showSnackBar('Cartella non trovata: ${directory.path}');
+      _showSnackBar('Cartella non trovata: ${directory.path}',
+          isError: true);
       return;
     }
 
@@ -348,7 +355,9 @@ class _BotDetailViewState extends State<BotDetailView> {
         command = 'xdg-open';
         args = [directory.path];
       } else {
-        _showSnackBar('Sistema operativo non supportato per questa operazione.');
+        _showSnackBar(
+            'Sistema operativo non supportato per questa operazione.',
+            isError: true);
         return;
       }
 
@@ -362,7 +371,8 @@ class _BotDetailViewState extends State<BotDetailView> {
         throw Exception(errorMessage);
       }
     } catch (e) {
-      _showSnackBar('Errore durante l\'apertura della cartella: $e');
+      _showSnackBar('Errore durante l\'apertura della cartella: $e',
+          isError: true);
       return;
     }
 
@@ -393,10 +403,13 @@ class _BotDetailViewState extends State<BotDetailView> {
         });
       } else {
         _showSnackBar(
-            'Impossibile recuperare i log (codice ${response.statusCode}).');
+          'Impossibile recuperare i log (codice ${response.statusCode}).',
+          isError: true,
+        );
       }
     } catch (e) {
-      _showSnackBar('Errore durante il caricamento dei log: $e');
+      _showSnackBar('Errore durante il caricamento dei log: $e',
+          isError: true);
     } finally {
       if (mounted) {
         setState(() {
@@ -717,7 +730,7 @@ class _BotDetailViewState extends State<BotDetailView> {
             }
           } catch (_) {}
         }
-        _showSnackBar(message);
+        _showSnackBar(message, isError: true);
         return;
       }
 
@@ -750,7 +763,8 @@ class _BotDetailViewState extends State<BotDetailView> {
         _showSnackBar('Segnale "$action" inviato al processo.');
       }
     } catch (e) {
-      _showSnackBar('Errore durante l\'invio del segnale: $e');
+      _showSnackBar('Errore durante l\'invio del segnale: $e',
+          isError: true);
     } finally {
       if (mounted) {
         setState(() {
@@ -1034,10 +1048,12 @@ class _BotDetailViewState extends State<BotDetailView> {
         );
       } else {
         _showSnackBar(
-            'Impossibile aprire il log (codice ${response.statusCode}).');
+          'Impossibile aprire il log (codice ${response.statusCode}).',
+          isError: true,
+        );
       }
     } catch (e) {
-      _showSnackBar('Errore durante l\'apertura del log: $e');
+      _showSnackBar('Errore durante l\'apertura del log: $e', isError: true);
     }
   }
 
@@ -1045,10 +1061,15 @@ class _BotDetailViewState extends State<BotDetailView> {
     final uri = Uri.parse(
         '${_baseUrl}/bots/${Uri.encodeComponent(widget.bot.language)}/${Uri.encodeComponent(widget.bot.botName)}/logs/${Uri.encodeComponent(log.runId)}');
     try {
+      await _requireStoragePermission(
+        'Per esportare il log è necessario consentire l\'accesso all\'archiviazione.',
+      );
       final response = await http.get(uri);
       if (response.statusCode != 200) {
         _showSnackBar(
-            'Impossibile esportare il log (codice ${response.statusCode}).');
+          'Impossibile esportare il log (codice ${response.statusCode}).',
+          isError: true,
+        );
         return;
       }
 
@@ -1056,15 +1077,46 @@ class _BotDetailViewState extends State<BotDetailView> {
       final file = File('${directory.path}/${log.logFileName}');
       await file.writeAsBytes(response.bodyBytes);
       _showSnackBar('Log salvato in ${file.path}');
+    } on _StoragePermissionDeniedException {
+      // Feedback già fornito.
     } catch (e) {
-      _showSnackBar('Errore durante l\'esportazione del log: $e');
+      _showSnackBar('Errore durante l\'esportazione del log: $e',
+          isError: true);
     }
   }
 
-  void _showSnackBar(String message) {
+  Future<void> _requireStoragePermission(String failureMessage) async {
+    if (!mounted) {
+      throw const _StoragePermissionDeniedException();
+    }
+
+    if (!Platform.isAndroid) {
+      return;
+    }
+
+    var status = await Permission.storage.status;
+    if (status.isGranted || status.isLimited) {
+      return;
+    }
+
+    status = await Permission.storage.request();
+    if (status.isGranted || status.isLimited) {
+      return;
+    }
+
+    final message = status.isPermanentlyDenied
+        ? '$failureMessage Abilita l\'autorizzazione dalle impostazioni di sistema.'
+        : failureMessage;
+    _showSnackBar(message, isError: true);
+    throw const _StoragePermissionDeniedException();
+  }
+
+  void _showSnackBar(String message, {bool isError = false}) {
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(message)),
+    FeedbackBanner.show(
+      context,
+      message: message,
+      isError: isError,
     );
   }
 
@@ -1718,6 +1770,10 @@ class _BotDetailViewState extends State<BotDetailView> {
       },
     );
   }
+}
+
+class _StoragePermissionDeniedException implements Exception {
+  const _StoragePermissionDeniedException();
 }
 
 class _ConsoleEntry {

--- a/lib/frontend/widgets/pages/bot_list_view.dart
+++ b/lib/frontend/widgets/pages/bot_list_view.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:archive/archive.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
@@ -14,6 +15,7 @@ import '../../services/bot_upload_service.dart';
 import '../components/app_gradient_background.dart';
 import '../components/bot_card_component.dart';
 import '../components/search_component.dart';
+import '../components/feedback_banner.dart';
 import 'bot_detail_view.dart';
 
 class BotList extends StatefulWidget {
@@ -277,9 +279,7 @@ class _BotListState extends State<BotList>
       await _categoryFutures[BotCategory.online];
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Errore durante l\'aggiornamento: $e')),
-      );
+      _showFeedback('Errore durante l\'aggiornamento: $e', isError: true);
     } finally {
       if (!mounted) return;
       setState(() {
@@ -338,7 +338,7 @@ class _BotListState extends State<BotList>
         file.name,
       );
     } catch (e) {
-      _showSnackBar('Errore durante la selezione del file: $e', isError: true);
+      _showFeedback('Errore durante la selezione del file: $e', isError: true);
     }
   }
 
@@ -363,13 +363,18 @@ class _BotListState extends State<BotList>
           await zipFile.delete();
         }
       }
+    } on _StoragePermissionDeniedException {
+      // Il feedback è già stato comunicato all'utente.
     } catch (e) {
-      _showSnackBar('Errore durante la selezione della cartella: $e',
+      _showFeedback('Errore durante la selezione della cartella: $e',
           isError: true);
     }
   }
 
   Future<File> _zipDirectory(String directoryPath) async {
+    await _requireStoragePermission(
+      'Per comprimere la cartella è necessario consentire l\'accesso all\'archiviazione.',
+    );
     final directory = Directory(directoryPath);
     if (!await directory.exists()) {
       throw Exception('La cartella selezionata non esiste più.');
@@ -396,6 +401,32 @@ class _BotListState extends State<BotList>
     final zipFile = File(zipPath);
     await zipFile.writeAsBytes(encoded, flush: true);
     return zipFile;
+  }
+
+  Future<void> _requireStoragePermission(String failureMessage) async {
+    if (!mounted) {
+      throw const _StoragePermissionDeniedException();
+    }
+
+    if (!Platform.isAndroid) {
+      return;
+    }
+
+    var status = await Permission.storage.status;
+    if (status.isGranted || status.isLimited) {
+      return;
+    }
+
+    status = await Permission.storage.request();
+    if (status.isGranted || status.isLimited) {
+      return;
+    }
+
+    final message = status.isPermanentlyDenied
+        ? '$failureMessage Abilita l\'autorizzazione dalle impostazioni di sistema.'
+        : failureMessage;
+    _showFeedback(message, isError: true);
+    throw const _StoragePermissionDeniedException();
   }
 
   Stream<List<int>> _streamFromPlatformFile(PlatformFile file) {
@@ -426,10 +457,10 @@ class _BotListState extends State<BotList>
 
       if (!mounted) return;
 
-      _showSnackBar('Bot "${bot.botName}" importato con successo.');
+      _showFeedback('Bot "${bot.botName}" importato con successo.');
       _refreshCategory(BotCategory.local);
     } catch (e) {
-      _showSnackBar('Errore durante il caricamento: $e', isError: true);
+      _showFeedback('Errore durante il caricamento: $e', isError: true);
     } finally {
       if (mounted) {
         setState(() {
@@ -455,13 +486,16 @@ class _BotListState extends State<BotList>
     });
   }
 
-  void _showSnackBar(String message, {bool isError = false}) {
+  void _showFeedback(String message, {bool isError = false}) {
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(message),
-        backgroundColor: isError ? Theme.of(context).colorScheme.error : null,
-      ),
+    FeedbackBanner.show(
+      context,
+      message: message,
+      isError: isError,
     );
   }
+}
+
+class _StoragePermissionDeniedException implements Exception {
+  const _StoragePermissionDeniedException();
 }

--- a/lib/frontend/widgets/pages/settings_page.dart
+++ b/lib/frontend/widgets/pages/settings_page.dart
@@ -3,6 +3,7 @@ import 'package:scriptagher/shared/services/telemetry_service.dart';
 import 'package:scriptagher/shared/theme/theme_controller.dart';
 
 import '../components/app_gradient_background.dart';
+import '../components/feedback_banner.dart';
 
 class SettingsPage extends StatelessWidget {
   final TelemetryService telemetryService;
@@ -69,22 +70,21 @@ class SettingsPage extends StatelessWidget {
                         ),
                         value: enabled,
                         onChanged: (value) async {
-                          final messenger = ScaffoldMessenger.of(context);
                           try {
                             await telemetryService.setTelemetryEnabled(value);
                             final message = value
                                 ? 'Telemetria attivata. Grazie per il supporto!'
                                 : 'Telemetria disattivata.';
-                            messenger.showSnackBar(
-                              SnackBar(content: Text(message)),
+                            FeedbackBanner.show(
+                              context,
+                              message: message,
                             );
                           } catch (e) {
-                            messenger.showSnackBar(
-                              const SnackBar(
-                                content: Text(
+                            FeedbackBanner.show(
+                              context,
+                              message:
                                   'Si è verificato un errore durante il salvataggio delle preferenze.',
-                                ),
-                              ),
+                              isError: true,
                             );
                           }
                         },
@@ -195,12 +195,10 @@ class _ThemeSelector extends StatelessWidget {
                           return;
                         }
                         themeController.setTheme(theme);
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text(
+                        FeedbackBanner.show(
+                          context,
+                          message:
                               'Tema impostato su ${_labelFor(theme)}',
-                            ),
-                          ),
                         );
                       },
                       selectedColor: colorScheme.primary,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   crypto: ^3.0.5
   file_picker: ^8.0.3
   mime: ^1.0.5
+  permission_handler: ^11.3.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a reusable `FeedbackBanner` helper that surfaces Material banners on mobile while falling back to snackbars elsewhere
- switch bot list/detail/settings pages to use the helper for user messages and request storage permission before local exports
- add the `permission_handler` dependency to support Android storage prompts

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f7bf2f8654832b90f657462e2a7e0f