### PR TITLE
feat: refresh logo with mini droid artwork

### DIFF
--- a/src/assets/branding/logo.svg
+++ b/src/assets/branding/logo.svg
@@ -1,35 +1,37 @@
-<svg width="180" height="48" viewBox="0 0 180 48" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="scriptagherLogoTitle">
-  <title id="scriptagherLogoTitle">Scriptagher</title>
+<svg width="180" height="48" viewBox="0 0 180 48" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="miniDroidLogoTitle miniDroidLogoDescription">
+  <title id="miniDroidLogoTitle">Mini Droid mascot</title>
+  <desc id="miniDroidLogoDescription">The Scriptagher brand mark featuring a miniature droid robot with antennas and friendly eyes beside the Scriptagher wordmark.</desc>
   <defs>
-    <linearGradient id="scriptagherOrb" x1="6" y1="6" x2="42" y2="42" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#38BDF8" />
-      <stop offset="0.5" stop-color="#818CF8" />
-      <stop offset="1" stop-color="#C084FC" />
+    <linearGradient id="miniDroidBody" x1="12" y1="34" x2="36" y2="10" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0EA5E9" />
+      <stop offset="1" stop-color="#6366F1" />
     </linearGradient>
-    <linearGradient id="scriptagherTrail" x1="15" y1="12" x2="33" y2="36" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0EA5E9" stop-opacity="0.95" />
-      <stop offset="1" stop-color="#A855F7" stop-opacity="0.95" />
+    <linearGradient id="miniDroidHead" x1="14" y1="22" x2="34" y2="6" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#22D3EE" />
+      <stop offset="1" stop-color="#A855F7" />
     </linearGradient>
-    <filter id="logoGlow" x="0" y="0" width="54" height="48" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-      <feGaussianBlur in="SourceGraphic" stdDeviation="1.4" result="blur" />
-    </filter>
+    <radialGradient id="miniDroidGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(20 0 0 20 24 24)">
+      <stop offset="0" stop-color="#A5F3FC" stop-opacity="0.85" />
+      <stop offset="1" stop-color="#38BDF8" stop-opacity="0" />
+    </radialGradient>
   </defs>
-  <g filter="url(#logoGlow)">
-    <circle cx="24" cy="24" r="20" fill="url(#scriptagherOrb)" opacity="0.82" />
+  <circle cx="24" cy="24" r="20" fill="url(#miniDroidGlow)" opacity="0.45" />
+  <g transform="translate(8 6)">
+    <path d="M15.5 6.2l-2.4-3.8a1 1 0 0 1 1.7-1l2.6 4a1 1 0 0 1-1.9 0.8z" fill="#8B5CF6" opacity="0.7" />
+    <path d="M25.5 6.2l2.4-3.8a1 1 0 0 0-1.7-1l-2.6 4a1 1 0 1 0 1.9 0.8z" fill="#8B5CF6" opacity="0.7" />
+    <rect x="12" y="6" width="18" height="14" rx="7" fill="url(#miniDroidHead)" />
+    <rect x="10" y="17" width="22" height="18" rx="10" fill="url(#miniDroidBody)" />
+    <rect x="5" y="19" width="6" height="14" rx="3" fill="#38BDF8" opacity="0.8" />
+    <rect x="31" y="19" width="6" height="14" rx="3" fill="#6366F1" opacity="0.8" />
+    <circle cx="18" cy="13" r="2.1" fill="#0F172A" />
+    <circle cx="24" cy="13" r="2.1" fill="#0F172A" />
+    <path d="M17 23c0 2.8 2.3 5.1 5 5.1s5-2.3 5-5.1h-10z" fill="#E0F2FE" opacity="0.9" />
+    <path d="M17 24.2h10c-.2 2.2-2.3 3.9-5 3.9s-4.8-1.7-5-3.9z" fill="#0F172A" opacity="0.2" />
   </g>
-  <path
-    d="M15.8 18.3c1.5-3.6 4.9-5.8 8.9-5.8 5.8 0 10.4 4.4 10.4 10.3 0 4.5-2.6 7.7-6.7 9.3l4.6 3.4-2.8 3.8-10.9-8.1c-2.5-1.9-4-4.3-4-7.2 0-2.9 1.3-5.3 3.4-6.7l2.7 3.2c-0.9 0.6-1.5 1.6-1.5 2.9 0 1.6 0.9 2.9 2.3 3.9l4.7 3.3c2.7-0.8 4.4-2.6 4.4-5.2 0-3-2.4-5.1-5.2-5.1-2 0-3.6 1-4.5 2.7l-3.2-2z"
-    fill="url(#scriptagherTrail)"
-  />
-  <path
-    d="M25.4 34.8c1 0 2-0.2 2.9-0.7l4.6 3.3-2.5 3.4-6.9-5.1c0.6 0 1.2 0.1 1.9 0.1z"
-    fill="#1D2B53"
-    opacity="0.18"
-  />
-  <text x="56" y="30" fill="#E2E8F0" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="600" font-size="21">
+  <text x="58" y="30" fill="#E2E8F0" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="600" font-size="21">
     Scriptagher
   </text>
-  <text x="56" y="47" fill="#94A3B8" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="400" font-size="10.5" letter-spacing="0.32em">
+  <text x="58" y="46" fill="#94A3B8" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="400" font-size="10.5" letter-spacing="0.32em">
     BOT LIBRARY
   </text>
 </svg>


### PR DESCRIPTION
## Summary
- replace the existing Scriptagher orb mark with the new Mini Droid artwork and descriptive metadata
- retain the Scriptagher wordmark while centering the logo around the refreshed mascot styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f7c1697b24832b8e3b09c6b5e130bf