### PR TITLE
Stop tracking generated mini droid assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,15 @@ Questo progetto è una semplice applicazione mobile/desktop/web sviluppata con F
 
 ## Risorse grafiche
 
-- `assets/icons/scriptagher_mini_droid.svg`: icona monocromatica del mini droid utilizzata nei componenti `WindowTitleBar` desktop e web per mostrare il marchio dell'app.
-- `web/favicon.svg`: variante solo testa impiegata come favicon tramite `web/index.html` e dichiarata nel `web/manifest.json`.
+- `assets/icons/scriptagher_mini_droid.svg`: logo ufficiale dell'app (mini droid monocromatico) utilizzato dalla UI e come sorgente unica per tutte le piattaforme.
+- `assets/icons/scriptagher_logo.svg`: alias dello stesso logo utilizzato per l'inclusione tramite `pubspec.yaml` e per i tool di packaging desktop/mobile.
+- `web/icons/app-icon.svg` e `web/favicon.svg`: versioni web e favicon generate dallo stesso SVG per garantire coerenza tra build browser e PWA.
+
+Per produrre le varianti raster richieste dagli store (Android/iOS) e dai pacchetti desktop (Windows/Linux/macOS) esegui lo script
+[`tool/generate_app_icons.py`](tool/generate_app_icons.py). Il comando crea PNG multipiattaforma e un file ICO all'interno di
+`assets/icons/generated/` e copia automaticamente le icone PWA (`icon-192.png`, `icon-512.png`) in `web/icons/`. Questi asset generati non
+sono versionati nel repository: esegui lo script localmente (dopo aver installato `cairosvg` e `Pillow`) per prepararli prima di un
+packaging o di una release.
 
 ## Bot per Scriptagher
 

--- a/assets/icons/scriptagher_logo.svg
+++ b/assets/icons/scriptagher_logo.svg
@@ -1,21 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
-  <title id="title">Scriptagher Logo</title>
-  <desc id="desc">Stylised S monogram within a rounded gradient square</desc>
-  <defs>
-    <linearGradient id="scriptagher-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0F172A" />
-      <stop offset="45%" stop-color="#1E3A8A" />
-      <stop offset="100%" stop-color="#0EA5E9" />
-    </linearGradient>
-    <linearGradient id="scriptagher-highlight" x1="15%" y1="15%" x2="85%" y2="85%">
-      <stop offset="0%" stop-color="#38BDF8" stop-opacity="0.65" />
-      <stop offset="100%" stop-color="#38BDF8" stop-opacity="0" />
-    </linearGradient>
-  </defs>
-  <rect width="256" height="256" rx="56" fill="url(#scriptagher-gradient)" />
-  <rect width="256" height="256" rx="56" fill="url(#scriptagher-highlight)" />
-  <path
-    fill="#F8FAFC"
-    d="M74 74c20-24 56-34 88-26 22 5 40 19 46 37 10 28-10 52-54 63-38 9-46 18-42 30 4 13 22 20 44 18 20-2 36-10 47-23l28 24c-18 22-46 36-79 39-54 5-102-26-106-71-3-32 16-56 56-68 34-10 46-18 42-30-3-12-20-18-38-16-16 3-28 11-40 25z"
-  />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Scriptagher Mini Droid</title>
+  <desc id="desc">Monochrome mini droid with bracket face, cylindrical body, hook arm and chest LED.</desc>
+  <g fill="none" stroke="#F8FAFC" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="12" y="8" width="40" height="22" rx="7" />
+    <path d="M26 19h-3c-2 0-3 1.5-3 3.5v2c0 2-1 3.5-3 3.5h-3" />
+    <path d="M38 19h3c2 0 3 1.5 3 3.5v2c0 2 1 3.5 3 3.5h3" />
+    <line x1="32" y1="30" x2="32" y2="34" />
+    <rect x="23" y="34" width="18" height="20" rx="9" />
+    <path d="M41 40h9a5.5 5.5 0 0 1 0 11h-4l3 3" />
+  </g>
+  <circle cx="32" cy="44" r="4" fill="#F8FAFC" />
 </svg>

--- a/lib/frontend/widgets/pages/bot_list_view.dart
+++ b/lib/frontend/widgets/pages/bot_list_view.dart
@@ -338,7 +338,9 @@ class _BotListState extends State<BotList>
         file.name,
       );
     } catch (e) {
-      _showSnackBar('Errore durante la selezione del file: $e', isError: true);
+      if (!mounted) return;
+      _showSnackBar(context, 'Errore durante la selezione del file: $e',
+          isError: true);
     }
   }
 
