### PR TITLE
Add responsive navigation shells and mobile optimizations

### DIFF
--- a/lib/frontend/navigation/app_navigation.dart
+++ b/lib/frontend/navigation/app_navigation.dart
@@ -6,13 +6,12 @@ class AppNavigationEntry {
     required this.label,
     required this.icon,
     this.route,
-    this.children = const <AppNavigationEntry>[],
-  }) : children = List.unmodifiable(children) {
-    assert(
-      route != null || this.children.isNotEmpty,
-      'A navigation entry must have either a route or children.',
-    );
-  }
+    List<AppNavigationEntry> children = const <AppNavigationEntry>[],
+  })  : assert(
+          route != null || children.isNotEmpty,
+          'A navigation entry must have either a route or children.',
+        ),
+        children = List.unmodifiable(children);
 
   final String label;
   final IconData icon;
@@ -23,43 +22,43 @@ class AppNavigationEntry {
 }
 
 const List<AppNavigationEntry> appNavigationEntries = <AppNavigationEntry>[
-  AppNavigationEntry(
+  const AppNavigationEntry(
     label: 'Home',
     icon: Icons.home_rounded,
     route: '/home',
   ),
-  AppNavigationEntry(
+  const AppNavigationEntry(
     label: 'Bots',
     icon: Icons.smart_toy_rounded,
     route: '/bots',
   ),
-  AppNavigationEntry(
+  const AppNavigationEntry(
     label: 'Tutorial',
     icon: Icons.school_rounded,
     route: '/tutorial',
   ),
-  AppNavigationEntry(
+  const AppNavigationEntry(
     label: 'Test',
     icon: Icons.science_rounded,
-    children: <AppNavigationEntry>[
-      AppNavigationEntry(
+    children: const <AppNavigationEntry>[
+      const AppNavigationEntry(
         label: 'Test 1',
         icon: Icons.filter_1_rounded,
         route: '/test1',
       ),
-      AppNavigationEntry(
+      const AppNavigationEntry(
         label: 'Test 2',
         icon: Icons.filter_2_rounded,
         route: '/test2',
       ),
-      AppNavigationEntry(
+      const AppNavigationEntry(
         label: 'Test 3',
         icon: Icons.filter_3_rounded,
         route: '/test3',
       ),
     ],
   ),
-  AppNavigationEntry(
+  const AppNavigationEntry(
     label: 'Settings',
     icon: Icons.settings_rounded,
     route: '/settings',

--- a/lib/frontend/navigation/app_navigation.dart
+++ b/lib/frontend/navigation/app_navigation.dart
@@ -6,12 +6,11 @@ class AppNavigationEntry {
     required this.label,
     required this.icon,
     this.route,
-    List<AppNavigationEntry> children = const <AppNavigationEntry>[],
-  })  : assert(
+    this.children = const <AppNavigationEntry>[],
+  }) : assert(
           route != null || children.isNotEmpty,
           'A navigation entry must have either a route or children.',
-        ),
-        children = List.unmodifiable(children);
+        );
 
   final String label;
   final IconData icon;

--- a/lib/frontend/navigation/app_navigation.dart
+++ b/lib/frontend/navigation/app_navigation.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+
+@immutable
+class AppNavigationEntry {
+  const AppNavigationEntry({
+    required this.label,
+    required this.icon,
+    this.route,
+    this.children = const <AppNavigationEntry>[],
+  }) : children = List.unmodifiable(children) {
+    assert(
+      route != null || this.children.isNotEmpty,
+      'A navigation entry must have either a route or children.',
+    );
+  }
+
+  final String label;
+  final IconData icon;
+  final String? route;
+  final List<AppNavigationEntry> children;
+
+  bool get isLeaf => children.isEmpty;
+}
+
+const List<AppNavigationEntry> appNavigationEntries = <AppNavigationEntry>[
+  AppNavigationEntry(
+    label: 'Home',
+    icon: Icons.home_rounded,
+    route: '/home',
+  ),
+  AppNavigationEntry(
+    label: 'Bots',
+    icon: Icons.smart_toy_rounded,
+    route: '/bots',
+  ),
+  AppNavigationEntry(
+    label: 'Tutorial',
+    icon: Icons.school_rounded,
+    route: '/tutorial',
+  ),
+  AppNavigationEntry(
+    label: 'Test',
+    icon: Icons.science_rounded,
+    children: <AppNavigationEntry>[
+      AppNavigationEntry(
+        label: 'Test 1',
+        icon: Icons.filter_1_rounded,
+        route: '/test1',
+      ),
+      AppNavigationEntry(
+        label: 'Test 2',
+        icon: Icons.filter_2_rounded,
+        route: '/test2',
+      ),
+      AppNavigationEntry(
+        label: 'Test 3',
+        icon: Icons.filter_3_rounded,
+        route: '/test3',
+      ),
+    ],
+  ),
+  AppNavigationEntry(
+    label: 'Settings',
+    icon: Icons.settings_rounded,
+    route: '/settings',
+  ),
+];
+
+Iterable<AppNavigationEntry> flattenNavigationEntries(
+  Iterable<AppNavigationEntry> entries,
+) sync* {
+  for (final AppNavigationEntry entry in entries) {
+    yield entry;
+    if (entry.children.isNotEmpty) {
+      yield* flattenNavigationEntries(entry.children);
+    }
+  }
+}
+
+AppNavigationEntry? findNavigationEntry(String route) {
+  for (final AppNavigationEntry entry
+      in flattenNavigationEntries(appNavigationEntries)) {
+    if (entry.route == route) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+bool navigationEntryContainsRoute(AppNavigationEntry entry, String route) {
+  if (entry.route == route) {
+    return true;
+  }
+  for (final AppNavigationEntry child in entry.children) {
+    if (navigationEntryContainsRoute(child, route)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/lib/frontend/widgets/components/bot_card_component.dart
+++ b/lib/frontend/widgets/components/bot_card_component.dart
@@ -4,8 +4,14 @@ import '../../models/bot.dart';
 class BotCard extends StatelessWidget {
   final Bot bot;
   final VoidCallback onTap;
+  final EdgeInsetsGeometry? margin;
 
-  const BotCard({super.key, required this.bot, required this.onTap});
+  const BotCard({
+    super.key,
+    required this.bot,
+    required this.onTap,
+    this.margin,
+  });
 
   List<Widget> _buildStatusChips(BuildContext context) {
     final compat = bot.compat;
@@ -89,7 +95,7 @@ class BotCard extends StatelessWidget {
         )));
 
     return Card(
-      margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+      margin: margin ?? const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
       child: ListTile(
         title: Text(bot.botName),
         subtitle: Column(

--- a/lib/frontend/widgets/components/navigation_menu.dart
+++ b/lib/frontend/widgets/components/navigation_menu.dart
@@ -1,81 +1,69 @@
 import 'package:flutter/material.dart';
 
-@immutable
-class NavigationMenuEntry {
-  NavigationMenuEntry({
-    required this.label,
-    this.route,
-    List<NavigationMenuEntry> children = const <NavigationMenuEntry>[],
-  }) : children = List.unmodifiable(children) {
-    assert(
-      route != null || this.children.isNotEmpty,
-      'A menu entry must have either a route or children.',
-    );
+import '../../navigation/app_navigation.dart';
+
+List<Widget> buildNavigationMenuChildren(BuildContext context) {
+  return appNavigationEntries
+      .map((entry) => _buildMenuEntry(context, entry))
+      .toList(growable: false);
+}
+
+Widget _buildMenuEntry(BuildContext context, AppNavigationEntry entry) {
+  if (entry.children.isEmpty) {
+    return _buildLeafMenuItem(context, entry);
   }
 
-  final String label;
-  final String? route;
-  final List<NavigationMenuEntry> children;
+  return SubmenuButton(
+    menuChildren: entry.children
+        .map((child) => _buildMenuEntry(context, child))
+        .toList(growable: false),
+    child: _SubMenuButtonLabel(label: entry.label),
+  );
+}
 
-  Widget toMenuWidget(BuildContext context) {
+Widget _buildLeafMenuItem(BuildContext context, AppNavigationEntry entry) {
+  final TextStyle? textStyle = Theme.of(context).textTheme.bodyMedium;
+  const EdgeInsets menuPadding = EdgeInsets.symmetric(
+    horizontal: 16,
+    vertical: 12,
+  );
+
+  return MenuItemButton(
+    style: MenuItemButton.styleFrom(padding: menuPadding),
+    child: Text(entry.label, style: textStyle),
+    onPressed: () {
+      if (entry.route == null) {
+        return;
+      }
+      MenuController.maybeOf(context)?.close();
+      Navigator.of(context).pushNamed(entry.route!);
+    },
+  );
+}
+
+class _SubMenuButtonLabel extends StatelessWidget {
+  const _SubMenuButtonLabel({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
     final TextStyle? textStyle = Theme.of(context).textTheme.bodyMedium;
     const EdgeInsets menuPadding = EdgeInsets.symmetric(
       horizontal: 16,
       vertical: 12,
     );
 
-    if (children.isEmpty) {
-      return MenuItemButton(
-        style: MenuItemButton.styleFrom(padding: menuPadding),
-        child: Text(label, style: textStyle),
-        onPressed: () {
-          if (route == null) {
-            return;
-          }
-          MenuController.maybeOf(context)?.close();
-          Navigator.of(context).pushNamed(route!);
-        },
-      );
-    }
-
-    return SubmenuButton(
-      menuChildren:
-          children.map((child) => child.toMenuWidget(context)).toList(),
-      child: Padding(
-        padding: menuPadding,
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(label, style: textStyle),
-            const SizedBox(width: 8),
-            const Icon(Icons.chevron_right),
-          ],
-        ),
+    return Padding(
+      padding: menuPadding,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(label, style: textStyle),
+          const SizedBox(width: 8),
+          const Icon(Icons.chevron_right),
+        ],
       ),
     );
   }
-}
-
-final List<NavigationMenuEntry> appNavigationEntries =
-    List<NavigationMenuEntry>.unmodifiable(<NavigationMenuEntry>[
-  NavigationMenuEntry(label: 'Home', route: '/home'),
-  NavigationMenuEntry(label: 'Bots', route: '/bots'),
-  NavigationMenuEntry(label: 'Tutorial', route: '/tutorial'),
-  NavigationMenuEntry(
-    label: 'Test',
-    children: <NavigationMenuEntry>[
-      NavigationMenuEntry(label: 'Test 1', route: '/test1'),
-      NavigationMenuEntry(label: 'Test 2', route: '/test2'),
-      NavigationMenuEntry(label: 'Test 3', route: '/test3'),
-    ],
-  ),
-  NavigationMenuEntry(label: 'Settings', route: '/settings'),
-]);
-
-List<Widget> buildNavigationMenuChildren(
-  BuildContext context,
-) {
-  return appNavigationEntries
-      .map((entry) => entry.toMenuWidget(context))
-      .toList(growable: false);
 }

--- a/lib/frontend/widgets/components/navigation_sidebar.dart
+++ b/lib/frontend/widgets/components/navigation_sidebar.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:scriptagher/shared/theme/theme_controller.dart';
 
-import 'navigation_menu.dart';
+import '../../navigation/app_navigation.dart';
 
 class NavigationSidebar extends StatelessWidget {
   const NavigationSidebar({super.key});
@@ -140,7 +140,7 @@ class _NavigationTile extends StatelessWidget {
     this.depth = 0,
   });
 
-  final NavigationMenuEntry entry;
+  final AppNavigationEntry entry;
   final String? currentRoute;
   final int depth;
 
@@ -169,7 +169,7 @@ class _NavigationLeafTile extends StatelessWidget {
     required this.depth,
   });
 
-  final NavigationMenuEntry entry;
+  final AppNavigationEntry entry;
   final bool isSelected;
   final int depth;
 
@@ -218,7 +218,7 @@ class _NavigationBranchTile extends StatelessWidget {
     required this.depth,
   });
 
-  final NavigationMenuEntry entry;
+  final AppNavigationEntry entry;
   final String? currentRoute;
   final int depth;
 
@@ -340,7 +340,7 @@ String _labelForTheme(AppTheme theme) {
   }
 }
 
-bool _entryContainsRoute(NavigationMenuEntry entry, String route) {
+bool _entryContainsRoute(AppNavigationEntry entry, String route) {
   if (entry.route == route) {
     return true;
   }

--- a/lib/frontend/widgets/layout/home_shell.dart
+++ b/lib/frontend/widgets/layout/home_shell.dart
@@ -1,2 +1,2 @@
-export 'home_shell_desktop.dart'
+export 'home_shell_io.dart'
     if (dart.library.html) 'home_shell_web.dart';

--- a/lib/frontend/widgets/layout/home_shell_io.dart
+++ b/lib/frontend/widgets/layout/home_shell_io.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+import 'home_shell_desktop.dart' as desktop_shell;
+import 'home_shell_mobile.dart' as mobile_shell;
+
+class HomeShell extends StatelessWidget {
+  const HomeShell({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isDesktopPlatform(defaultTargetPlatform)) {
+      return const desktop_shell.HomeShell();
+    }
+    return const mobile_shell.HomeShell();
+  }
+}
+
+bool _isDesktopPlatform(TargetPlatform platform) {
+  switch (platform) {
+    case TargetPlatform.windows:
+    case TargetPlatform.linux:
+    case TargetPlatform.macOS:
+      return true;
+    case TargetPlatform.android:
+    case TargetPlatform.fuchsia:
+    case TargetPlatform.iOS:
+      return false;
+  }
+}

--- a/lib/frontend/widgets/layout/home_shell_mobile.dart
+++ b/lib/frontend/widgets/layout/home_shell_mobile.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+
+import '../../navigation/app_navigation.dart';
+import '../pages/home_page_view.dart';
+
+class HomeShell extends StatefulWidget {
+  const HomeShell({super.key});
+
+  @override
+  State<HomeShell> createState() => _HomeShellState();
+}
+
+class _HomeShellState extends State<HomeShell> {
+  int _selectedIndex = 0;
+
+  List<AppNavigationEntry> get _entries => appNavigationEntries;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final route = ModalRoute.of(context);
+    if (route != null && route.isCurrent && _selectedIndex != 0) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          setState(() => _selectedIndex = 0);
+        }
+      });
+    }
+  }
+
+  void _handleDestinationSelected(int index) {
+    final AppNavigationEntry entry = _entries[index];
+    if (_selectedIndex != index) {
+      setState(() => _selectedIndex = index);
+    }
+
+    if (entry.children.isNotEmpty) {
+      _showSubNavigation(entry);
+      return;
+    }
+
+    _navigateToEntry(entry);
+  }
+
+  void _navigateToEntry(AppNavigationEntry entry) {
+    final String? route = entry.route;
+    if (route == null) {
+      return;
+    }
+    if (route == '/home') {
+      Navigator.of(context).popUntil((modalRoute) => modalRoute.isFirst);
+      return;
+    }
+    Navigator.of(context).pushNamed(route);
+  }
+
+  Future<void> _showSubNavigation(AppNavigationEntry entry) async {
+    final String? route = await showModalBottomSheet<String>(
+      context: context,
+      showDragHandle: true,
+      builder: (context) {
+        final ColorScheme colorScheme = Theme.of(context).colorScheme;
+        final TextTheme textTheme = Theme.of(context).textTheme;
+        return SafeArea(
+          child: ListView.separated(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            shrinkWrap: true,
+            itemCount: entry.children.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 4),
+            itemBuilder: (context, index) {
+              final AppNavigationEntry child = entry.children[index];
+              return ListTile(
+                leading: Icon(child.icon, color: colorScheme.primary),
+                title: Text(
+                  child.label,
+                  style: textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                onTap: () => Navigator.of(context).pop(child.route),
+              );
+            },
+          ),
+        );
+      },
+    );
+
+    if (!mounted || route == null || route.isEmpty) {
+      return;
+    }
+    Navigator.of(context).pushNamed(route);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final NavigationBar navigationBar = NavigationBar(
+      height: 68,
+      selectedIndex: _selectedIndex,
+      labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,
+      onDestinationSelected: _handleDestinationSelected,
+      destinations: _entries
+          .map(
+            (entry) => NavigationDestination(
+              icon: Icon(entry.icon),
+              label: entry.label,
+            ),
+          )
+          .toList(growable: false),
+    );
+
+    return HomePage(
+      appBar: AppBar(
+        title: const Text('Scriptagher'),
+      ),
+      bottomNavigationBar: SafeArea(
+        top: false,
+        child: navigationBar,
+      ),
+    );
+  }
+}

--- a/lib/frontend/widgets/layout/home_shell_web.dart
+++ b/lib/frontend/widgets/layout/home_shell_web.dart
@@ -1,21 +1,239 @@
 import 'package:flutter/material.dart';
 
-import '../components/navigation_sidebar.dart';
+import '../../navigation/app_navigation.dart';
+import '../components/mini_droid_brand.dart';
+import '../components/navigation_menu.dart';
 import '../pages/home_page_view.dart';
 
 class HomeShell extends StatelessWidget {
   const HomeShell({super.key});
 
+  void _navigateToEntry(BuildContext context, AppNavigationEntry entry) {
+    final String? route = entry.route;
+    if (route == null) {
+      return;
+    }
+    if (route == '/home') {
+      Navigator.of(context).popUntil((modalRoute) => modalRoute.isFirst);
+      return;
+    }
+    Navigator.of(context).pushNamed(route);
+  }
+
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Row(
-        children: [
-          NavigationSidebar(),
-          Expanded(
-            child: HomePage(),
-          ),
-        ],
+    final String? currentRoute = ModalRoute.of(context)?.settings.name;
+    final bool isRootRoute = !Navigator.of(context).canPop();
+
+    return HomePage(
+      appBar: _WebTopNavigationBar(
+        currentRoute: currentRoute,
+        isRootRoute: isRootRoute,
+        onNavigate: (entry) => _navigateToEntry(context, entry),
+      ),
+    );
+  }
+}
+
+class _WebTopNavigationBar extends StatelessWidget
+    implements PreferredSizeWidget {
+  const _WebTopNavigationBar({
+    required this.currentRoute,
+    required this.isRootRoute,
+    required this.onNavigate,
+  });
+
+  final String? currentRoute;
+  final bool isRootRoute;
+  final ValueChanged<AppNavigationEntry> onNavigate;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(72);
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final TextTheme textTheme = Theme.of(context).textTheme;
+
+    return Material(
+      elevation: 4,
+      color: colorScheme.surface,
+      child: SafeArea(
+        bottom: false,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final bool isCompact = constraints.maxWidth < 960;
+            final EdgeInsets padding = EdgeInsets.symmetric(
+              horizontal: isCompact ? 16 : 32,
+              vertical: 12,
+            );
+
+            return Padding(
+              padding: padding,
+              child: Row(
+                children: [
+                  const MiniDroidBrandMark(size: 28),
+                  const SizedBox(width: 12),
+                  Text(
+                    'Scriptagher',
+                    style: textTheme.titleLarge?.copyWith(
+                      color: colorScheme.onSurface,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 0.2,
+                    ),
+                  ),
+                  const Spacer(),
+                  if (isCompact)
+                    MenuAnchor(
+                      alignmentOffset: const Offset(0, 8),
+                      builder: (context, controller, child) {
+                        return IconButton(
+                          tooltip: 'Apri navigazione',
+                          icon: Icon(
+                            controller.isOpen
+                                ? Icons.close_rounded
+                                : Icons.menu_rounded,
+                          ),
+                          onPressed: () => controller.isOpen
+                              ? controller.close()
+                              : controller.open(),
+                        );
+                      },
+                      menuChildren: buildNavigationMenuChildren(context),
+                    )
+                  else
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: appNavigationEntries
+                          .map(
+                            (entry) => _TopNavigationEntry(
+                              entry: entry,
+                              isActive: _isEntryActive(entry),
+                              onNavigate: onNavigate,
+                            ),
+                          )
+                          .toList(growable: false),
+                    ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  bool _isEntryActive(AppNavigationEntry entry) {
+    final String? route = currentRoute;
+    if (route == null || route.isEmpty) {
+      return entry.route == '/home' && isRootRoute;
+    }
+    if (entry.route != null && entry.route == route) {
+      return true;
+    }
+    if (entry.children.isEmpty) {
+      return false;
+    }
+    return navigationEntryContainsRoute(entry, route);
+  }
+}
+
+class _TopNavigationEntry extends StatelessWidget {
+  const _TopNavigationEntry({
+    required this.entry,
+    required this.isActive,
+    required this.onNavigate,
+  });
+
+  final AppNavigationEntry entry;
+  final bool isActive;
+  final ValueChanged<AppNavigationEntry> onNavigate;
+
+  @override
+  Widget build(BuildContext context) {
+    if (entry.children.isEmpty) {
+      return _NavigationButton(
+        label: entry.label,
+        isActive: isActive,
+        onPressed: () => onNavigate(entry),
+      );
+    }
+
+    return MenuAnchor(
+      alignmentOffset: const Offset(0, 8),
+      builder: (context, controller, child) {
+        return _NavigationButton(
+          label: entry.label,
+          isActive: isActive,
+          trailingIcon: controller.isOpen
+              ? Icons.keyboard_arrow_up_rounded
+              : Icons.keyboard_arrow_down_rounded,
+          onPressed: () => controller.isOpen
+              ? controller.close()
+              : controller.open(),
+        );
+      },
+      menuChildren: entry.children
+          .map(
+            (child) => MenuItemButton(
+              leadingIcon: Icon(child.icon),
+              child: Text(child.label),
+              onPressed: () {
+                MenuController.maybeOf(context)?.close();
+                onNavigate(child);
+              },
+            ),
+          )
+          .toList(growable: false),
+    );
+  }
+}
+
+class _NavigationButton extends StatelessWidget {
+  const _NavigationButton({
+    required this.label,
+    required this.onPressed,
+    required this.isActive,
+    this.trailingIcon,
+  });
+
+  final String label;
+  final VoidCallback onPressed;
+  final bool isActive;
+  final IconData? trailingIcon;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final TextTheme textTheme = Theme.of(context).textTheme;
+    final Color foregroundColor =
+        isActive ? colorScheme.primary : colorScheme.onSurface;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: TextButton(
+        onPressed: onPressed,
+        style: TextButton.styleFrom(
+          foregroundColor: foregroundColor,
+          padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              label,
+              style: textTheme.titleSmall?.copyWith(
+                color: foregroundColor,
+                fontWeight: isActive ? FontWeight.w700 : FontWeight.w500,
+                letterSpacing: 0.2,
+              ),
+            ),
+            if (trailingIcon != null) ...[
+              const SizedBox(width: 6),
+              Icon(trailingIcon, size: 18, color: foregroundColor),
+            ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/frontend/widgets/pages/bot_list_view.dart
+++ b/lib/frontend/widgets/pages/bot_list_view.dart
@@ -647,7 +647,7 @@ class _BotListState extends State<BotList>
   Future<void> _performUpload(
       Stream<List<int>> stream, int length, String filename) async {
     if (_botUploadService == null) {
-      _showSnackBar(
+      _showFeedback(
         'L\'importazione è disponibile solo con un backend configurato (--dart-define=API_BASE_URL=<url>).',
         isError: true,
       );

--- a/lib/frontend/widgets/pages/bot_list_view.dart
+++ b/lib/frontend/widgets/pages/bot_list_view.dart
@@ -211,7 +211,11 @@ class _BotListState extends State<BotList>
     );
   }
 
-  Widget _buildCategoryView(BotCategory category) {
+  Widget _buildCategoryView(
+    BotCategory category,
+    EdgeInsets listPadding,
+    EdgeInsetsGeometry cardMargin,
+  ) {
     return FutureBuilder<Map<String, List<Bot>>>(
       future: _categoryFutures[category],
       builder: (context, snapshot) {
@@ -237,17 +241,19 @@ class _BotListState extends State<BotList>
         }
 
         return ListView(
-          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+          padding: listPadding,
           children: filteredData.entries.map((entry) {
             final language = entry.key;
             final bots = entry.value;
 
             return ExpansionTile(
               title: Text(language),
+              childrenPadding: const EdgeInsets.only(bottom: 4),
               children: bots
                   .map(
                     (bot) => BotCard(
                       bot: bot,
+                      margin: cardMargin,
                       onTap: () {
                         Navigator.push(
                           context,
@@ -268,30 +274,60 @@ class _BotListState extends State<BotList>
 
   @override
   Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final double width = mediaQuery.size.width;
+    final bool isTablet = width < 900;
+    final bool isPhone = width < 600;
+
+    final EdgeInsets listPadding = EdgeInsets.symmetric(
+      horizontal: isPhone ? 4 : (isTablet ? 8 : 16),
+      vertical: isPhone ? 4 : 8,
+    );
+    final EdgeInsetsGeometry cardMargin = EdgeInsets.fromLTRB(
+      isPhone ? 4 : (isTablet ? 8 : 16),
+      0,
+      isPhone ? 4 : (isTablet ? 8 : 16),
+      isPhone ? 10 : (isTablet ? 12 : 16),
+    );
+    final EdgeInsets contentCardMargin = EdgeInsets.fromLTRB(
+      isPhone ? 8 : (isTablet ? 12 : 16),
+      0,
+      isPhone ? 8 : (isTablet ? 12 : 16),
+      isPhone ? 12 : (isTablet ? 18 : 24),
+    );
+    final EdgeInsets filterPadding = EdgeInsets.fromLTRB(
+      isPhone ? 12 : (isTablet ? 16 : 24),
+      isPhone ? 12 : 16,
+      isPhone ? 12 : (isTablet ? 16 : 24),
+      isPhone ? 12 : 16,
+    );
+    final EdgeInsets backendPadding = EdgeInsets.fromLTRB(
+      isPhone ? 12 : (isTablet ? 16 : 24),
+      16,
+      isPhone ? 12 : (isTablet ? 16 : 24),
+      isPhone ? 8 : 12,
+    );
+    final BorderRadius searchRadius = BorderRadius.circular(isPhone ? 16 : 20);
+    final EdgeInsets searchInnerPadding = EdgeInsets.symmetric(
+      horizontal: isPhone ? 10 : 12,
+      vertical: isPhone ? 6 : 8,
+    );
+    final bool compactTabs = width < 720;
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Gestione Bot'),
+        centerTitle: isPhone,
         actions: [
           if (_selectedCategory == BotCategory.online)
             Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8.0),
-              child: FilledButton.tonalIcon(
-                onPressed:
-                    _isRefreshingOnline ? null : () => _refreshOnlineBots(),
-                icon: _isRefreshingOnline
-                    ? const SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : const Icon(Icons.refresh_rounded),
-                label: Text(
-                    _isRefreshingOnline ? 'Aggiornamento...' : 'Aggiorna'),
-              ),
+              padding: EdgeInsets.symmetric(horizontal: isPhone ? 4 : 8),
+              child: _buildRefreshAction(compact: isPhone),
             ),
         ],
         bottom: TabBar(
           controller: _tabController,
+          isScrollable: compactTabs,
           tabs: BotCategory.values
               .map((category) => Tab(text: _labelForCategory(category)))
               .toList(),
@@ -304,25 +340,22 @@ class _BotListState extends State<BotList>
           children: [
             if (!_hasBackend) ...[
               Padding(
-                padding:
-                    const EdgeInsets.only(left: 16, right: 16, top: 16, bottom: 8),
+                padding: backendPadding,
                 child: _buildBackendBanner(context),
               ),
             ],
             Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 16.0, vertical: 16.0),
+              padding: filterPadding,
               child: DecoratedBox(
                 decoration: BoxDecoration(
                   color: Theme.of(context)
                       .colorScheme
                       .surfaceVariant
                       .withOpacity(0.6),
-                  borderRadius: BorderRadius.circular(20),
+                  borderRadius: searchRadius,
                 ),
                 child: Padding(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  padding: searchInnerPadding,
                   child: SearchView(
                     onFilterChanged: _handleFilterChanged,
                     hintText:
@@ -333,15 +366,21 @@ class _BotListState extends State<BotList>
             ),
             Expanded(
               child: Card(
-                margin: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+                margin: contentCardMargin,
                 shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(24),
+                  borderRadius: BorderRadius.circular(isPhone ? 20 : 24),
                 ),
                 clipBehavior: Clip.antiAlias,
                 child: TabBarView(
                   controller: _tabController,
                   children: BotCategory.values
-                      .map(_buildCategoryView)
+                      .map(
+                        (category) => _buildCategoryView(
+                          category,
+                          listPadding,
+                          cardMargin,
+                        ),
+                      )
                       .toList(growable: false),
                 ),
               ),
@@ -349,26 +388,85 @@ class _BotListState extends State<BotList>
           ],
         ),
       ),
-      floatingActionButton: _selectedCategory == BotCategory.local
-          ? FloatingActionButton.extended(
-              onPressed: (_isUploading || _botUploadService == null)
-                  ? null
-                  : _showUploadOptions,
-              icon: AnimatedSwitcher(
-                duration: const Duration(milliseconds: 200),
-                child: _isUploading
-                    ? const SizedBox(
-                        key: ValueKey('progress'),
-                        width: 20,
-                        height: 20,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : const Icon(Icons.upload_file_rounded,
-                        key: ValueKey('icon')),
+      floatingActionButton: _buildUploadFab(compact: isPhone),
+    );
+  }
+
+  Widget _buildRefreshAction({required bool compact}) {
+    if (compact) {
+      return IconButton(
+        tooltip: _isRefreshingOnline ? 'Aggiornamento...' : 'Aggiorna catalogo',
+        onPressed: _isRefreshingOnline ? null : _refreshOnlineBots,
+        icon: AnimatedSwitcher(
+          duration: const Duration(milliseconds: 200),
+          child: _isRefreshingOnline
+              ? const SizedBox(
+                  key: ValueKey('progress'),
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(
+                  Icons.refresh_rounded,
+                  key: ValueKey('icon'),
+                ),
+        ),
+      );
+    }
+
+    return FilledButton.tonalIcon(
+      onPressed: _isRefreshingOnline ? null : _refreshOnlineBots,
+      icon: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 200),
+        child: _isRefreshingOnline
+            ? const SizedBox(
+                key: ValueKey('progress'),
+                width: 16,
+                height: 16,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : const Icon(
+                Icons.refresh_rounded,
+                key: ValueKey('icon'),
               ),
-              label: Text(_isUploading ? 'Caricamento...' : 'Importa bot'),
+      ),
+      label: Text(_isRefreshingOnline ? 'Aggiornamento...' : 'Aggiorna'),
+    );
+  }
+
+  Widget? _buildUploadFab({required bool compact}) {
+    if (_selectedCategory != BotCategory.local) {
+      return null;
+    }
+
+    final bool disabled = _isUploading || _botUploadService == null;
+    final Widget icon = AnimatedSwitcher(
+      duration: const Duration(milliseconds: 200),
+      child: _isUploading
+          ? const SizedBox(
+              key: ValueKey('progress'),
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
             )
-          : null,
+          : const Icon(
+              Icons.upload_file_rounded,
+              key: ValueKey('icon'),
+            ),
+    );
+
+    if (compact) {
+      return FloatingActionButton(
+        onPressed: disabled ? null : _showUploadOptions,
+        tooltip: _isUploading ? 'Caricamento...' : 'Importa bot',
+        child: icon,
+      );
+    }
+
+    return FloatingActionButton.extended(
+      onPressed: disabled ? null : _showUploadOptions,
+      icon: icon,
+      label: Text(_isUploading ? 'Caricamento...' : 'Importa bot'),
     );
   }
 

--- a/lib/frontend/widgets/pages/home_page_view.dart
+++ b/lib/frontend/widgets/pages/home_page_view.dart
@@ -7,7 +7,14 @@ import '../components/home_feature_grid.dart';
 import '../components/home_hero_section.dart';
 
 class HomePage extends StatelessWidget {
-  const HomePage({super.key});
+  const HomePage({
+    super.key,
+    this.appBar,
+    this.bottomNavigationBar,
+  });
+
+  final PreferredSizeWidget? appBar;
+  final Widget? bottomNavigationBar;
 
   void _openBots(BuildContext context, BotCategory category) {
     Navigator.pushNamed(
@@ -69,6 +76,7 @@ class HomePage extends StatelessWidget {
     ];
 
     return Scaffold(
+      appBar: appBar,
       body: AppGradientBackground(
         padding: EdgeInsets.zero,
         child: LayoutBuilder(
@@ -107,6 +115,7 @@ class HomePage extends StatelessWidget {
           },
         ),
       ),
+      bottomNavigationBar: bottomNavigationBar,
     );
   }
 }


### PR DESCRIPTION
## Summary
- introduce shared navigation metadata to drive mobile, web, and desktop shells without duplicating labels or routes
- add a mobile shell with a bottom navigation bar and a web shell with a responsive top app bar while selecting the correct shell per platform
- tighten bot list layouts and card spacing so narrow viewports stay readable

## Testing
- `flutter test` *(fails: flutter command is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f7cc33bce0832b93c55fa3003ab899