### PR TITLE
Add GitHub Pages fallback for web bot listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Il server backend Shelf esposto su `http://localhost:8080` gestisce automaticame
 
 ### Configurare un endpoint API remoto
 
-Per le build non desktop (ad esempio Chrome o dispositivi mobili) l'app utilizza una variabile di compilazione `API_BASE_URL` per determinare l'endpoint dell'API. Se non viene fornita, viene usato automaticamente l'`origin` della pagina web oppure `http://localhost:8080` sulle piattaforme desktop. Per puntare a un backend remoto, passa il valore desiderato tramite `--dart-define` al momento dell'esecuzione:
+Per le build non desktop (ad esempio Chrome o dispositivi mobili) l'app utilizza una variabile di compilazione `API_BASE_URL` per determinare l'endpoint dell'API. Senza questo valore le azioni di download, upload ed esecuzione vengono disabilitate (sulle build web viene mostrata solo una modalità anteprima con i metadati pubblicati su GitHub Pages), mentre sulle piattaforme desktop viene usato automaticamente `http://localhost:8080`. Per puntare a un backend remoto, passa il valore desiderato tramite `--dart-define` al momento dell'esecuzione:
 
 ```sh
 flutter run -d chrome --dart-define=API_BASE_URL=https://your-host.example

--- a/lib/frontend/services/bot_download_service.dart
+++ b/lib/frontend/services/bot_download_service.dart
@@ -7,7 +7,7 @@ import '../models/bot.dart';
 
 class BotDownloadService {
   BotDownloadService({String? baseUrl, http.Client? httpClient})
-      : baseUrl = baseUrl ?? ApiBaseUrl.resolve(),
+      : baseUrl = baseUrl ?? ApiBaseUrl.require(),
         _httpClient = httpClient ?? http.Client();
 
   final String baseUrl;

--- a/lib/frontend/services/bot_get_service.dart
+++ b/lib/frontend/services/bot_get_service.dart
@@ -1,22 +1,97 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:scriptagher/shared/config/api_base_url.dart';
 
 import '../models/bot.dart';
 import '../models/bot_filter.dart';
+import 'bot_get_service_web.dart';
 
-class BotGetService {
-  final String baseUrl;
+abstract class BotGetService {
+  const BotGetService.protected();
 
-  BotGetService({String? baseUrl}) : baseUrl = baseUrl ?? ApiBaseUrl.resolve();
+  factory BotGetService({String? baseUrl, http.Client? httpClient}) {
+    final resolved = baseUrl ?? ApiBaseUrl.resolve();
+    if (resolved != null && resolved.isNotEmpty) {
+      return _ApiBotGetService(
+        baseUrl: resolved,
+        httpClient: httpClient ?? http.Client(),
+      );
+    }
 
-  Future<Map<String, List<Bot>>> fetchBots(
-          {bool forceRefresh = false, BotFilter? filter}) =>
+    if (kIsWeb) {
+      return BotGetServiceWeb(httpClient: httpClient);
+    }
+
+    throw StateError(
+      'Nessun endpoint API configurato. '
+      'Passa --dart-define=API_BASE_URL=<url> per abilitare tutte le funzionalità.',
+    );
+  }
+
+  factory BotGetService.unavailable() => const _UnavailableBotGetService();
+
+  Future<Map<String, List<Bot>>> fetchBots({
+    bool forceRefresh = false,
+    BotFilter? filter,
+  }) =>
       fetchOnlineBots(forceRefresh: forceRefresh, filter: filter);
 
-  Future<Map<String, List<Bot>>> fetchOnlineBots(
-      {bool forceRefresh = false, BotFilter? filter}) async {
+  Future<Map<String, List<Bot>>> fetchOnlineBots({
+    bool forceRefresh = false,
+    BotFilter? filter,
+  });
+
+  Future<List<Bot>> fetchOnlineBotsFlat({
+    bool forceRefresh = false,
+    BotFilter? filter,
+  });
+
+  Future<Map<String, List<Bot>>> refreshOnlineBots() =>
+      fetchOnlineBots(forceRefresh: true);
+
+  Future<Map<String, List<Bot>>> fetchDownloadedBots({BotFilter? filter});
+
+  Future<List<Bot>> fetchDownloadedBotsFlat({BotFilter? filter});
+
+  Future<Map<String, List<Bot>>> fetchLocalBots({BotFilter? filter});
+
+  Future<List<Bot>> fetchLocalBotsFlat({BotFilter? filter});
+
+  Map<String, List<Bot>> applyFilter(
+      Map<String, List<Bot>> groupedBots, BotFilter? filter) {
+    if (filter == null || filter.isEmpty) {
+      return groupedBots;
+    }
+
+    final Map<String, List<Bot>> filtered = {};
+    groupedBots.forEach((language, bots) {
+      final filteredBots = bots.where(filter.matches).toList();
+      if (filteredBots.isNotEmpty) {
+        filtered[language] = filteredBots;
+      }
+    });
+
+    return filtered;
+  }
+}
+
+class _ApiBotGetService extends BotGetService {
+  _ApiBotGetService({
+    required this.baseUrl,
+    required http.Client httpClient,
+  })  : _httpClient = httpClient,
+        super.protected();
+
+  final String baseUrl;
+  final http.Client _httpClient;
+
+  @override
+  Future<Map<String, List<Bot>>> fetchOnlineBots({
+    bool forceRefresh = false,
+    BotFilter? filter,
+  }) async {
     final uri = forceRefresh
         ? Uri.parse('$baseUrl/bots').replace(queryParameters: {
             'forceRefresh': 'true',
@@ -26,39 +101,47 @@ class BotGetService {
     return applyFilter(grouped, filter);
   }
 
-  Future<List<Bot>> fetchOnlineBotsFlat(
-      {bool forceRefresh = false, BotFilter? filter}) async {
+  @override
+  Future<List<Bot>> fetchOnlineBotsFlat({
+    bool forceRefresh = false,
+    BotFilter? filter,
+  }) async {
     final grouped = await fetchOnlineBots(
-        forceRefresh: forceRefresh, filter: filter);
+      forceRefresh: forceRefresh,
+      filter: filter,
+    );
     return grouped.values.expand((bots) => bots).toList();
   }
 
-  Future<Map<String, List<Bot>>> refreshOnlineBots() async =>
-      fetchOnlineBots(forceRefresh: true);
-
-  Future<Map<String, List<Bot>>> fetchDownloadedBots({BotFilter? filter}) async {
+  @override
+  Future<Map<String, List<Bot>>> fetchDownloadedBots({
+    BotFilter? filter,
+  }) async {
     final grouped = await _fetchGrouped(Uri.parse('$baseUrl/bots/downloaded'));
     return applyFilter(grouped, filter);
   }
 
-  Future<Map<String, List<Bot>>> fetchLocalBots({BotFilter? filter}) async {
-    final grouped = await _fetchGrouped(Uri.parse('$baseUrl/localbots'));
-    return applyFilter(grouped, filter);
-  }
-
-  Future<List<Bot>> fetchLocalBotsFlat({BotFilter? filter}) async {
-    final grouped = await fetchLocalBots(filter: filter);
-    return grouped.values.expand((bots) => bots).toList();
-  }
-
+  @override
   Future<List<Bot>> fetchDownloadedBotsFlat({BotFilter? filter}) async {
     final grouped = await fetchDownloadedBots(filter: filter);
     return grouped.values.expand((bots) => bots).toList();
   }
 
+  @override
+  Future<Map<String, List<Bot>>> fetchLocalBots({BotFilter? filter}) async {
+    final grouped = await _fetchGrouped(Uri.parse('$baseUrl/localbots'));
+    return applyFilter(grouped, filter);
+  }
+
+  @override
+  Future<List<Bot>> fetchLocalBotsFlat({BotFilter? filter}) async {
+    final grouped = await fetchLocalBots(filter: filter);
+    return grouped.values.expand((bots) => bots).toList();
+  }
+
   Future<Map<String, List<Bot>>> _fetchGrouped(Uri url) async {
     try {
-      final response = await http.get(url);
+      final response = await _httpClient.get(url);
 
       if (response.statusCode == 200) {
         final List<dynamic> data = jsonDecode(response.body);
@@ -78,21 +161,38 @@ class BotGetService {
       throw Exception('Failed to fetch bots: $e');
     }
   }
+}
 
-  Map<String, List<Bot>> applyFilter(
-      Map<String, List<Bot>> groupedBots, BotFilter? filter) {
-    if (filter == null || filter.isEmpty) {
-      return groupedBots;
-    }
+class _UnavailableBotGetService extends BotGetService {
+  const _UnavailableBotGetService() : super.protected();
 
-    final Map<String, List<Bot>> filtered = {};
-    groupedBots.forEach((language, bots) {
-      final filteredBots = bots.where(filter.matches).toList();
-      if (filteredBots.isNotEmpty) {
-        filtered[language] = filteredBots;
-      }
-    });
+  @override
+  Future<Map<String, List<Bot>>> fetchOnlineBots({
+    bool forceRefresh = false,
+    BotFilter? filter,
+  }) async => const {};
 
-    return filtered;
-  }
+  @override
+  Future<List<Bot>> fetchOnlineBotsFlat({
+    bool forceRefresh = false,
+    BotFilter? filter,
+  }) async => const [];
+
+  @override
+  Future<Map<String, List<Bot>>> fetchDownloadedBots({
+    BotFilter? filter,
+  }) async => const {};
+
+  @override
+  Future<List<Bot>> fetchDownloadedBotsFlat({
+    BotFilter? filter,
+  }) async => const [];
+
+  @override
+  Future<Map<String, List<Bot>>> fetchLocalBots({
+    BotFilter? filter,
+  }) async => const {};
+
+  @override
+  Future<List<Bot>> fetchLocalBotsFlat({BotFilter? filter}) async => const [];
 }

--- a/lib/frontend/services/bot_get_service_web.dart
+++ b/lib/frontend/services/bot_get_service_web.dart
@@ -1,0 +1,172 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:scriptagher/shared/constants/APIS.dart';
+
+import '../models/bot.dart';
+import '../models/bot_filter.dart';
+import 'bot_get_service.dart';
+
+class BotGetServiceWeb extends BotGetService {
+  BotGetServiceWeb({http.Client? httpClient})
+      : _httpClient = httpClient ?? http.Client(),
+        super.protected();
+
+  final http.Client _httpClient;
+  Map<String, List<Bot>>? _cachedBots;
+
+  static final Uri _botlistUri =
+      Uri.parse('${APIS.BASE_URL_GH_PAGES}botlist.json');
+
+  @override
+  Future<Map<String, List<Bot>>> fetchOnlineBots({
+    bool forceRefresh = false,
+    BotFilter? filter,
+  }) async {
+    final grouped = await _loadBotlist(forceRefresh: forceRefresh);
+    return applyFilter(grouped, filter);
+  }
+
+  @override
+  Future<List<Bot>> fetchOnlineBotsFlat({
+    bool forceRefresh = false,
+    BotFilter? filter,
+  }) async {
+    final grouped = await fetchOnlineBots(
+      forceRefresh: forceRefresh,
+      filter: filter,
+    );
+    return grouped.values.expand((bots) => bots).toList();
+  }
+
+  @override
+  Future<Map<String, List<Bot>>> fetchDownloadedBots({
+    BotFilter? filter,
+  }) async => const {};
+
+  @override
+  Future<List<Bot>> fetchDownloadedBotsFlat({BotFilter? filter}) async =>
+      const [];
+
+  @override
+  Future<Map<String, List<Bot>>> fetchLocalBots({BotFilter? filter}) async =>
+      const {};
+
+  @override
+  Future<List<Bot>> fetchLocalBotsFlat({BotFilter? filter}) async => const [];
+
+  Future<Map<String, List<Bot>>> _loadBotlist({bool forceRefresh = false}) async {
+    if (!forceRefresh && _cachedBots != null) {
+      return _cachedBots!;
+    }
+
+    final response = await _httpClient.get(_botlistUri);
+    if (response.statusCode != 200) {
+      throw Exception(
+        'Impossibile caricare botlist.json (status ${response.statusCode}).',
+      );
+    }
+
+    final decoded = jsonDecode(utf8.decode(response.bodyBytes));
+    final grouped = _parseBotlist(decoded);
+    _cachedBots = grouped;
+    return grouped;
+  }
+
+  Map<String, List<Bot>> _parseBotlist(dynamic payload) {
+    if (payload is! Map<String, dynamic>) {
+      throw const FormatException('Formato botlist non valido');
+    }
+
+    final botsData = payload['bots'];
+    if (botsData is! List) {
+      return const {};
+    }
+
+    final Map<String, List<Bot>> grouped = {};
+    for (final entry in botsData) {
+      if (entry is! Map<String, dynamic>) {
+        continue;
+      }
+      final manifest = entry['manifest'];
+      final manifestMap = manifest is Map<String, dynamic>
+          ? Map<String, dynamic>.from(manifest)
+          : <String, dynamic>{};
+
+      final bot = _botFromManifest(entry, manifestMap);
+      grouped.putIfAbsent(bot.language, () => <Bot>[]).add(bot);
+    }
+
+    return grouped;
+  }
+
+  Bot _botFromManifest(
+      Map<String, dynamic> entry, Map<String, dynamic> manifest) {
+    final language = _readString(manifest['language']) ??
+        _readString(entry['language']) ??
+        'unknown';
+    final botName = _readString(manifest['bot_name']) ??
+        _readString(manifest['botName']) ??
+        _readString(entry['name']) ??
+        'Bot senza nome';
+    final description = _readString(manifest['description']) ?? '';
+    final startCommand =
+        _readString(manifest['start_command']) ??
+            _readString(manifest['startCommand']) ??
+            '';
+    final version = _readString(manifest['version']) ?? '';
+    final author = _readString(manifest['author']);
+    final permissions = _readStringList(manifest['permissions']);
+    final tags = _readStringList(manifest['tags']);
+    final archiveSha = _readString(entry['archiveSha256']) ??
+        _readString(manifest['archive_sha256']) ??
+        _readString(manifest['archiveSha256']);
+    final compat = BotCompat.fromJson(manifest['compat']);
+    final manifestUrl = _readString(entry['manifestUrl']);
+    final fallbackSlug = botName
+        .toLowerCase()
+        .replaceAll(RegExp(r'[^a-z0-9]+'), '-')
+        .replaceAll(RegExp(r'-{2,}'), '-')
+        .replaceAll(RegExp(r'^-+|-+$'), '');
+    final sourcePath = manifestUrl != null && manifestUrl.isNotEmpty
+        ? 'cdn:$manifestUrl'
+        : 'cdn:$language/$fallbackSlug';
+
+    return Bot(
+      botName: botName,
+      description: description,
+      startCommand: startCommand,
+      sourcePath: sourcePath,
+      language: language,
+      compat: compat,
+      permissions: permissions,
+      archiveSha256: archiveSha,
+      version: version,
+      author: author,
+      tags: tags,
+    );
+  }
+
+  String? _readString(dynamic value) {
+    if (value is String) {
+      final trimmed = value.trim();
+      return trimmed.isNotEmpty ? trimmed : null;
+    }
+    if (value != null) {
+      final str = value.toString().trim();
+      return str.isNotEmpty ? str : null;
+    }
+    return null;
+  }
+
+  List<String> _readStringList(dynamic value) {
+    if (value is List) {
+      return value
+          .whereType<String>()
+          .map((e) => e.trim())
+          .where((e) => e.isNotEmpty)
+          .toList();
+    }
+    return const [];
+  }
+}

--- a/lib/frontend/services/bot_upload_service.dart
+++ b/lib/frontend/services/bot_upload_service.dart
@@ -7,7 +7,7 @@ import '../models/bot.dart';
 
 class BotUploadService {
   BotUploadService({String? baseUrl})
-      : baseUrl = baseUrl ?? ApiBaseUrl.resolve();
+      : baseUrl = baseUrl ?? ApiBaseUrl.require();
 
   final String baseUrl;
 

--- a/lib/frontend/widgets/pages/bot_list_view.dart
+++ b/lib/frontend/widgets/pages/bot_list_view.dart
@@ -2,9 +2,11 @@ import 'dart:io';
 
 import 'package:archive/archive.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
+import 'package:scriptagher/shared/config/api_base_url.dart';
 
 import '../../models/bot.dart';
 import '../../models/bot_filter.dart';
@@ -25,21 +27,51 @@ class BotList extends StatefulWidget {
 
 class _BotListState extends State<BotList>
     with SingleTickerProviderStateMixin {
-  final BotGetService _botGetService = BotGetService();
-  final BotUploadService _botUploadService = BotUploadService();
+  late final BotGetService _botGetService;
+  BotUploadService? _botUploadService;
 
   late Map<BotCategory, Future<Map<String, List<Bot>>>> _categoryFutures;
   late final TabController _tabController;
 
+  String? _baseUrl;
+  bool _hasBackend = false;
+  Object? _backendError;
   BotCategory _selectedCategory = BotCategory.online;
   bool _argumentsHandled = false;
   bool _isUploading = false;
   bool _isRefreshingOnline = false;
   BotFilter _activeFilter = const BotFilter();
 
+  String? get _backendErrorMessage {
+    final error = _backendError;
+    if (error == null) {
+      return null;
+    }
+    if (error is StateError) {
+      return error.message;
+    }
+    return error.toString();
+  }
+
   @override
   void initState() {
     super.initState();
+    final resolvedBase = ApiBaseUrl.resolve();
+    _baseUrl = resolvedBase;
+    _hasBackend = resolvedBase != null && resolvedBase.isNotEmpty;
+
+    try {
+      _botGetService = BotGetService(baseUrl: resolvedBase);
+    } on StateError catch (error) {
+      _backendError = error;
+      _botGetService = BotGetService.unavailable();
+      _hasBackend = false;
+    }
+
+    if (_hasBackend) {
+      _botUploadService = BotUploadService(baseUrl: resolvedBase);
+    }
+
     _categoryFutures = {
       BotCategory.downloaded: _botGetService.fetchDownloadedBots(),
       BotCategory.online: _botGetService.fetchOnlineBots(),
@@ -94,10 +126,17 @@ class _BotListState extends State<BotList>
   }
 
   String _emptyMessageForCategory(BotCategory category) {
+    if (!_hasBackend && category != BotCategory.online) {
+      return 'Disponibile solo con un backend configurato (--dart-define=API_BASE_URL=<url>).';
+    }
+
     switch (category) {
       case BotCategory.downloaded:
         return 'Nessun bot scaricato trovato.';
       case BotCategory.online:
+        if (!_hasBackend && kIsWeb) {
+          return 'Nessun bot pubblicato sul catalogo GitHub Pages.';
+        }
         return 'Nessun bot disponibile online al momento.';
       case BotCategory.local:
         return 'Nessun bot locale trovato.';
@@ -112,6 +151,62 @@ class _BotListState extends State<BotList>
 
   Map<String, List<Bot>> _filterBots(Map<String, List<Bot>> data) {
     return _botGetService.applyFilter(data, _activeFilter);
+  }
+
+  Widget _buildBackendBanner(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = theme.colorScheme.secondaryContainer;
+    final onColor = theme.colorScheme.onSecondaryContainer;
+    final textTheme = theme.textTheme;
+    final errorMessage = _backendErrorMessage;
+
+    return Card(
+      margin: EdgeInsets.zero,
+      color: color,
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(Icons.cloud_off_outlined, color: onColor),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    'Funzionalità limitate',
+                    style: textTheme.titleMedium?.copyWith(
+                      color: onColor,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Esegui l\'app con --dart-define=API_BASE_URL=<url> per abilitare download, upload e avvio dei bot.',
+              style: textTheme.bodyMedium?.copyWith(color: onColor),
+            ),
+            if (kIsWeb) ...[
+              const SizedBox(height: 6),
+              Text(
+                'In questa anteprima web vengono mostrati solo i metadati pubblicati tramite GitHub Pages.',
+                style: textTheme.bodySmall?.copyWith(color: onColor),
+              ),
+            ],
+            if (errorMessage != null && errorMessage.isNotEmpty) ...[
+              const SizedBox(height: 6),
+              Text(
+                errorMessage,
+                style: textTheme.bodySmall?.copyWith(color: onColor),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
   }
 
   Widget _buildCategoryView(BotCategory category) {
@@ -205,6 +300,13 @@ class _BotListState extends State<BotList>
         padding: EdgeInsets.zero,
         child: Column(
           children: [
+            if (!_hasBackend) ...[
+              Padding(
+                padding:
+                    const EdgeInsets.only(left: 16, right: 16, top: 16, bottom: 8),
+                child: _buildBackendBanner(context),
+              ),
+            ],
             Padding(
               padding:
                   const EdgeInsets.symmetric(horizontal: 16.0, vertical: 16.0),
@@ -247,7 +349,9 @@ class _BotListState extends State<BotList>
       ),
       floatingActionButton: _selectedCategory == BotCategory.local
           ? FloatingActionButton.extended(
-              onPressed: _isUploading ? null : _showUploadOptions,
+              onPressed: (_isUploading || _botUploadService == null)
+                  ? null
+                  : _showUploadOptions,
               icon: AnimatedSwitcher(
                 duration: const Duration(milliseconds: 200),
                 child: _isUploading
@@ -413,12 +517,20 @@ class _BotListState extends State<BotList>
 
   Future<void> _performUpload(
       Stream<List<int>> stream, int length, String filename) async {
+    if (_botUploadService == null) {
+      _showSnackBar(
+        'L\'importazione è disponibile solo con un backend configurato (--dart-define=API_BASE_URL=<url>).',
+        isError: true,
+      );
+      return;
+    }
+
     setState(() {
       _isUploading = true;
     });
 
     try {
-      final bot = await _botUploadService.uploadBotFile(
+      final bot = await _botUploadService!.uploadBotFile(
         stream: stream,
         length: length,
         filename: filename,

--- a/lib/shared/config/api_base_url.dart
+++ b/lib/shared/config/api_base_url.dart
@@ -6,23 +6,50 @@ class ApiBaseUrl {
 
   static const _envKey = 'API_BASE_URL';
 
-  /// Returns the API base URL following the priority:
+  /// Returns the API base URL if available.
+  ///
+  /// Priority:
   /// 1. Compile-time override via [String.fromEnvironment] using [_envKey].
-  /// 2. The current browser origin when running on the web.
-  /// 3. The local development endpoint for desktop and tests.
-  static String resolve() {
+  /// 2. Local development endpoint when running on a desktop platform.
+  ///
+  /// For non-desktop builds without an override the method returns `null`.
+  static String? resolve() {
     const override = String.fromEnvironment(_envKey);
     if (override.isNotEmpty) {
       return override;
     }
 
-    if (kIsWeb) {
-      final origin = Uri.base.origin;
-      if (origin.isNotEmpty) {
-        return origin;
-      }
+    if (_isDesktopPlatform) {
+      return 'http://localhost:8080';
     }
 
-    return 'http://localhost:8080';
+    return null;
+  }
+
+  /// Resolves the base URL or throws a descriptive [StateError] when missing.
+  static String require() {
+    final value = resolve();
+    if (value == null || value.isEmpty) {
+      throw StateError(
+        'Nessun endpoint API configurato. '
+        'Passa --dart-define=API_BASE_URL=<url> per abilitare tutte le funzionalità.',
+      );
+    }
+    return value;
+  }
+
+  static bool get _isDesktopPlatform {
+    if (kIsWeb) {
+      return false;
+    }
+
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+      case TargetPlatform.linux:
+        return true;
+      default:
+        return false;
+    }
   }
 }

--- a/test/frontend/widgets/bot_detail_view_test.dart
+++ b/test/frontend/widgets/bot_detail_view_test.dart
@@ -11,7 +11,7 @@ class FakeBotGetService extends BotGetService {
   FakeBotGetService({
     this.downloadedBots = const [],
     this.remoteBots = const [],
-  }) : super(baseUrl: '');
+  }) : super.protected();
 
   final List<Bot> downloadedBots;
   final List<Bot> remoteBots;
@@ -48,6 +48,16 @@ class FakeBotGetService extends BotGetService {
     BotFilter? filter,
   }) async {
     return remoteBots;
+  }
+
+  @override
+  Future<Map<String, List<Bot>>> fetchLocalBots({BotFilter? filter}) async {
+    return const {};
+  }
+
+  @override
+  Future<List<Bot>> fetchLocalBotsFlat({BotFilter? filter}) async {
+    return const [];
   }
 }
 


### PR DESCRIPTION
## Summary
- require an explicit API base on non-desktop builds by returning null from `ApiBaseUrl.resolve()` and exposing a throwing helper
- split the bot fetching service so web builds can load metadata from the published GitHub Pages `botlist.json`
- surface limited-mode banners, disable backend actions, and wire the new data source into the bot list and detail views

## Testing
- not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f7bf307db4832bb4e2ed1f0bee6303