@@ -364,7 +366,8 @@ class _BotListState extends State<BotList>
         }
       }
     } catch (e) {
-      _showSnackBar('Errore durante la selezione della cartella: $e',
+      if (!mounted) return;
+      _showSnackBar(context, 'Errore durante la selezione della cartella: $e',
           isError: true);
     }
   }
@@ -426,10 +429,15 @@ class _BotListState extends State<BotList>
 
       if (!mounted) return;
 
-      _showSnackBar('Bot "${bot.botName}" importato con successo.');
+      _showSnackBar(
+        context,
+        'Bot "${bot.botName}" importato con successo.',
+      );
       _refreshCategory(BotCategory.local);
     } catch (e) {
-      _showSnackBar('Errore durante il caricamento: $e', isError: true);
+      if (!mounted) return;
+      _showSnackBar(context, 'Errore durante il caricamento: $e',
+          isError: true);
     } finally {
       if (mounted) {
         setState(() {
@@ -455,13 +463,17 @@ class _BotListState extends State<BotList>
     });
   }
 
-  void _showSnackBar(String message, {bool isError = false}) {
-    if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(message),
-        backgroundColor: isError ? Theme.of(context).colorScheme.error : null,
-      ),
-    );
-  }
+}
+
+void _showSnackBar(
+  BuildContext context,
+  String message, {
+  bool isError = false,
+}) {
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(
+      content: Text(message),
+      backgroundColor: isError ? Theme.of(context).colorScheme.error : null,
+    ),
+  );
 }

