### PR TITLE
Automate platform icon updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ Questo progetto è una semplice applicazione mobile/desktop/web sviluppata con F
 
 Per produrre le varianti raster richieste dagli store (Android/iOS) e dai pacchetti desktop (Windows/Linux/macOS) esegui lo script
 [`tool/generate_app_icons.py`](tool/generate_app_icons.py). Il comando crea PNG multipiattaforma e un file ICO all'interno di
-`assets/icons/generated/` e copia automaticamente le icone PWA (`icon-192.png`, `icon-512.png`) in `web/icons/`. Questi asset generati non
-sono versionati nel repository: esegui lo script localmente (dopo aver installato `cairosvg` e `Pillow`) per prepararli prima di un
-packaging o di una release.
+`assets/icons/generated/`, copia automaticamente le icone PWA (`icon-192.png`, `icon-512.png`) in `web/icons/` e, quando sono presenti le
+directory di piattaforma generate da `flutter create`, sovrascrive le icone di lancio su Android (`android/app/src/main/res/**`), quelle del
+runner Windows (`windows/runner/resources/app_icon.ico`) e il catalogo AppIcon di macOS (`macos/Runner/Assets.xcassets/AppIcon.appiconset`).
+Questi asset generati non sono versionati nel repository: esegui lo script localmente (dopo aver installato `cairosvg` e `Pillow`) per
+prepararli prima di un packaging o di una release.
 
 ## Bot per Scriptagher
 

--- a/tool/generate_app_icons.py
+++ b/tool/generate_app_icons.py
@@ -2,6 +2,7 @@
 """Generate raster app icons from the shared Scriptagher SVG logo."""
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
 
@@ -12,15 +13,56 @@ ROOT = Path(__file__).resolve().parents[1]
 SVG_SOURCE = ROOT / "assets" / "icons" / "scriptagher_mini_droid.svg"
 OUTPUT_DIR = ROOT / "assets" / "icons" / "generated"
 WEB_ICON_DIR = ROOT / "web" / "icons"
+ANDROID_RES_DIR = ROOT / "android" / "app" / "src" / "main" / "res"
+WINDOWS_ICON_PATH = ROOT / "windows" / "runner" / "resources" / "app_icon.ico"
+MACOS_APP_ICONSET = (
+    ROOT / "macos" / "Runner" / "Assets.xcassets" / "AppIcon.appiconset"
+)
 PWA_ICON_SIZES = {192: "icon-192.png", 512: "icon-512.png"}
 
-PNG_SIZES = [16, 32, 48, 64, 72, 96, 128, 144, 152, 167, 180, 192, 256, 512, 1024]
+PNG_SIZES = [
+    16,
+    24,
+    32,
+    48,
+    64,
+    72,
+    96,
+    128,
+    144,
+    152,
+    167,
+    180,
+    192,
+    256,
+    432,
+    512,
+    1024,
+]
 ICO_SIZES = [16, 24, 32, 48, 64, 128, 256]
+
+ANDROID_MIPMAP_SIZES = {
+    "mipmap-mdpi": 48,
+    "mipmap-hdpi": 72,
+    "mipmap-xhdpi": 96,
+    "mipmap-xxhdpi": 144,
+    "mipmap-xxxhdpi": 192,
+}
+
 
 
 def ensure_output_dir() -> None:
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     WEB_ICON_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def ensure_png_size(size: int, rendered: dict[int, Path]) -> Path:
+    if size not in rendered:
+        rendered[size] = render_png(size)
+    path = rendered[size]
+    if not path.exists():
+        rendered[size] = render_png(size)
+    return rendered[size]
 
 
 def render_png(size: int) -> Path:
@@ -34,10 +76,10 @@ def render_png(size: int) -> Path:
     return target
 
 
-def render_png_variants() -> list[Path]:
-    rendered: list[Path] = []
+def render_png_variants() -> dict[int, Path]:
+    rendered: dict[int, Path] = {}
     for size in PNG_SIZES:
-        rendered.append(render_png(size))
+        rendered[size] = render_png(size)
     return rendered
 
 