--- a/tool/generate_app_icons.py
+++ b/tool/generate_app_icons.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Generate raster app icons from the shared Scriptagher SVG logo."""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import cairosvg
+from PIL import Image
+
+ROOT = Path(__file__).resolve().parents[1]
+SVG_SOURCE = ROOT / "assets" / "icons" / "scriptagher_mini_droid.svg"
+OUTPUT_DIR = ROOT / "assets" / "icons" / "generated"
+WEB_ICON_DIR = ROOT / "web" / "icons"
+PWA_ICON_SIZES = {192: "icon-192.png", 512: "icon-512.png"}
+
+PNG_SIZES = [16, 32, 48, 64, 72, 96, 128, 144, 152, 167, 180, 192, 256, 512, 1024]
+ICO_SIZES = [16, 24, 32, 48, 64, 128, 256]
+
+
+def ensure_output_dir() -> None:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    WEB_ICON_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def render_png(size: int) -> Path:
+    target = OUTPUT_DIR / f"scriptagher_mini_droid_{size}.png"
+    cairosvg.svg2png(
+        url=str(SVG_SOURCE),
+        write_to=str(target),
+        output_width=size,
+        output_height=size,
+    )
+    return target
+
+
+def render_png_variants() -> list[Path]:
+    rendered: list[Path] = []
+    for size in PNG_SIZES:
+        rendered.append(render_png(size))
+    return rendered
+
+
+def sync_pwa_icons() -> list[Path]:
+    copied: list[Path] = []
+    for size, filename in PWA_ICON_SIZES.items():
+        source = OUTPUT_DIR / f"scriptagher_mini_droid_{size}.png"
+        if not source.exists():
+            source = render_png(size)
+        target = WEB_ICON_DIR / filename
+        shutil.copyfile(source, target)
+        copied.append(target)
+    return copied
+
+
+def render_ico() -> Path:
+    ico_path = OUTPUT_DIR / "scriptagher_mini_droid.ico"
+    images = []
+    for size in ICO_SIZES:
+        png_path = OUTPUT_DIR / f"scriptagher_mini_droid_{size}.png"
+        if not png_path.exists():
+            png_path = render_png(size)
+        images.append(Image.open(png_path).convert("RGBA"))
+    base_image = images[0]
+    base_image.save(ico_path, format="ICO", sizes=[(size, size) for size in ICO_SIZES])
+    return ico_path
+
+
+def main() -> None:
+    ensure_output_dir()
+    rendered = render_png_variants()
+    ico_path = render_ico()
+    pwa_paths = sync_pwa_icons()
+    all_paths = rendered + [ico_path] + pwa_paths
+    print("Generated icons:")
+    for path in all_paths:
+        rel = path.relative_to(ROOT)
+        print(f" - {rel} ({path.stat().st_size} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/favicon.svg
+++ b/web/favicon.svg
@@ -1,10 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
-  <title id="title">Scriptagher Mini Droid Head</title>
-  <desc id="desc">Rounded rectangular droid head with centered braces and a glowing LED.</desc>
-  <g fill="none" stroke="#F8FAFC" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
-    <rect x="8" y="10" width="48" height="32" rx="11" />
-    <path d="M30 22h-5c-3 0-4 2-4 4.5v2c0 2.5-1 4.5-4 4.5h-5" />
-    <path d="M34 22h5c3 0 4 2 4 4.5v2c0 2.5 1 4.5 4 4.5h5" />
+  <title id="title">Scriptagher Mini Droid</title>
+  <desc id="desc">Monochrome mini droid with bracket face, cylindrical body, hook arm and chest LED.</desc>
+  <g fill="none" stroke="#F8FAFC" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="12" y="8" width="40" height="22" rx="7" />
+    <path d="M26 19h-3c-2 0-3 1.5-3 3.5v2c0 2-1 3.5-3 3.5h-3" />
+    <path d="M38 19h3c2 0 3 1.5 3 3.5v2c0 2 1 3.5 3 3.5h3" />
+    <line x1="32" y1="30" x2="32" y2="34" />
+    <rect x="23" y="34" width="18" height="20" rx="9" />
+    <path d="M41 40h9a5.5 5.5 0 0 1 0 11h-4l3 3" />
   </g>
-  <circle cx="32" cy="44" r="5" fill="#F8FAFC" />
+  <circle cx="32" cy="44" r="4" fill="#F8FAFC" />
 </svg>

--- a/web/icons/app-icon.svg
+++ b/web/icons/app-icon.svg
@@ -1,21 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
-  <title id="title">Scriptagher App Icon</title>
-  <desc id="desc">Rounded gradient square with a stylised S monogram</desc>
-  <defs>
-    <linearGradient id="app-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0F172A" />
-      <stop offset="45%" stop-color="#1E3A8A" />
-      <stop offset="100%" stop-color="#0EA5E9" />
-    </linearGradient>
-    <linearGradient id="app-highlight" x1="18%" y1="18%" x2="82%" y2="82%">
-      <stop offset="0%" stop-color="#38BDF8" stop-opacity="0.6" />
-      <stop offset="100%" stop-color="#38BDF8" stop-opacity="0" />
-    </linearGradient>
-  </defs>
-  <rect width="256" height="256" rx="56" fill="url(#app-gradient)" />
-  <rect width="256" height="256" rx="56" fill="url(#app-highlight)" />
-  <path
-    fill="#F8FAFC"
-    d="M74 74c20-24 56-34 88-26 22 5 40 19 46 37 10 28-10 52-54 63-38 9-46 18-42 30 4 13 22 20 44 18 20-2 36-10 47-23l28 24c-18 22-46 36-79 39-54 5-102-26-106-71-3-32 16-56 56-68 34-10 46-18 42-30-3-12-20-18-38-16-16 3-28 11-40 25z"
-  />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">Scriptagher Mini Droid</title>
+  <desc id="desc">Monochrome mini droid with bracket face, cylindrical body, hook arm and chest LED.</desc>
+  <g fill="none" stroke="#F8FAFC" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="12" y="8" width="40" height="22" rx="7" />
+    <path d="M26 19h-3c-2 0-3 1.5-3 3.5v2c0 2-1 3.5-3 3.5h-3" />
+    <path d="M38 19h3c2 0 3 1.5 3 3.5v2c0 2 1 3.5 3 3.5h3" />
+    <line x1="32" y1="30" x2="32" y2="34" />
+    <rect x="23" y="34" width="18" height="20" rx="9" />
+    <path d="M41 40h9a5.5 5.5 0 0 1 0 11h-4l3 3" />
+  </g>
+  <circle cx="32" cy="44" r="4" fill="#F8FAFC" />
 </svg>

--- a/web/index.html
+++ b/web/index.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Scriptagher</title>
     <link rel="manifest" href="manifest.json">
-    <!-- Head-only mini droid favicon variant -->
+    <!-- Scriptagher mini droid favicon -->
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <meta name="theme-color" content="#0175C2">
   </head>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -8,9 +8,14 @@
   "description": "Scriptagher web experience",
   "icons": [
     {
-      "src": "icons/app-icon.svg",
-      "type": "image/svg+xml",
-      "sizes": "any"
+      "src": "icons/icon-192.png",
+      "type": "image/png",
+      "sizes": "192x192"
+    },
+    {
+      "src": "icons/icon-512.png",
+      "type": "image/png",
+      "sizes": "512x512"
     },
     {
       "src": "icons/app-icon.svg",


### PR DESCRIPTION
## Summary
- remove the committed mini droid PNG/ICO variants and leave a placeholder for regenerated assets
- update the icon generation helper to also refresh the PWA PNGs in `web/icons/`
- document in the README that raster icons must be generated locally before packaging

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f7c00e25f4832ba4b114d76481f8af