@@ -66,14 +108,104 @@ def render_ico() -> Path:
     return ico_path
 
 
+def update_windows_icon(ico_path: Path) -> list[Path]:
+    if not WINDOWS_ICON_PATH.parent.exists():
+        return []
+    shutil.copyfile(ico_path, WINDOWS_ICON_PATH)
+    return [WINDOWS_ICON_PATH]
+
+
+def update_macos_icons(rendered: dict[int, Path]) -> list[Path]:
+    if not MACOS_APP_ICONSET.exists():
+        return []
+
+    contents_path = MACOS_APP_ICONSET / "Contents.json"
+    if not contents_path.exists():
+        return []
+
+    with contents_path.open("r", encoding="utf8") as fp:
+        contents = json.load(fp)
+
+    updated: list[Path] = []
+    images = contents.get("images", [])
+    for image in images:
+        filename = image.get("filename")
+        size = image.get("size")
+        scale = image.get("scale")
+        if not filename or not size or not scale:
+            continue
+
+        try:
+            base_size = float(size.split("x")[0])
+            scale_factor = float(scale.replace("x", ""))
+        except ValueError:
+            continue
+
+        pixel_size = int(round(base_size * scale_factor))
+        source = ensure_png_size(pixel_size, rendered)
+        target = MACOS_APP_ICONSET / filename
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, target)
+        updated.append(target)
+
+    return updated
+
+
+def update_android_icons(rendered: dict[int, Path]) -> list[Path]:
+    if not ANDROID_RES_DIR.exists():
+        return []
+
+    updated: list[Path] = []
+    for folder, size in ANDROID_MIPMAP_SIZES.items():
+        folder_path = ANDROID_RES_DIR / folder
+        if not folder_path.exists():
+            continue
+        source = ensure_png_size(size, rendered)
+        for filename in ("ic_launcher.png", "ic_launcher_round.png"):
+            target = folder_path / filename
+            shutil.copyfile(source, target)
+            updated.append(target)
+
+    updated.extend(_rewrite_android_adaptive_icons())
+
+    return updated
+
+
+def _rewrite_android_adaptive_icons() -> list[Path]:
+    targets = []
+    anydpi = ANDROID_RES_DIR / "mipmap-anydpi-v26"
+    if not anydpi.exists():
+        return targets
+
+    replacements = {
+        "ic_launcher.xml": "@mipmap/ic_launcher",
+        "ic_launcher_round.xml": "@mipmap/ic_launcher_round",
+    }
+
+    for filename, resource in replacements.items():
+        xml_path = anydpi / filename
+        if not xml_path.exists():
+            continue
+        text = xml_path.read_text(encoding="utf8")
+        new_text = text.replace("@drawable/ic_launcher_foreground", resource)
+        if new_text != text:
+            xml_path.write_text(new_text, encoding="utf8")
+            targets.append(xml_path)
+
+    return targets
+
+
 def main() -> None:
     ensure_output_dir()
     rendered = render_png_variants()
     ico_path = render_ico()
     pwa_paths = sync_pwa_icons()
-    all_paths = rendered + [ico_path] + pwa_paths
+    platform_paths = []
+    platform_paths.extend(update_windows_icon(ico_path))
+    platform_paths.extend(update_macos_icons(rendered))
+    platform_paths.extend(update_android_icons(rendered))
     print("Generated icons:")
-    for path in all_paths:
+    for path in list(rendered.values()) + [ico_path] + pwa_paths + platform_paths:
         rel = path.relative_to(ROOT)
         print(f" - {rel} ({path.stat().st_size} bytes)")
 


### PR DESCRIPTION
## Summary
- extend the icon generation script to update Android, Windows, and macOS launcher assets when the platform folders are present
- generate additional PNG sizes required by desktop and Android launchers and adjust adaptive icon XML to use the generated resources
- document the new behaviour in the README so desktop and mobile builds reuse the Scriptagher brand automatically

## Testing
- python -m compileall tool/generate_app_icons.py

------
https://chatgpt.com/codex/tasks/task_e_68f9507c2724832b88e1c3cdde397230